### PR TITLE
Improve til.py tagging

### DIFF
--- a/backlog/tasks/task-0002 - Refactor-tilpy-unify-config.md
+++ b/backlog/tasks/task-0002 - Refactor-tilpy-unify-config.md
@@ -1,0 +1,59 @@
+---
+id: task-0002
+title: Refactor til.py to unify config for tag/keyword/project extraction
+status: Done
+assignee:
+    - "@opencode"
+created_date: "2025-07-25"
+updated_date: "2025-07-25"
+labels: []
+dependencies: []
+---
+
+## Description
+
+Refactor til.py to unify all keyword/tag/project logic behind a single config system. The config should support both direct string matches and regex patterns, using "string" for exact and "/regex/" for regex. Each config entry can be a string (direct tag) or a map with tag and pattern (array of strings/regexes). This will simplify maintenance and ensure consistent tag extraction.
+
+## Implementation Notes
+
+### Motivation & Goals
+
+-   Previous tag extraction logic was fragmented, hard to maintain, and inconsistent for new technical domains or project references.
+-   Goal: Centralize all tag/keyword/project logic in a single config system for maintainability, extensibility, and deterministic output.
+
+### Key Design Decisions
+
+-   Introduced `TAG_CONFIG` for unified tag/keyword extraction:
+    -   Supports both direct string matches and regex-based patterns.
+    -   Regex patterns use capturing groups for project prefix extraction (e.g. "ag" from "[[ag-0018]]").
+    -   Config is easily extensible: add new string or regex entries for new domains.
+-   Introduced `TAG_MERGE` for canonicalizing/merging similar tags:
+    -   Maps alternative tags to preferred canonical tags (e.g. "formalization", "verification" → "formal").
+    -   Ensures search and organization are consistent across diary entries.
+-   Extraction logic refactored to use config for both string and regex matching, with robust filtering for non-technical tags.
+-   Merging logic refactored to use config, with deterministic ordering and duplicate prevention.
+
+### Testing & Validation
+
+-   Automated test suite added to til.py covering:
+    -   Basic technical content
+    -   Citation extraction from bib titles
+    -   Project references (e.g. [[ag-0018]])
+    -   Explicit topic tags
+    -   Mixed technical content
+    -   Non-technical filtering
+-   Edge cases handled:
+    -   Project references anywhere in content
+    -   Bib citation tags only extract valid technical tags
+    -   Non-technical tags (e.g. "time") are filtered out
+-   All tests pass, including edge cases for citations, project references, and non-technical filtering.
+-   Idempotency and determinism verified: repeated runs produce identical results.
+
+### Gotchas & Future Guidance
+
+-   Regex patterns for project tags must use capturing groups for prefix extraction.
+-   When extending config, ensure new tags are technical and not overly broad (to avoid false positives).
+-   For new technical domains, add both string and regex patterns as needed.
+-   Merging logic can be extended by adding new preferred tags and their alternatives in `TAG_MERGE`.
+-   If extraction logic changes, update tests to cover new edge cases.
+-   Only til.py modified; see commit for details.

--- a/backlog/tasks/task-0003 - Refactor-tilpy-explicit-tagging-and-deduplication.md
+++ b/backlog/tasks/task-0003 - Refactor-tilpy-explicit-tagging-and-deduplication.md
@@ -1,0 +1,64 @@
+---
+id: task-0003
+title: Refactor til.py for explicit #tag extraction and deduplication logic
+status: Done
+assignee:
+    - "@opencode"
+created_date: "2025-07-25"
+updated_date: "2025-07-25"
+labels: []
+dependencies: []
+---
+
+## Description
+
+Update `til.py` to only recognize explicit tags in the form `#tag` or `#multi-word-tag`, surrounded by spaces or line ends. Remove support for the legacy `- abc related` pattern. Implement deduplication so explicit tags are not included in other recognized patterns. Add CLI options to control whether explicit tags are included or deduplicated in the final output.
+
+## Acceptance Criteria
+
+-   [x] Only explicit tags (`#tag`, `#multi-word-tag`) are recognized as tags.
+-   [x] Old pattern (`- abc related`) is no longer recognized.
+-   [x] Explicit tags are extracted only when surrounded by space or line end.
+-   [x] Deduplication logic ensures explicit tags are not repeated in other tag lists.
+-   [x] CLI option `--dedup` (default) to deduplicate explicit tags from output (explicit tags are NOT included).
+-   [x] CLI option `--no-dedup` to include explicit tags in output (explicit tags ARE included).
+-   [x] All changes documented in backlog task file with execution notes.
+
+## Implementation Notes
+
+### Motivation & Goals
+
+-   Remove legacy topic-related pattern and support only explicit tagging for clarity and maintainability.
+-   Provide flexible CLI options for tag output control to suit different search and organization needs.
+
+### Key Design Decisions
+
+-   Use regex to extract explicit tags (`#tag`, `#multi-word-tag`) only when surrounded by space or line end.
+-   Deduplicate explicit tags from other recognized patterns in the final output.
+-   CLI flags now use `--dedup` (default) and `--no-dedup` for explicit tag control.
+
+### Testing & Validation
+
+-   Added test cases for explicit tag extraction, deduplication, and CLI options.
+-   Verified that legacy patterns are no longer recognized.
+-   Ensured deterministic and idempotent output.
+
+### Gotchas & Future Guidance
+
+-   Regex for explicit tags avoids matching fragments of URLs or other text.
+-   When extending tag logic, update tests and documentation accordingly.
+-   Only til.py modified; see commit for details.
+
+## AGENT-NOTE
+
+This task follows G-task, G-scope, G-commit, and G-verify rules in AGENTS.md. All code and documentation changes must be committed with [AGENT] tag and execution notes. Task is not done until all acceptance criteria are met and tested.
+
+### Execution Notes
+
+-   Removed legacy '- abc related' pattern recognition from til.py
+-   Implemented robust explicit tag extraction (regex for #tag/#multi-word-tag, space/line boundaries)
+-   Updated deduplication logic so explicit tags are not included in other recognized patterns
+-   Added CLI options to control explicit tag inclusion/deduplication in final output
+-   Added/expanded tests for explicit tag extraction, deduplication, and both CLI options (`--dedup`, `--no-dedup`)
+-   All changes tested and verified for idempotency and determinism
+-   CLI refactor verified: default is dedup ON, explicit tags omitted unless `--no-dedup` is specified

--- a/backlog/tasks/task-0004 - Reduce-tilpy-log-verbosity-and-add-tag-stats-summary.md
+++ b/backlog/tasks/task-0004 - Reduce-tilpy-log-verbosity-and-add-tag-stats-summary.md
@@ -60,3 +60,7 @@ This task follows G-task, G-scope, G-commit, and G-verify rules in AGENTS.md. Al
 -   Updated and expanded test suite to verify both default and verbose outputs
 -   All tests pass for both modes
 -   No changes outside til.py
+-   Monthly tag stats now use #tag for single, #tag N for multiple occurrences, with ANSI color for #tag in TTY
+-   Output is plain when piped
+-   Format is concise and visually clear per user feedback
+-   See commit history for details

--- a/backlog/tasks/task-0004 - Reduce-tilpy-log-verbosity-and-add-tag-stats-summary.md
+++ b/backlog/tasks/task-0004 - Reduce-tilpy-log-verbosity-and-add-tag-stats-summary.md
@@ -1,0 +1,62 @@
+---
+id: task-0004
+title: Reduce til.py log verbosity and add tag stats summary
+status: Done
+assignee:
+    - "@opencode"
+created_date: "2025-07-25"
+updated_date: "2025-07-25"
+labels: []
+dependencies: []
+---
+
+## Description
+
+Update `til.py` logging so that by default it only outputs concise statistics:
+
+-   Show tag count for each month
+-   Show how many tags are merged by default
+    If the `--verbose` flag is provided, output detailed logs in the format:
+-   `date: matched the keyword pattern -> tag`
+
+## Acceptance Criteria
+
+-   [x] Default log output is concise: only monthly tag counts and merge stats
+-   [x] `--verbose` flag enables detailed logs for each tag extraction event
+-   [x] Detailed logs show: `date: matched the keyword pattern -> tag`
+-   [x] All changes documented in backlog task file with execution notes
+
+## Implementation Notes
+
+### Motivation & Goals
+
+-   Reduce log noise for routine runs, making output more useful for summary review
+-   Provide a way to debug or audit tag extraction with `--verbose`
+
+### Key Design Decisions
+
+-   Default log output is summary only
+-   `--verbose` flag triggers detailed per-tag logs
+
+### Testing & Validation
+
+-   Add/expand tests to verify both default and verbose log outputs
+-   Ensure summary stats are correct and detailed logs match extraction events
+-   All tests pass for both modes
+
+### Gotchas & Future Guidance
+
+-   When extending tag logic, update logging and tests accordingly
+-   Only til.py modified; see commit for details
+
+## AGENT-NOTE
+
+This task follows G-task, G-scope, G-commit, and G-verify rules in AGENTS.md. All code and documentation changes must be committed with [AGENT] tag and execution notes. Task is not done until all acceptance criteria are met and tested.
+
+### Execution Notes
+
+-   Refactored til.py logging: default output is monthly tag counts and merge stats
+-   Added --verbose flag for detailed logs (date: matched the keyword pattern -> tag)
+-   Updated and expanded test suite to verify both default and verbose outputs
+-   All tests pass for both modes
+-   No changes outside til.py

--- a/til.py
+++ b/til.py
@@ -770,6 +770,9 @@ def print_monthly_tag_stats(filepath, top_n=20):
                 color_tag(tag) if count == 1 else f"{color_tag(tag)} {count}"
                 for tag, count in top_tags
             ])
+            # Append ellipsis if more tags exist than top_n
+            if len(month_tag_counter[month]) > top_n:
+                tag_str += ', ...'
             print(f"{yyyymm} ({total_tags} tags): {tag_str}")
 
 

--- a/til.py
+++ b/til.py
@@ -732,26 +732,32 @@ def print_merge_stats():
 
 
 def print_monthly_tag_stats(filepath):
-    """Print top 20 tag statistics for each month."""
+    """Print top 20 tag statistics for each month, including months with no tags."""
     import re
     from collections import defaultdict, Counter
     month_tag_counter = defaultdict(Counter)
+    all_months = set()
     try:
         with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()
     except Exception:
         return
+    # Find all mdnote entries (with or without tags) to collect all months
+    pattern_month = r"\\subtree\[(\d{4}-\d{2})-\d{2}\]{\\mdnote{\d{4}-\d{2}-\d{2}}"
+    for match in re.finditer(pattern_month, content):
+        month = match.group(1)
+        all_months.add(month)
     # Find all mdnote entries with tags
-    pattern = r"\\subtree\[(\d{4}-\d{2})-\d{2}\]{\\mdnote{\d{4}-\d{2}-\d{2}}{\\tags{([^}]*)}"
-    for match in re.finditer(pattern, content):
+    pattern_tags = r"\\subtree\[(\d{4}-\d{2})-\d{2}\]{\\mdnote{\d{4}-\d{2}-\d{2}}{\\tags{([^}]*)}"
+    for match in re.finditer(pattern_tags, content):
         month = match.group(1)
         tags = match.group(2)
         for t in tags.split():
             if t.startswith('#'):
                 month_tag_counter[month][t] += 1
-    if month_tag_counter:
+    if all_months:
         print("\nMonthly top 20 tags:")
-        for month in sorted(month_tag_counter.keys()):
+        for month in sorted(all_months):
             top_tags = month_tag_counter[month].most_common(20)
             tag_str = ' '.join([f"{tag} ({count})" for tag, count in top_tags])
             print(f"{month}: {tag_str}")

--- a/til.py
+++ b/til.py
@@ -759,7 +759,15 @@ def print_monthly_tag_stats(filepath):
         print("\nMonthly top 20 tags:")
         for month in sorted(all_months):
             top_tags = month_tag_counter[month].most_common(20)
-            tag_str = ' '.join([f"{tag} ({count})" for tag, count in top_tags])
+            # ANSI color for #tag if output is a TTY
+            import sys
+            use_color = sys.stdout.isatty()
+            def color_tag(tag):
+                return f"\033[96m{tag}\033[0m" if use_color else tag
+            tag_str = ' '.join([
+                color_tag(tag) if count == 1 else f"{color_tag(tag)} x{count}"
+                for tag, count in top_tags
+            ])
             print(f"{month}: {tag_str}")
 
 

--- a/til.py
+++ b/til.py
@@ -760,10 +760,11 @@ def print_monthly_tag_stats(filepath, top_n=20):
         import sys
         use_color = sys.stdout.isatty()
         def color_tag(tag):
-            return f"\033[96m{tag}\033[0m" if use_color else tag
+            # AGENT-NOTE: Use ANSI 256-color code 114 for #98c379 green
+            return f"\033[38;5;114m{tag}\033[0m" if use_color else tag
         for month in sorted(all_months):
             top_tags = month_tag_counter[month].most_common(top_n)
-            total_tags = sum(month_tag_counter[month].values())
+            unique_tag_count = len(month_tag_counter[month])
             # Format YYYYMM
             yyyymm = month.replace('-', '')
             tag_str = ', '.join([
@@ -771,9 +772,9 @@ def print_monthly_tag_stats(filepath, top_n=20):
                 for tag, count in top_tags
             ])
             # Append ellipsis if more tags exist than top_n
-            if len(month_tag_counter[month]) > top_n:
+            if unique_tag_count > top_n:
                 tag_str += ', ...'
-            print(f"{yyyymm} ({total_tags} tags): {tag_str}")
+            print(f"{yyyymm} ({unique_tag_count} tags): {tag_str}")
 
 
 

--- a/til.py
+++ b/til.py
@@ -145,9 +145,6 @@ def extract_keywords_from_content(content, date, dedup=True, verbose=False):
         url_context = content[max(0, match.start()-8):match.end()+8]
         if '://' not in url_context:
             explicit_tags.add(tag.lower())
-            if verbose:
-                print(f"{date}: matched explicit tag pattern -> {tag.lower()}")
-    # AGENT-NOTE: explicit_tags now contains all explicit #tags found in content
 
     """Extract meaningful technical keywords from daily entry content using TAG_CONFIG."""
 
@@ -267,8 +264,6 @@ def extract_keywords_from_content(content, date, dedup=True, verbose=False):
             # Exact match tag
             if entry in content_lower and entry not in EXCLUDE_WORDS:
                 found_keywords.append(entry)
-                if verbose:
-                    print(f"{date}: matched keyword '{entry}' -> {entry}")
         elif isinstance(entry, dict):
             tag = entry.get("tag")
             patterns = entry.get("patterns", [])
@@ -291,8 +286,7 @@ def extract_keywords_from_content(content, date, dedup=True, verbose=False):
                             prefix = m.group(1) if m else None
                         if prefix and prefix not in found_keywords and prefix not in EXCLUDE_WORDS:
                             if verbose:
-                                print(f"{date}: matched project pattern -> {prefix}")
-                            found_keywords.append(prefix)
+                                found_keywords.append(prefix)
                     elif isinstance(match, tuple):
                         for submatch in match:
                             if submatch and submatch not in EXCLUDE_WORDS:
@@ -300,8 +294,7 @@ def extract_keywords_from_content(content, date, dedup=True, verbose=False):
                     else:
                         if tag and tag not in found_keywords and tag not in EXCLUDE_WORDS:
                             if verbose:
-                                print(f"{date}: matched pattern for tag '{tag}' -> {tag}")
-                            found_keywords.append(tag)
+                                found_keywords.append(tag)
 
     # Special handling for git (context-sensitive)
     if "git" in found_keywords:
@@ -362,7 +355,7 @@ def extract_keywords_from_content(content, date, dedup=True, verbose=False):
         for preferred, alternatives in TAG_MERGE.items():
             if kw == preferred or kw in alternatives:
                 if verbose:
-                    print(f"{date}: merging '{kw}' to '{preferred}'")
+                    print(f"[merge] {date}: merging '{kw}' to '{preferred}'")
                 merged_keywords.add(preferred)
                 found = True
                 # Track merge stats (only if kw is different from preferred)
@@ -373,7 +366,7 @@ def extract_keywords_from_content(content, date, dedup=True, verbose=False):
                 break
         if not found:
             if verbose:
-                print(f"{date}: {kw} -> #{kw}")
+                print(f"{kw} -> #{kw}")
             merged_keywords.add(kw)
     # Also merge explicit tags if dedup is False
     if not dedup:

--- a/til.py
+++ b/til.py
@@ -765,7 +765,7 @@ def print_monthly_tag_stats(filepath):
             def color_tag(tag):
                 return f"\033[96m{tag}\033[0m" if use_color else tag
             tag_str = ' '.join([
-                color_tag(tag) if count == 1 else f"{color_tag(tag)} x{count}"
+                color_tag(tag) if count == 1 else f"{color_tag(tag)} {count}"
                 for tag, count in top_tags
             ])
             print(f"{month}: {tag_str}")

--- a/til.py
+++ b/til.py
@@ -414,9 +414,9 @@ def improve_title(date, content, dedup=True, verbose=False):
     """Generate improved title based on content analysis."""
     keywords = extract_keywords_from_content(content, date, dedup=dedup, verbose=verbose)
 
+    # If no keywords, return date and empty list (no fallback 'misc' tag)
     if not keywords:
-        # Fallback for entries with no technical keywords
-        return date, ["misc"]
+        return date, []
 
     # Return date and keywords separately
     return date, keywords
@@ -742,7 +742,7 @@ def print_monthly_tag_stats(filepath):
     except Exception:
         return
     # Find all mdnote entries with tags
-    pattern = r"\\subtree\[(\d{4}-\d{2})-\d{2}\]\\{\\mdnote\\{\d{4}-\d{2}-\d{2}\\}\\{\\tags\\{([^}]*)\\}"
+    pattern = r"\\subtree\[(\d{4}-\d{2})-\d{2}\]{\\mdnote{\d{4}-\d{2}-\d{2}}{\\tags{([^}]*)}"
     for match in re.finditer(pattern, content):
         month = match.group(1)
         tags = match.group(2)

--- a/til.py
+++ b/til.py
@@ -732,26 +732,30 @@ def print_merge_stats():
 
 
 def print_monthly_tag_stats(filepath):
-    """Print tag count statistics for each month."""
+    """Print top 20 tag statistics for each month."""
     import re
-    from collections import defaultdict
-    month_tag_counts = defaultdict(int)
+    from collections import defaultdict, Counter
+    month_tag_counter = defaultdict(Counter)
     try:
         with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()
     except Exception:
         return
     # Find all mdnote entries with tags
-    pattern = r"\\subtree\\[([0-9]{4}-[0-9]{2})\\]\\{\\mdnote\\{[0-9]{4}-[0-9]{2}-[0-9]{2}\\}\\{\\tags\\{([^}]*)\\}"
+    pattern = r"\\subtree\[(\d{4}-\d{2})-\d{2}\]\\{\\mdnote\\{\d{4}-\d{2}-\d{2}\\}\\{\\tags\\{([^}]*)\\}"
     for match in re.finditer(pattern, content):
         month = match.group(1)
         tags = match.group(2)
-        tag_count = len([t for t in tags.split() if t.startswith('#')])
-        month_tag_counts[month] += tag_count
-    if month_tag_counts:
-        print("\nMonthly tag counts:")
-        for month, count in sorted(month_tag_counts.items()):
-            print(f"{month}: {count} tags")
+        for t in tags.split():
+            if t.startswith('#'):
+                month_tag_counter[month][t] += 1
+    if month_tag_counter:
+        print("\nMonthly top 20 tags:")
+        for month in sorted(month_tag_counter.keys()):
+            top_tags = month_tag_counter[month].most_common(20)
+            tag_str = ' '.join([f"{tag} ({count})" for tag, count in top_tags])
+            print(f"{month}: {tag_str}")
+
 
 
 

--- a/trees/uts-0018.tree
+++ b/trees/uts-0018.tree
@@ -22,7 +22,7 @@
 \subtree[2025-07]{
 \title{July, 2025}
 
-\subtree[2025-07-04]{\mdnote{2025-07-04}{
+\subtree[2025-07-04]{\mdnote{2025-07-04}{\tags{#cg #duckdb #gpu #news #os #proof #render #rust #wasm #✍️}
 - #web
     - [Our Fullstack Architecture: Eta, HTMX, and Lit](https://www.lorenstew.art/blog/eta-htmx-lit-stack)
         - [Eta](https://eta.js.org/): a lightweight, fast, and simple embedded JavaScript templating engine
@@ -62,7 +62,7 @@
     - [how did the Solar System form?](https://hoggresearch.blogspot.com/2025/07/how-did-solar-system-form.html)
 }}
 
-\subtree[2025-07-03]{\mdnote{2025-07-03}{
+\subtree[2025-07-03]{\mdnote{2025-07-03}{\tags{#ebpf #gpu #news #os #software #sqlite #wasm #web}
 - #rust
     - [Introducing tmux-rs](https://richardscollin.github.io/tmux-rs/)
         - initially used [c2rust](https://github.com/immunant/c2rust), a tool to migrate C code to (unsafe) Rust
@@ -112,7 +112,7 @@
     - [WASM Agents: AI agents running in the browser](https://blog.mozilla.ai/wasm-agents-ai-agents-running-in-your-browser/) ([on HN](https://news.ycombinator.com/item?id=44461341))
 }}
 
-\subtree[2025-07-02]{\mdnote{2025-07-02}{
+\subtree[2025-07-02]{\mdnote{2025-07-02}{\tags{#os #sec #web}
 - [Code-GUI bidirectional editing via LSP](https://jamesbvaughan.com/bidirectional-editing/)
 - [OpenBao, the community fork of Vault](https://github.com/openbao/openbao/)
     - manage secrets, or encrypted passwords, API keys, and other bits of sensitive information in distributed computing setups
@@ -140,7 +140,7 @@
     - fun fact: clamp is median
 }}
 
-\subtree[2025-07-01]{\mdnote{2025-07-01}{
+\subtree[2025-07-01]{\mdnote{2025-07-01}{\tags{#agent #agent/tasking #codegen #compiler #debugger #duckdb #gpu #haskell #json #llvm}
 - #agent
     - [Claude Code now supports hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) ([on HN](https://news.ycombinator.com/item?id=44429225))
         - Claude Code hooks: user-defined shell commands that execute at various points in Claude Code’s lifecycle.
@@ -231,7 +231,7 @@
 \subtree[2025-06]{
 \title{June, 2025}
 
-\subtree[2025-06-30]{\mdnote{2025-06-30}{
+\subtree[2025-06-30]{\mdnote{2025-06-30}{\tags{#agent #json #lean #news #os}
 - [Agile Was Never Your Problem](https://thecynical.dev/posts/agile-was-never-your-problem/)
     - lean process
         - minimal structure, shorten feedback loop, allowing changing direction quickly
@@ -264,7 +264,7 @@
     - fun to play, but the challenge should be using the SQL to output the answer
 }}
 
-\subtree[2025-06-29]{\mdnote{2025-06-29}{
+\subtree[2025-06-29]{\mdnote{2025-06-29}{\tags{#formal #lean #news #os #sci #sec #sqlite #zig}
 - #data-structure
     - [Bloom Filters by Example](https://llimllib.github.io/bloomfilter-tutorial/) ([on HN](https://news.ycombinator.com/item?id=44412370))
     - [Telescopes Are Tries: A Dependent Type Shellac on SQLite](https://www.philipzucker.com/telescope_tries/)
@@ -316,7 +316,7 @@
     - from [johncarlosbaez's post on mathstodon.xyz](https://mathstodon.xyz/@johncarlosbaez/114765861656278963)
 }}
 
-\subtree[2025-06-28]{\mdnote{2025-06-28}{
+\subtree[2025-06-28]{\mdnote{2025-06-28}{\tags{#context #datafusion #duckdb #game #git #gpu #news #os #physics #proof}
 - [A Newbie's First Contribution to (Rust for) Linux](https://blog.buenzli.dev/rust-for-linux-first-contrib/)
     - Raspberry Pi has a fork of kernel
     - it's possible to write out-of-tree kernel module in Rust
@@ -427,7 +427,7 @@
 - [Researchers develop a battery cathode material that does it all](https://arstechnica.com/science/2025/06/researchers-develop-a-battery-cathode-material-that-does-it-all/) #sci
 }}
 
-\subtree[2025-06-26]{\mdnote{2025-06-26}{
+\subtree[2025-06-26]{\mdnote{2025-06-26}{\tags{#agent #context #game #idea #news #os #rust #web}
 - #agent
     - [AI Improves at Improving Itself Using an Evolutionary Trick](https://spectrum.ieee.org/evolutionary-ai)
     - [Learnings from building AI agents](https://www.cubic.dev/blog/learnings-from-building-ai-agents)
@@ -457,7 +457,7 @@
     - I'm really frustrated by Github Actions Windows CI build failure that has little information to debug
 }}
 
-\subtree[2025-06-25]{\mdnote{2025-06-25}{
+\subtree[2025-06-25]{\mdnote{2025-06-25}{\tags{#compiler #gpu #llvm #news #os #render #sec #shader #software #vulkan}
 - [A new PNG spec](https://www.programmax.net/articles/png-is-back/)
     - I'm thinking about preserving the most valuable photos in minimal size, encrypted, stored in public repo, and the format might be just png
 - #ai-safety
@@ -490,7 +490,7 @@
 - [How to Write Compelling Release Announcements](https://refactoringenglish.com/chapters/release-announcements/)
 }}
 
-\subtree[2025-06-24]{\mdnote{2025-06-24}{
+\subtree[2025-06-24]{\mdnote{2025-06-24}{\tags{#agent #build #news #os #rust #sqlite #web #zig}
 - #build
     - [Bazel’s Original Sins](https://fzakaria.com/2025/06/22/bazel-s-original-sins)
     - [Chromium's build system is switching from Ninja to Siso for external developers](https://groups.google.com/a/chromium.org/g/chromium-dev/c/v-WOvWUtOpg)
@@ -519,7 +519,7 @@
     - I need to give it and fly.io a try
 }}
 
-\subtree[2025-06-23]{\mdnote{2025-06-23}{
+\subtree[2025-06-23]{\mdnote{2025-06-23}{\tags{#game #news #os #rust #tla #typst #zig #✍️}
 - [How I use my terminal](https://jyn.dev/how-i-use-my-terminal/)
     - the author explains how things work, especially for those that people are surprised to find possible at all
 - [I wrote my PhD Thesis in Typst](https://fransskarman.com/phd_thesis_in_typst.html) ([on HN](https://news.ycombinator.com/item?id=44350322)) ([on lobste.rs](https://lobste.rs/s/pdrso1))
@@ -549,7 +549,7 @@
     - [writing a little gosh](https://flak.tedunangst.com/post/writing-a-gosh)
 }}
 
-\subtree[2025-06-22]{\mdnote{2025-06-22}{\tags{#gpu #rust #yaml #zig}
+\subtree[2025-06-22]{\mdnote{2025-06-22}{\tags{#os #rust #yaml}
 - [model.yaml](https://simonwillison.net/2025/Jun/21/model-yaml/#atom-everything)
     - an open standard in YAML for defining crossplatform, composable AI models by LM Studio team
 - #gpu
@@ -565,7 +565,7 @@
         - C23 has a new rule for struct, union, and enum compatibility
 }}
 
-\subtree[2025-06-21]{\mdnote{2025-06-21}{\tags{#agent #formal #scheme}
+\subtree[2025-06-21]{\mdnote{2025-06-21}{\tags{#agent #formal #os #software #web}
 - [That Time I Tried Browsing the Web Without CSS](https://css-tricks.com/that-time-i-tried-browsing-the-web-without-css/)
     - I really should keep my sites readable without JS, and even without CSS
 - [Harper – an open-source alternative to Grammarly](https://writewithharper.com)
@@ -588,7 +588,7 @@
     - I didn't know it's even possible
 }}
 
-\subtree[2025-06-20]{\mdnote{2025-06-20}{\tags{#makefile #rust}
+\subtree[2025-06-20]{\mdnote{2025-06-20}{\tags{#news #os #rust #web}
 - [Infinite Mac OS X](https://blog.persistent.info/2025/03/infinite-mac-os-x.html) ([on HN](https://news.ycombinator.com/item?id=44323719)) ([on lobste.rs](https://lobste.rs/s/la5mgg))
 - [JavaScript broke the web (and called it progress)](https://www.jonoalderson.com/conjecture/javascript-broke-the-web-and-called-it-progress/) ([on HN](https://news.ycombinator.com/item?id=44325563)) ([on lobste.rs](https://lobste.rs/s/3ew6rt))
 - [Hurl: Run and test HTTP requests with plain text](https://github.com/Orange-OpenSource/hurl)
@@ -604,7 +604,7 @@
 - found [How to Design Programs 2nd Ed (2024)](https://htdp.org)
 }}
 
-\subtree[2025-06-19]{\mdnote{2025-06-19}{\tags{#ai-safety #compiler #haskell #math-app #rust #x86}
+\subtree[2025-06-19]{\mdnote{2025-06-19}{\tags{#cg #compiler #haskell #news #os #simd #software}
 - [How Close to Black Mirror Are We?](https://www.howclosetoblackmirror.com/)
 - #math-app
     - [Curved-Crease Sculpture](https://erikdemaine.org/curved/)
@@ -631,7 +631,7 @@
         - uses [fasm](https://flatassembler.net/) as backend
 }}
 
-\subtree[2025-06-18]{\mdnote{2025-06-18}{\tags{#agent #benchmark #docker #editor #prompt #quantum #robot #sec #wayland #✍️}
+\subtree[2025-06-18]{\mdnote{2025-06-18}{\tags{#agent #benchmark #debugger #docker #news #os #quantum #software #web}
 - #helix
     - work on [helix-cheat-sheet](https://github.com/utensil/helix-cheat-sheet)
     - [I really like the Helix editor](https://herecomesthemoon.net/2025/06/i-like-helix/)
@@ -694,7 +694,7 @@
     - from [Benchmark: snapDOM vs html2canvas](https://zumerlab.github.io/snapdom/)
 }}
 
-\subtree[2025-06-17]{\mdnote{2025-06-17}{\tags{#agent #news #privacy #tech-history}
+\subtree[2025-06-17]{\mdnote{2025-06-17}{\tags{#build #context #misc #os #sec #software #tui #web}
 - [Accumulation of Cognitive Debt When Using an AI Assistant for Essay Writing Task](https://www.brainonllm.com/)
     - now with Helix, I use less of auto-complete, and enjoy genuine programming
 - #tech-history
@@ -735,7 +735,7 @@
 - [Intuiting Monty Hall](https://entropicthoughts.com/intuiting-monty-hall)
 }}
 
-\subtree[2025-06-16]{\mdnote{2025-06-16}{\tags{#agent #claude #rgsql #rust}
+\subtree[2025-06-16]{\mdnote{2025-06-16}{\tags{#agent #os #rust}
 - #agent
     - [Agents for the Agent](https://ampcode.com/agents-for-the-agent)
         - amp on subagent
@@ -749,7 +749,7 @@
 - found [rgSQL: A test suite to help you build your own database engine](https://technicaldeft.com/posts/rgsql-a-test-suite-for-database-engines)
 }}
 
-\subtree[2025-06-15]{\mdnote{2025-06-15}{\tags{#cg #physics #raymarching #software #theory}
+\subtree[2025-06-15]{\mdnote{2025-06-15}{\tags{#os #physics #raymarching}
 - [Q-learning is not yet scalable](https://seohong.me/blog/q-learning-is-not-yet-scalable/)
 - found [Todo.txt](http://todotxt.org/)
     - from [todo.txt tasks in my TRMNL](https://akselmo.dev/posts/todotxt-in-my-trmnl/)
@@ -768,7 +768,7 @@
 - found [Foundations of Computer Vision](https://visionbook.mit.edu)
 }}
 
-\subtree[2025-06-14]{\mdnote{2025-06-14}{\tags{#agent #apl #biology #cg #compiler #datalog #formal #game #lean #ocaml}
+\subtree[2025-06-14]{\mdnote{2025-06-14}{\tags{#agent #blogging #compiler #context #formal #game #idea #interop #lean #news}
 - started using Mac's dictation in agent coding
 - [Blogging about papers](https://simonwillison.net/2025/Jun/13/blogging-about-papers/#atom-everything)
     - [Design Patterns for Securing LLM Agents against Prompt Injections](https://simonwillison.net/2025/Jun/13/prompt-injection-design-patterns/) ([on HN](https://news.ycombinator.com/item?id=44268335)) ([on lobste.rs](https://lobste.rs/s/zuadfv))
@@ -854,7 +854,7 @@
     - not sure if it's a good idea security-wise, but neat anyway
 }}
 
-\subtree[2025-06-13]{\mdnote{2025-06-13}{\tags{#ai-safty #arm #benchmark #formal #lean #rust #z3 #zig}
+\subtree[2025-06-13]{\mdnote{2025-06-13}{\tags{#benchmark #formal #lean #news #os #rss #rust #tui #z3 #zig}
 - [Solving LinkedIn Queens with SMT](https://buttondown.com/hillelwayne/archive/solving-linkedin-queens-with-smt/)
     - in Z3 SMT solver instead of CVC5 SMT solver as in [Using SAT to Get the World Record on LinkedIn's Queens](https://ryanberger.me/posts/queens/)
     -  SAT solvers are "criminally underused by the industry" (from [Modern SAT solvers: fast, neat and underused](https://codingnest.com/modern-sat-solvers-fast-neat-underused-part-1-of-n/))
@@ -910,7 +910,7 @@
 - [What I talk about when I talk about IRs](https://bernsteinbear.com/blog/irs/?utm_source=rss)
 }}
 
-\subtree[2025-06-12]{\mdnote{2025-06-12}{\tags{#compiler #debugger #formal #game #lean #optimization #proof #raku #render #rust}
+\subtree[2025-06-12]{\mdnote{2025-06-12}{\tags{#cg #compiler #diagram #formal #game #optimization #os #proof #render #rust}
 - wrote [[uts-016K]] ([on reddit](https://www.reddit.com/r/Zig/comments/1lb2vq8/trying_zigs_selfhosted_x86_backend_on_apple/))
 - #lean
     - [Premise Selection for a Lean Hammer](https://arxiv.org/abs/2506.07477)
@@ -955,7 +955,7 @@
 - found [Verse Language](https://dev.epicgames.com/documentation/en-us/fortnite/verse-language-reference), a new scripting language for Fortnite by Epic
 }}
 
-\subtree[2025-06-11]{\mdnote{2025-06-11}{\tags{#agent #css #render #typst #zig}
+\subtree[2025-06-11]{\mdnote{2025-06-11}{\tags{#agent #os #render #tui #typst #web #zig}
 - [My Unfiltered Take on the AI Coding Agent Landscape](https://xxchan.me/ai/2025/06/10/ai-coding-en.html)
     - found and tried [amp](https://ampcode.com/)
         - love their [Frequently Ignored Feedback](https://ampcode.com/fif) but disagree with some of them
@@ -977,7 +977,7 @@
     - [HUG CSS, how I approach CSS architecture](https://gomakethings.com/hug-css-how-i-approach-css-architecture/)
 }}
 
-\subtree[2025-06-10]{\mdnote{2025-06-10}{\tags{#compiler #embedding #formal #optimization #os #performance #qwen #rust #wasm}
+\subtree[2025-06-10]{\mdnote{2025-06-10}{\tags{#agent #compiler #diagram #formal #llvm #makefile #news #optimization #rust #sec}
 - [Lightweight Diagramming for Lightweight Formal Methods](https://blog.brownplt.org/2025/06/09/copeanddrag.html)
 - #performance
     - [Why doesn’t Rust care more about compiler performance?](https://kobzol.github.io/rust/rustc/2025/06/09/why-doesnt-rust-care-more-about-compiler-performance.html)
@@ -1021,7 +1021,7 @@
     - [Exploring Topological Spaces with Prolog: A Practical Approach Using “Mathematics with Prolog”](https://medium.com/@kenichisasagawa/exploring-topological-spaces-with-prolog-a-practical-approach-using-mathematics-with-prolog-b5806bb8b98f)
 }}
 
-\subtree[2025-06-09]{\mdnote{2025-06-09}{\tags{#agent #apache #arm #arrow #backrest #bookwyrm #datafusion #docker #duckdb #elixir}
+\subtree[2025-06-09]{\mdnote{2025-06-09}{\tags{#agent #datafusion #docker #duckdb #elixir #formal #harbor #idea #json #lemmy}
 - [Ditching HAProxy (in my homelab)](https://arch.dog/bark/ditching-haproxy)
     - found [Ran out of infrastructure titles](https://arch.dog/bark/2025-03-30-infrastructure) from the author
         - [backrest](https://github.com/garethgeorge/backrest)
@@ -1075,7 +1075,7 @@
 - [Training a Rust 1.5B Coder LM with Reinforcement Learning (GRPO) | Oxen.ai](https://ghost.oxen.ai/training-a-rust-1-5b-coder-lm-with-reinforcement-learning-grpo/)
 }}
 
-\subtree[2025-06-08]{\mdnote{2025-06-08}{\tags{#agent #blogging #claude #cloudflare #faer #optimization #pulp #rust #simd #zig}
+\subtree[2025-06-08]{\mdnote{2025-06-08}{\tags{#agent #news #optimization #os #rust #sec #simd #web #zig}
 - [Vanishing zeroes for geometric algebra in Rust](https://dotat.at/@/2020-12-06-vanishing-zeroes-for-geometric-algebra-in-rust.html)
 - [A plan for SIMD](https://linebender.org/blog/a-plan-for-simd/)
     - learn about [pulp](https://github.com/sarah-quinones/pulp) and [check its usage in faer](https://deepwiki.com/search/is-faer-only-using-pulp-for-si_877456ee-d5c0-4462-bf78-be43779cb07c)
@@ -1116,14 +1116,14 @@
 - [Interactive Guide: Mastering Rate Limiting](https://blog.sagyamthapa.com.np/interactive-guide-to-rate-limiting)
 }}
 
-\subtree[2025-06-07]{\mdnote{2025-06-07}{\tags{#git #perses #sqlite}
+\subtree[2025-06-07]{\mdnote{2025-06-07}{\tags{#git #os #sqlite}
 - [Simplifying and Isolating Failure-Inducing Input (Delta Debugging)](https://www.cs.purdue.edu/homes/xyzhang/fall07/Papers/delta-debugging.pdf)
     - found [Perses: Syntax-Directed Program Reduction](https://github.com/uw-pluverse/perses)
     - found [WDD: Weighted Delta Debugging](https://arxiv.org/abs/2411.19410)
 - found [git-remote-sqlite: Single-file Git repos that can replicate with Litestream](https://github.com/chrislloyd/git-remote-sqlite)
 }}
 
-\subtree[2025-06-06]{\mdnote{2025-06-06}{\tags{#agent #apl #clojure #compiler #dspy #formal #fuzzing #gradient #optimization #prompt}
+\subtree[2025-06-06]{\mdnote{2025-06-06}{\tags{#agent #apl #clojure #compiler #dspy #formal #fuzzing #interop #news #optimization}
 - investigating DSPy (Demonstrate-Search-Predict)
     - [Pipelines & Prompt Optimization with DSPy](https://www.dbreunig.com/2024/12/12/pipelines-prompt-optimization-with-dspy.html)
     - found [MLflow DSPy Flavor](https://mlflow.org/docs/latest/llms/dspy/index.html)
@@ -1152,7 +1152,7 @@
     - [The unreasonable effectiveness of fuzzing for porting programs](https://rjp.io/blog/2025-06-17-unreasonable-effectiveness-of-fuzzing) ([on HN](https://news.ycombinator.com/item?id=44311241)) ([on lobste.rs](https://lobste.rs/s/zgoytt))
 }}
 
-\subtree[2025-06-06-2]{\mdnote{2025-06-06}{\tags{#apl #game #lean #shader #tla #vulkan #zig #zigar}
+\subtree[2025-06-06-2]{\mdnote{2025-06-06}{\tags{#apl #game #lean #shader #tla #vulkan #web #zig}
 - [AI is a gamechanger for TLA+ users](https://buttondown.com/hillelwayne/archive/ai-is-a-gamechanger-for-tla-users/)
 - [In which I have Opinions about parsing and grammars](https://www.chiark.greenend.org.uk/~sgtatham/quasiblog/parsing/)
 - [Experimenting with no-build Web Applications](https://andregarzia.com/2025/06/experimenting-with-no-build-web-applications.html)
@@ -1163,7 +1163,7 @@
 - [I Think I’m Done Thinking About genAI For Now](https://blog.glyph.im/2025/06/i-think-im-done-thinking-about-genai-for-now.html)
 }}
 
-\subtree[2025-06-05]{\mdnote{2025-06-05}{\tags{#claude #compiler #jujutsu #lean #mongodb #rust #sec #tla}
+\subtree[2025-06-05]{\mdnote{2025-06-05}{\tags{#agent #compiler #debugger #jujutsu #lean #os #rust #sec #software #tla}
 - [Physicality: the new age of UI](https://www.lux.camera/physicality-the-new-age-of-ui/)
     - love it
 - [jujutsu on tangled](https://blog.tangled.sh/stacking)
@@ -1184,7 +1184,7 @@
 - [Script Debugger Retired](https://latenightsw.com/script-debugger-retired/), IDE for AppleScript
 }}
 
-\subtree[2025-06-02]{\mdnote{2025-06-02}{\tags{#aria #benchmark #compiler #json #rust #z3 #✍️}
+\subtree[2025-06-02]{\mdnote{2025-06-02}{\tags{#benchmark #compiler #json #news #os #rust #web #z3}
 - [Fast character classification with z3](https://lemire.me/blog/2025/06/01/easy-vectorized-classification-with-z3/)
 - structured error
     - [Designing Error Types in Rust Libraries](https://d34dl0ck.me/rust-bites-designing-error-types-in-rust-libraries/index.html)
@@ -1209,7 +1209,7 @@
         - learn about aria features and roles, it also has demo
 }}
 
-\subtree[2025-06-01]{\mdnote{2025-06-01}{\tags{#git #lean #neovim #tla #zig #✍️}
+\subtree[2025-06-01]{\mdnote{2025-06-01}{\tags{#git #lean #neovim #os #sec #tla #zig}
 - [Tools built on tree-sitter's concrete syntax trees](https://www.scannedinavian.com/tools-built-on-tree-sitters-concrete-syntax-trees.html)
     - found [ssr.nvim](https://github.com/cshuaimin/ssr.nvim), Structural search and replace for Neovim, seems more convenient than `ast-grep`
     - should take a look at
@@ -1239,7 +1239,7 @@
 
 % tried [Ente Photos v1](https://ente.io/blog/v1)
 
-\subtree[2025-05-31]{\mdnote{2025-05-31}{\tags{#agent #dspy #lean #prompt #rust}
+\subtree[2025-05-31]{\mdnote{2025-05-31}{\tags{#agent #dspy #lean #os #rust}
 - found [C++ to Rust Phrasebook](https://cel.cs.brown.edu/crp/title-page.html)
 - [Simpler backoff](https://commaok.xyz/post/simple-backoff/)
 - [Consider Knitting](http://journal.stuffwithstuff.com/2025/05/30/consider-knitting/)
@@ -1254,7 +1254,7 @@
         - [Advances and Challenges in Foundation Agents: From Brain-Inspired Intelligence to Evolutionary, Collaborative, and Safe Systems](https://arxiv.org/abs/2504.01990)
 }}
 
-\subtree[2025-05-30]{\mdnote{2025-05-30}{\tags{#formal #rust}
+\subtree[2025-05-30]{\mdnote{2025-05-30}{\tags{#build #formal #rust}
 - found [Grog: the mono-repo build tool for the grug-brained dev](https://grog.build/)
     - then the configuration language [Pkl: Configuration that is Programmable, Scalable, and Safe](https://pkl-lang.org/)
     - [The Grug Brained Developer (2022)](https://grugbrain.dev/)
@@ -1263,14 +1263,13 @@
 - [When was the last time you broke production and how?](https://lobste.rs/s/ytefme/when_was_last_time_you_broke_production)
 }}
 
-\subtree[2025-05-29]{\mdnote{2025-05-29}{\tags{#misc}
-- [Why Your AI Coding Assistant Keeps Doing It Wrong, and How To Fix It](https://blog.thepete.net/blog/2025/05/22/why-your-ai-coding-assistant-keeps-doing-it-wrong-and-how-to-fix-it/)
+\subtree[2025-05-29]{\mdnote{2025-05-29}{- [Why Your AI Coding Assistant Keeps Doing It Wrong, and How To Fix It](https://blog.thepete.net/blog/2025/05/22/why-your-ai-coding-assistant-keeps-doing-it-wrong-and-how-to-fix-it/)
 - [workflows for ai coding](https://anniecherkaev.com/the-times-they-are-ai-changing)
     - interesting take on human attention span
 - [Compiling a Neural Net to C for a 1,744× speedup](https://slightknack.dev/blog/difflogic/)
 }}
 
-\subtree[2025-05-28]{\mdnote{2025-05-28}{\tags{#agent #gpu #performance #proof #render}
+\subtree[2025-05-28]{\mdnote{2025-05-28}{\tags{#agent #codegen #gpu #os #proof #render #web}
 - [WebGPU Fluid Simulations: High Performance & Real-Time Rendering](https://tympanus.net/codrops/2025/02/26/webgpu-fluid-simulations-high-performance-real-time-rendering/)
 - learn about [uzi](https://github.com/devflowinc/uzi)
     - from [LLM Codegen go Brrr – Parallelization with Git Worktrees and Tmux](https://www.skeptrune.com/posts/git-worktrees-agents-and-tmux/)
@@ -1278,14 +1277,13 @@
 - [What a Difference a Faster Hash Makes](https://nickdrozd.github.io/2025/05/27/faster-hash.html)
 }}
 
-\subtree[2025-05-27]{\mdnote{2025-05-27}{\tags{#✍️}
-- found [Effekt Language: Home](https://effekt-lang.org/)
+\subtree[2025-05-27]{\mdnote{2025-05-27}{- found [Effekt Language: Home](https://effekt-lang.org/)
 - [The Three Kinds of Money](https://principles.page/three-money-types/)
     - summarized with doubao, then inspired me to work on mermaid and markmap integration
 - [The two types of open source](https://filiph.net/text/two-types-of-open-source.html)
 }}
 
-\subtree[2025-05-26]{\mdnote{2025-05-26}{\tags{#bevy #exif #formal #game #id3 #physics #rust #zig #✍️}
+\subtree[2025-05-26]{\mdnote{2025-05-26}{\tags{#bevy #exif #formal #id3 #news #os #physics #racket #rust #software}
 - found [F2](https://f2.freshman.tech/guide/how-variables-work), a bulk renaming tool that supports metadata such as EXIF, ID3 and more
 - Idiomatic Rust
     - [Don't Worry About Lifetimes](https://corrode.dev/blog/lifetimes/)
@@ -1317,7 +1315,7 @@
     - [What Works (and Doesn't) Selling Formal Methods](https://www.galois.com/articles/what-works-and-doesnt-selling-formal-methods)
 }}
 
-\subtree[2025-05-25]{\mdnote{2025-05-25}{\tags{#formal #galgebra #haskell #lean #ocaml #rust #theory #zig}
+\subtree[2025-05-25]{\mdnote{2025-05-25}{\tags{#formal #haskell #lean #ocaml #os #rust #zig}
 - [Having your compile-time cake and eating it too](https://0x44.xyz/blog/comptime-1)
     - [Hindley-Milner (HM)](\verb>>>|https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system>>>), the most popular human-friendly type system, used in Swift, Rust, Scala, Haskell, OCaml etc.
     - proposed four big features to replace pretty much all Rust macros, including derive ones, while keeping Rust's type system, and achieving (most of) Zig's comptime features
@@ -1339,7 +1337,7 @@
 - [Does gratitude increase happiness?](https://dynomight.net/gratitude/)
 }}
 
-\subtree[2025-05-24]{\mdnote{2025-05-24}{\tags{#apl #arm #claude #compiler #git #haskell #hiedb #lean #prompt #rust}
+\subtree[2025-05-24]{\mdnote{2025-05-24}{\tags{#agent #apl #cg #compiler #git #haskell #lean #os #rust #software}
 - [Anthropic’s ‘System Card’ for Claude 4 (Opus and Sonnet)](https://www-cdn.anthropic.com/4263b940cabb546aa0e3283f35b686f4f3b2ff47.pdf)
     - particularly fun reading
         - 4.1.1.1 Continuations of self-exfiltration attempts
@@ -1359,7 +1357,7 @@
 }}
 
 \subtree[2025-05-23]{
-\mdnote{2025-05-23}{\tags{#ocaml #rust #tla #✍️}
+\mdnote{2025-05-23}{\tags{#ocaml #os #rust #tla}
 - [Why I love OCaml](https://mccd.space/posts/ocaml-the-worlds-best/)
 - [How to Get Your Research Paper Accepted](https://maxwellforbes.com/posts/how-to-get-a-paper-accepted)
 - [Fork Union: Beyond OpenMP in C++ and Rust?](https://ashvardanian.com/posts/beyond-openmp-in-cpp-rust/)
@@ -1382,7 +1380,7 @@
 }
 }
 
-\subtree[2025-05-22]{\mdnote{2025-05-22}{\tags{#formal #galgebra}
+\subtree[2025-05-22]{\mdnote{2025-05-22}{\tags{#context #formal #idea #os}
 - [Adventures in Symbolic Algebra with Model Context Protocol](https://www.stephendiehl.com/posts/computer_algebra_mcp/)
     - maybe I should create MCP for GAlgebra
     - followup: [Interfacing MCP with Combinatorial, Convex, and SMT Solvers](https://www.stephendiehl.com/posts/smt_and_mcp_solvers/)
@@ -1391,13 +1389,13 @@
 - found [Obsidian Bases](https://mas.to/@obsidian/114546538858212821)
 }}
 
-\subtree[2025-05-21]{\mdnote{2025-05-21}{\tags{#sqlite}
+\subtree[2025-05-21]{\mdnote{2025-05-21}{\tags{#os #sqlite}
 - [If composers were hackers](https://mmapped.blog/posts/18-if-composers-were-hackers)
 - found [Litestream: Revamped](https://fly.io/blog/litestream-revamped/), making SQLite apps reliably recoverable from object storage
 - [The Ingredients of a Productive Monorepo](https://blog.swgillespie.me/posts/monorepo-ingredients/)
 }}
 
-\subtree[2025-05-20]{\mdnote{2025-05-20}{\tags{#gpu}
+\subtree[2025-05-20]{\mdnote{2025-05-20}{\tags{#gpu #news #os #web}
 - [Not causal chains, but interactions and adaptations](https://surfingcomplexity.blog/2025/05/19/not-causal-chains-but-interactions-and-adaptations/)
     - RCA(root cause analysis) model v.s. RE(resilience engineering) model, for incidents
     - related
@@ -1410,7 +1408,7 @@
 - [Particle Life simulation in browser using WebGPU](https://lisyarus.github.io/blog/posts/particle-life-simulation-in-browser-using-webgpu.html)
 }}
 
-\subtree[2025-05-19]{\mdnote{2025-05-19}{\tags{#agent #docker #lemmy #mastodon #qwen}
+\subtree[2025-05-19]{\mdnote{2025-05-19}{\tags{#agent #docker #lemmy #mastodon #os}
 - [Agent Recursion](https://choly.ca/post/agent-recursion/)
 - [Semgrep: AutoFixes using LLMs](https://choly.ca/post/semgrep-autofix-llm/)
     - found a few alternatives to `semgrep`, e.g. [ast-grep](https://ast-grep.github.io/)
@@ -1426,7 +1424,7 @@
 - found [macOS VMs in a Docker Container](https://github.com/trycua/cua/tree/main/libs/lumier)
 }}
 
-\subtree[2025-05-18]{\mdnote{2025-05-18}{\tags{#apl #compiler #game #gpu #performance #physics #quantum #shader #zig}
+\subtree[2025-05-18]{\mdnote{2025-05-18}{\tags{#apl #compiler #game #gpu #os #physics #quantum #shader #zig}
 - found [Algorithms by Jeff Erickson (2019)](https://jeffe.cs.illinois.edu/teaching/algorithms)
 - \citef{van2025comparing}
     - learned that APL can run on GPU via [Dyalog](https://www.dyalog.com/), the paper even discussed a flash attention implementation
@@ -1442,7 +1440,7 @@
 - found [Path Integrals in Quantum Mechanics, Statistics, Polymer Physics, and Financial Markets by Hagen Kleinert](https://hagenkleinert.de/documents/pi/HagenKleinert_PathIntegrals.pdf)
 }}
 
-\subtree[2025-05-17]{\mdnote{2025-05-17}{\tags{#elixir #game #ocaml #rust}
+\subtree[2025-05-17]{\mdnote{2025-05-17}{\tags{#elixir #game #ocaml #os #rust #software #web #zig}
 - [Parallel Scaling Law for Language Models](https://huggingface.co/papers/2505.10475)
 - [The Language That Never Was](https://blog.celes42.com/the_language_that_never_was.html)
     - [Leaving Rust gamedev after 3 years](https://loglog.games/blog/leaving-rust-gamedev/)
@@ -1462,7 +1460,7 @@
 - found [Teal: a statically-typed dialect of Lua](https://teal-language.org/), a statically-typed dialect of Lua
 }}
 
-\subtree[2025-05-16]{\mdnote{2025-05-16}{\tags{#formal #game #rust #tla #zig}
+\subtree[2025-05-16]{\mdnote{2025-05-16}{\tags{#formal #game #news #os #rust #tla #zig}
 - [I don’t like NumPy](https://dynomight.net/numpy/)
     - [Writing a better code with pytorch and einops](https://einops.rocks/pytorch-examples.html)
     - [Einops and Einsum Summarized](https://pratik-doshi-99.github.io/posts/einops/)
@@ -1490,7 +1488,7 @@
     - discovered [Helicopter game](https://neal.fun/internet-artifacts/helicopter-game/)
 }}
 
-\subtree[2025-05-15]{\mdnote{2025-05-15}{\tags{#formal #tla #zig}
+\subtree[2025-05-15]{\mdnote{2025-05-15}{\tags{#formal #forth #os #tla #zig}
 - [Introducing oniux: Kernel-level Tor isolation for any Linux app](https://blog.torproject.org/introducing-oniux-tor-isolation-using-linux-namespaces/)
     - [code](https://gitlab.torproject.org/tpo/core/oniux)
     - found [smoltcp](https://github.com/smoltcp-rs/smoltcp)
@@ -1510,7 +1508,7 @@
 - [Zig App Release and Updates via Github ⚡](https://dbushell.com/2025/03/18/zig-app-release-and-updates-via-github/)
 }}
 
-\subtree[2025-05-14]{\mdnote{2025-05-14}{\tags{#agent #ebpf #physics #rust #yaml}
+\subtree[2025-05-14]{\mdnote{2025-05-14}{\tags{#agent #ebpf #os #physics #rust #software #tui #web #yaml}
 - try [genspark](https://www.genspark.ai/agents?id=0cb4084a-b9ba-4755-8f00-029ddf087680)
     - impressive result
     - one deep research per day for free
@@ -1536,7 +1534,7 @@
     - found [DTrace book](https://illumos.org/books/dtrace/preface.html)
 }}
 
-\subtree[2025-05-12]{\mdnote{2025-05-12}{\tags{#apl #formal #mongodb #performance #proof #rust #tla}
+\subtree[2025-05-12]{\mdnote{2025-05-12}{\tags{#apl #formal #os #proof #rust #sec #tla #web}
 - [Are We Serious About Using TLA+ For Statistical Properties?](https://emptysqua.re/blog/are-we-serious-about-statistical-properties-tlaplus/)
     - found [FizzBee](https://fizzbee.io/) for behavior correctness verification and performance modelling, based on simulation
     - I've wished for a tool like this for a long time
@@ -1551,7 +1549,7 @@
 - [A tool to verify estimates, II: a flexible proof assistant](https://terrytao.wordpress.com/2025/05/09/a-tool-to-verify-estimates-ii-a-flexible-proof-assistant/)
 }}
 
-\subtree[2025-05-09]{\mdnote{2025-05-09}{\tags{#rust #zig}
+\subtree[2025-05-09]{\mdnote{2025-05-09}{\tags{#os #rust #zig}
 - [Memory Safety Features in Zig](https://gencmurat.com/en/posts/memory-safety-features-in-zig/)
     - very well summarized, with great examples
 - [Reservoir Sampling](https://samwho.dev/reservoir-sampling/)
@@ -1562,7 +1560,7 @@
 - [A catalog of ways to generate SSA](https://bernsteinbear.com/blog/ssa/)
 }}
 
-\subtree[2025-05-08]{\mdnote{2025-05-08}{\tags{#agent #gpu #performance #zig}
+\subtree[2025-05-08]{\mdnote{2025-05-08}{\tags{#agent #gpu #idea #interop #os #software #web #zig}
 - \citef{zhang2024transformers}
     - insightful, and well summarized related work
 - trying to figure out a way to let AI agent to read all papers citing an paper, and write a summary of the follow-up research
@@ -1578,7 +1576,7 @@
 - got zig to work inside lima with minimal setup
 }}
 
-\subtree[2025-05-07]{\mdnote{2025-05-07}{\tags{#rust #zig}
+\subtree[2025-05-07]{\mdnote{2025-05-07}{\tags{#os #rust #tui #web #zig}
 - [Zig’s Low-Level Safety Features Leave Rust in the Dust](https://www.reddit.com/r/Zig/comments/1kgk07m/zigs_lowlevel_safety_features_leave_rust_in_the/)
 - [Zig defer Patterns](https://matklad.github.io/2024/03/21/defer-patterns.html)
 - [Glossary Web Component](https://dbushell.com/2025/05/07/glossary-web-component/)
@@ -1588,7 +1586,7 @@
 - found [nnd: A TUI alternative to gdb](https://github.com/al13n321/nnd)
 }}
 
-\subtree[2025-05-07-2]{\mdnote{2025-05-07}{\tags{#ebpf #rust #zig}
+\subtree[2025-05-07-2]{\mdnote{2025-05-07}{\tags{#ebpf #os #rust #tui #zig}
 - [Zig’s Low-Level Safety Features Leave Rust in the Dust](https://www.reddit.com/r/Zig/comments/1kgk07m/zigs_lowlevel_safety_features_leave_rust_in_the/)
 - found [Parallel, Concurrent and Distributed Programming](https://ilyasergey.net/YSC4231/) in Scala
 - found [nnd: A TUI alternative to gdb](https://github.com/al13n321/nnd)
@@ -1605,7 +1603,7 @@
 }}
 
 \subtree[2025-05-06]{
-\mdnote{2025-05-06}{\tags{#agent #benchmark #formal #game #gpu #optimization #performance #physics #render #theory}
+\mdnote{2025-05-06}{\tags{#agent #benchmark #blogging #context #formal #game #gpu #news #optimization #os}
 - LM
     - survey papers
         - [A Survey on Inference Engines for Large Language Models: Perspectives on Optimization and Efficiency](https://huggingface.co/papers/2505.01658)
@@ -1642,7 +1640,7 @@
 }
 }
 
-\subtree[2025-05-04]{\mdnote{2025-05-04}{\tags{#git #lean}
+\subtree[2025-05-04]{\mdnote{2025-05-04}{\tags{#git #interop #lean #os}
 - found [pyonji](https://git.sr.ht/~emersion/pyonji), a tool to support sr.ht style e-mail patches
 - [Git: programmatic staging](https://choly.ca/post/git-programmatic-staging/)
     - and learn about `grepdiff`, unfortunately, it's not available on Mac
@@ -1653,7 +1651,7 @@
 }}
 
 \subtree[2025-05-02]{
-\mdnote{2025-05-02}{\tags{#formal}
+\mdnote{2025-05-02}{\tags{#formal #os #web}
 - \citef{ren2025deepseekproverv2}
     - \citef{tie2025survey}
         - notes on LM could be based on this survey and the following papers related to r1
@@ -1674,7 +1672,7 @@
 
 \subtree[2025-04]{
 \title{April, 2025}
-\subtree[2025-04-30]{\mdnote{2025-04-30}{\tags{#apl #formal #lean}
+\subtree[2025-04-30]{\mdnote{2025-04-30}{\tags{#apl #formal #lean #os #prolog}
 - found \citef{zhang2025leanabell}
 - skimmed \citef{lipman2024flow}
 - [APL: Comparison with Traditional Mathematics](https://aplwiki.com/wiki/Comparison_with_traditional_mathematics)
@@ -1683,7 +1681,7 @@
 - found [Quotes on notation design & how it affects thought](https://github.com/kai-qu/notation)
 }}
 
-\subtree[2025-04-29]{\mdnote{2025-04-29}{\tags{#prompt #qwen #theory #✍️}
+\subtree[2025-04-29]{\mdnote{2025-04-29}{\tags{#agent #os #✍️}
 - found [A Dependently Typed Assembly Language](https://www.cs.cmu.edu/~rwh/papers/dtal/OGI-CSE-99-008.pdf)
 - [Qwen3: Think Deeper, Act Faster](https://qwenlm.github.io/blog/qwen3/)
 - found [Topologies and Sheaves Appeared as Syntax and Semantics of Natural Language (2012)](http://www.pdmi.ras.ru/~prosorov/papers/Prosorov_PhML2012.pdf)
@@ -1693,7 +1691,7 @@
 - wrote [[uts-016B]]
 }}
 
-\subtree[2025-04-28]{\mdnote{2025-04-28}{\tags{#compiler #llvm #theory #zig}
+\subtree[2025-04-28]{\mdnote{2025-04-28}{\tags{#compiler #llvm #os #zig}
 - [BitNet v2: Native 4-bit Activations with Hadamard Transformation for 1-bit LLMs](https://huggingface.co/papers/2504.18415)
 - [Converting a C API to Zig with the help of comptime](https://www.reddit.com/r/Zig/comments/1k9vuni/converting_a_c_api_to_zig_with_the_help_of/)
 - [How a Single Line Of Code Could Brick Your iPhone](https://rambo.codes/posts/2025-04-24-how-a-single-line-of-code-could-brick-your-iphone)
@@ -1707,7 +1705,7 @@
 - [toycalculator, an MLIR/LLVM compiler experiment.](https://peeterjoot.com/2025/04/27/toycalculator-an-mlir-llvm-compiler-experiment/)
 }}
 
-\subtree[2025-04-27]{\mdnote{2025-04-27}{\tags{#apl}
+\subtree[2025-04-27]{\mdnote{2025-04-27}{\tags{#apl #news #os #web}
 - found [APL Cultivations](https://xpqz.github.io/cultivations/Intro.html)
 - [Understanding SVG Paths](https://www.nan.fyi/svg-paths)
 - [Remove these tags from <head>](https://getoutofmyhead.dev/)
@@ -1723,7 +1721,7 @@
 - found [PyGraph: Robust Compiler Support for CUDA Graphs in PyTorch](https://arxiv.org/abs/2503.19779)
 }}
 
-\subtree[2025-04-25]{\mdnote{2025-04-25}{\tags{#bevy #gpu #parquet #render #sec #spiraldb #tla #wasm}
+\subtree[2025-04-25]{\mdnote{2025-04-25}{\tags{#bevy #gpu #idea #news #os #render #sec #software #tla #wasm}
 - [Bevy 0.16](https://bevyengine.org/news/bevy-0-16/)
     - learn about GPU-Driven Rendering and [WESL](https://wesl-lang.dev/)
 - [How I Got Hacked: A Warning about Malicious PoCs](https://chocapikk.com/posts/2025/s1nk/)
@@ -1735,7 +1733,7 @@
     - a next-generation columnar format with self-describing layouts and WASM decoders that is 200x faster than Parquet for random access, among other goodies
 }}
 
-\subtree[2025-04-24]{\mdnote{2025-04-24}{\tags{#duckdb #gpu #llvm #optimization #performance #theory #tla #wasm #✍️}
+\subtree[2025-04-24]{\mdnote{2025-04-24}{\tags{#diagram #duckdb #gpu #idea #llvm #optimization #os #tla #wasm #✍️}
 - [Abusing DuckDB-WASM by making SQL draw 3D graphics (Sort Of)](https://www.hey.earth/posts/duckdb-doom)
     - a very cool idea
     - I should learn more about modern databases
@@ -1753,15 +1751,14 @@
     - but `~/Library/Mobile Documents/com~apple~CloudDocs` already works well for my purpose
 }}
 
-\subtree[2025-04-23]{\mdnote{2025-04-23}{\tags{#elixir #rust #zig}
+\subtree[2025-04-23]{\mdnote{2025-04-23}{\tags{#elixir #os #rust #zig}
 - [Nine Reasons to Use OSH](https://oils.pub/osh.html)
     - it contains a POSIX-compatible shell `osh`, and an incompatible shell `ysh`
     - it's written in a subset of Python, then transpiled to C++ by [mycpp](https://github.com/oils-for-unix/oils/blob/master/mycpp/README.md) that is based on MyPy, an interesting approach
 - found [codapi](https://codapi.org/) which supports sandboxes for Rust, Zig, Elixir etc.
 }}
 
-\subtree[2025-04-22]{\mdnote{2025-04-22}{\tags{#misc}
-- [Make Your Own Internet Presence with NetBSD and a 1 euro VPS – Part 1: Your Blog](https://it-notes.dragas.net/2025/04/22/make-your-own-internet-presence-with-netbsd-and-a-1-euro-vps-part-1-your-blog/)
+\subtree[2025-04-22]{\mdnote{2025-04-22}{- [Make Your Own Internet Presence with NetBSD and a 1 euro VPS – Part 1: Your Blog](https://it-notes.dragas.net/2025/04/22/make-your-own-internet-presence-with-netbsd-and-a-1-euro-vps-part-1-your-blog/)
     - which uses [BSSG](https://bssg.dragas.net/), a simple static site generator written in Bash
     - will settle on UTM for Mac/BSD virtualization, and Lima for Linux virtualization
     - still haven't figure out how to virtualize/emulate NetBSD with UTM, see [this issue](https://github.com/utmapp/UTM/discussions/7069)
@@ -1770,7 +1767,7 @@
 }}
 
 \subtree[2025-04-21]{
-\mdnote{2025-04-21}{\tags{#ag #render #rust #theory #z3 #zig}
+\mdnote{2025-04-21}{\tags{#context #elixir #idea #os #render #rust #web #z3 #zig}
 - wish to learn more about other architectures of LMs, e.g.
     - \citef{ma2025bitnet}
     - \citef{zhao2025d1}
@@ -1799,14 +1796,14 @@
 }
 }
 
-\subtree[2025-04-19]{\mdnote{2025-04-19}{\tags{#elixir #formal}
+\subtree[2025-04-19]{\mdnote{2025-04-19}{\tags{#elixir #formal #os}
 - [Common shell script mistakes](https://www.pixelbeat.org/programming/shell_script_mistakes.html)
 - [Four Years of Jai](https://smarimccarthy.is/posts/2024-12-02-four-years-of-jai/)
 - [My journey from Ruby to Elixir: lessons learned](https://www.erlang-solutions.com/blog/my-journey-from-ruby-to-elixir-lessons-from-a-developer/)
 - [Revisiting an early critique of formal verification](https://lawrencecpaulson.github.io/2025/03/14/revisiting_demillo.html)
 }}
 
-\subtree[2025-04-18]{\mdnote{2025-04-18}{\tags{#gpu #zig}
+\subtree[2025-04-18]{\mdnote{2025-04-18}{\tags{#gpu #os #zig}
 - found [Matrix Calculus for Machine Learning and Beyond](https://github.com/mitmath/matrixcalc)
 - [Reflections on Unikernels](https://dave.recoil.org/unikernels/)
     - found [OSv](https://osv.io/)
@@ -1818,7 +1815,7 @@
 - [Zig and GPUs](https://alichraghi.github.io/blog/zig-gpu/)
 }}
 
-\subtree[2025-04-17]{\mdnote{2025-04-17}{\tags{#agent #performance #rust #zig #✍️}
+\subtree[2025-04-17]{\mdnote{2025-04-17}{\tags{#agent #news #os #rust #sec #tui #zig #✍️}
 - found [A practical hacker's guide to the C programming language](https://github.com/codr7/hacktical-c)
 - [An Intro to DeepSeek's Distributed File System](https://maknee.github.io/blog/2025/3FS-Performance-Journal-1/)
     - my takeaway: DeepSeek's 3FS sacrifices small-file performance, POSIX compatibility, and fault tolerance (single-master risk) to maximize large-file throughput via CRAQ-based chain replication and RDMA-optimized chunk writes on 512B-sector SSDs
@@ -1837,7 +1834,7 @@
 - wrote some more Taiji notes
 }}
 
-\subtree[2025-04-16]{\mdnote{2025-04-16}{\tags{#dspy #gradient #tla #webgl #zig}
+\subtree[2025-04-16]{\mdnote{2025-04-16}{\tags{#dspy #tla #tui #web #webgl #zig}
 - [A flowing WebGL gradient, deconstructed](https://alexharri.com/blog/webgl-gradients)
 - found [An Introduction to Modern CMake](https://cliutils.gitlab.io/modern-cmake/README.html)
 - [JSX Over The Wire](https://overreacted.io/jsx-over-the-wire/)
@@ -1847,7 +1844,7 @@
 - found [Terminal Trove](https://terminaltrove.com/), a collection of terminal-based applications
 }}
 
-\subtree[2025-04-15]{\mdnote{2025-04-15}{\tags{#compiler #enhancedformysql #helixdb #optimization #render #rust}
+\subtree[2025-04-15]{\mdnote{2025-04-15}{\tags{#compiler #optimization #os #render #rust}
 - [A 2025 Survey of Rust GUI Libraries](https://www.boringcactus.com/2025/04/13/2025-survey-of-rust-gui-libraries.html)
 - [Algebraic Semantics for Machine Knitting](https://uwplse.org/2025/03/31/Algebraic-Knitting.html)
     - further reading:
@@ -1879,7 +1876,7 @@
 - [Solving One Million Sudoku Puzzles per hour](https://www.miakoring.de/blog/sudoku) in Swift
 }}
 
-\subtree[2025-04-13]{\mdnote{2025-04-13}{\tags{#compiler #ebpf #elixir #lean #performance #scylladb #zig}
+\subtree[2025-04-13]{\mdnote{2025-04-13}{\tags{#compiler #ebpf #elixir #lean #tui #zig}
 - looking for Zig libraries for TUI, `io_uring`, eBPF, scripting, e-graph
     - the candidates are `libvaxis`, `libxev`, `zbpf`, `Cyber`, `zegg`, respectively
 - found [Juniper CAS](https://github.com/MixedMatched/juniper), which is exactly my original dream for lean-ga
@@ -1890,7 +1887,7 @@
 - found [Performance Analysis and Tuning on Modern CPUs](https://github.com/dendibakh/perf-book)
 }}
 
-\subtree[2025-04-12]{\mdnote{2025-04-12}{\tags{#arm #compiler #elixir #gpu #rust #shader #tla}
+\subtree[2025-04-12]{\mdnote{2025-04-12}{\tags{#cg #compiler #elixir #gpu #rust #shader #software #tla}
 - [Bootstrapping Understanding: An Introduction to Reverse Engineering](https://www.muppetlabs.com/~breadbox/txt/bure.html)
 - [Bug in Outlook PST Password Protection (2006)](https://www.nirsoft.net/articles/pst_password_bug.html)
 - [Erlang’s not about lightweight processes and message passing…](https://stevana.github.io/erlangs_not_about_lightweight_processes_and_message_passing.html)
@@ -1900,13 +1897,13 @@
 - [Build a Static Site in Elixir Under 5 Minutes with Phoenix Components](https://mishka.tools/blog/build-a-static-site-in-elixir-under-5-minutes-with-phoenix-components) while looking for SSG in Elixir
 }}
 
-\subtree[2025-04-11]{\mdnote{2025-04-11}{\tags{#agent}
+\subtree[2025-04-11]{\mdnote{2025-04-11}{\tags{#agent #software}
 - [12-factor-agents: Principles to build LLM-powered software good enough to put in the hands of production customers](https://github.com/humanlayer/12-factor-agents)
 - found [cargo-mutants: Inject bugs and see if your tests catch them](https://github.com/sourcefrog/cargo-mutants)
 - found [DeepCoder: A Fully Open-Source 14B Coder at O3-mini Level](https://pretty-radio-b75.notion.site/DeepCoder-A-Fully-Open-Source-14B-Coder-at-O3-mini-Level-1cf81902c14680b3bee5eb349a512a51)
 }}
 
-\subtree[2025-04-09]{\mdnote{2025-04-09}{\tags{#elixir #rust}
+\subtree[2025-04-09]{\mdnote{2025-04-09}{\tags{#elixir #os #rust}
 - [Archiving URLs](https://gwern.net/archiving)
     - maybe I should use tools like [ArchiveBox](https://github.com/ArchiveBox/ArchiveBox#input-formats) to prevent link rot
 - [Mistakes and cool things to do with arena allocators](https://zylinski.se/posts/dynamic-arrays-and-arenas/)
@@ -1920,7 +1917,7 @@
 
 }}
 
-\subtree[2025-04-08]{\mdnote{2025-04-08}{\tags{#compiler #neovim #render #rust}
+\subtree[2025-04-08]{\mdnote{2025-04-08}{\tags{#compiler #neovim #os #render #rust}
 - [Beautiful CI for Bazel](https://narang99.github.io/2025-03-22-monorepo-bazel-jenkins/)
 - found [Real-Time Rendering Resources](https://www.realtimerendering.com/)
 - [The Gamma Knife model of incidents (2019)](https://surfingcomplexity.blog/2019/08/25/the-gamma-knife-model-of-incidents/)
@@ -1934,13 +1931,13 @@
 - wrote [[uts-016A]]
 }}
 
-\subtree[2025-04-05]{\mdnote{2025-04-05}{\tags{#rust}
+\subtree[2025-04-05]{\mdnote{2025-04-05}{\tags{#os #rust}
 - [Atproto Ethos](https://atproto.com/articles/atproto-ethos)
 - [BPF From Scratch In Rust](https://yeet.cx/blog/bpf-from-scratch-in-rust/)
 - [Pitfalls of Safe Rust](https://corrode.dev/blog/pitfalls-of-safe-rust/)
 }}
 
-\subtree[2025-04-04]{\mdnote{2025-04-04}{\tags{#lean #performance #rust #simd}
+\subtree[2025-04-04]{\mdnote{2025-04-04}{\tags{#lean #news #os #rust #simd #web}
 - [Of manners and machines](https://commaok.xyz/post/manners/)
 - [Rewriting my site in vanilla web](https://leanrada.com/notes/vanilla-web-rewrite/)
     - [TAC: A new CSS methodology](https://jordanbrennan.hashnode.dev/tac-a-new-css-methodology)
@@ -1952,7 +1949,7 @@
 - found [Public mdBooks](https://mdbooks.code-maven.com/)
 }}
 
-\subtree[2025-04-03]{\mdnote{2025-04-03}{\tags{#lean #rust}
+\subtree[2025-04-03]{\mdnote{2025-04-03}{\tags{#biology #lean #rust #tui #web}
 - learn about [geonum](https://github.com/mxfactorial/geonum), a ridiculously fast Rust library that supports many GA operations except for geometric product
 - some portions of [On the Biology of a Large Language Model](https://transformer-circuits.pub/2025/attribution-graphs/biology.html)
     - it's a particularly inspiring article on the interpretability of LLMs
@@ -1964,7 +1961,7 @@
 - found [chawan: TUI Web Browser](\verb>>>|https://sr.ht/%7Ebptato/chawan/>>>)
 }}
 
-\subtree[2025-04-02]{\mdnote{2025-04-02}{\tags{#formal #sec #theory}
+\subtree[2025-04-02]{\mdnote{2025-04-02}{\tags{#formal #os #sec #web}
 - [Stop syncing everything](https://sqlsync.dev/posts/stop-syncing-everything/), which launches [Graft](https://github.com/orbitinghail/graft), an open-source transactional storage engine optimized for lazy, partial, and strongly consistent replication—perfect for edge, offline-first, and distributed applications.
 - [The Most Amusing Security Flaws I've Discovered](https://predr.ag/blog/xorry-not-sorry-most-amusing-security-flaws-ive-discovered/)
 - [Foundation Models and Unix](https://vagos.github.io/blog/foundation-models-unix.html)
@@ -1984,7 +1981,7 @@
 \subtree[2025-03]{
 \title{March, 2025}
 
-\subtree[2025-03-31]{\mdnote{2025-03-31}{\tags{#rust}
+\subtree[2025-03-31]{\mdnote{2025-03-31}{\tags{#os #rust}
 - [There is no Vibe Engineering](https://serce.me/posts/2025-31-03-there-is-no-vibe-engineering)
 - found [Koto Programming Language](https://koto.dev/), it's not so DSL-friendly like Rhai, but a reasonably good script language embeddable in Rust
 - [Thoughts on ECS](https://blog.voxagon.se/2025/03/28/thoughts-on-ecs.html)
@@ -1992,14 +1989,14 @@
     - I really wanted this for French, except for not in TypeScript, but something Rust-like
 }}
 
-\subtree[2025-03-30]{\mdnote{2025-03-30}{\tags{#claude #✍️}
+\subtree[2025-03-30]{\mdnote{2025-03-30}{\tags{#agent #idea}
 - work on exporting Discord chat and feeding them to [RAG](https://github.com/stars/utensil/lists/llm-kb), the result is not quite ideal
 - try DeepSeek-v3-0324, but still not as good as Claude 3.5 for my use cases
 - re-evaluate [marimo](https://marimo.io/) as an alternative to testing with Jupyter notebooks
     - but it doesn' store outputs, and [the candidate testing solution](https://github.com/marimo-team/marimo/discussions/573) is not elegant
 }}
 
-\subtree[2025-03-28]{\mdnote{2025-03-28}{\tags{#rust #theory #✍️}
+\subtree[2025-03-28]{\mdnote{2025-03-28}{\tags{#os #rust #✍️}
 - found
     - \citef{bach2024learning}
     - \citef{feng2023winding}, and read [the blog post](https://nzfeng.github.io/research/WNoDS/index.html)
@@ -2009,7 +2006,7 @@
 - wrote [[uts-0167]]
 }}
 
-\subtree[2025-03-27]{\mdnote{2025-03-27}{\tags{#elixir #rust #zig}
+\subtree[2025-03-27]{\mdnote{2025-03-27}{\tags{#elixir #news #os #rust #zig}
 - learn more about Elixir
     - [Running ML models in Elixir using Pythonx](https://samrat.me/running-ml-models-in-elixir-using-pythonx/)
     - [Embedded Zig with Elixir, Mandelbrot set](https://zig.news/ndrean/embedded-zig-with-elixir-mandelbrot-set-4e31)
@@ -2018,14 +2015,14 @@
 - [Why MCP Won](https://www.latent.space/p/why-mcp-won)
 }}
 
-\subtree[2025-03-24]{\mdnote{2025-03-24}{\tags{#clifford}
+\subtree[2025-03-24]{\mdnote{2025-03-24}{\tags{#os}
 - slowly picking up open-source work, after fragmented learning due to the DeepSeek hype
 - found [PeanoScript](https://peanoscript.mjgrzymek.com/tutorial), TypeScript but a theorem prover
 - [attention is logarithmic, actually](https://supaiku.com/attention-is-logarithmic)
 - \citef{roelfs2025willing}, the [Kingdon](https://github.com/tBuLi/kingdon) paper
 }}
 
-\subtree[2025-03-18]{\mdnote{2025-03-18}{\tags{#ocaml #racket}
+\subtree[2025-03-18]{\mdnote{2025-03-18}{\tags{#ocaml #os #racket #tui}
 - found [Rhombus](https://rhombus-lang.org/), a Racket without parenthesis
 - [Writing a SIGGRAPH paper (for fun) (2020)](https://www.mattkeeter.com/projects/siggraph/)
 - [The 70\% problem: Hard truths about AI-assisted coding](https://addyo.substack.com/p/the-70-problem-hard-truths-about)
@@ -2034,11 +2031,10 @@
 - found \citef{prasolov1995intuitive}
 }}
 
-\subtree[2025-03-13]{\mdnote{2025-03-13}{\tags{#galgebra}
-- learn about \citef{helmstetter2013minimal}, a paper about determining whether a multivector is a versor, as versors are invertible lipschitzian elements, related to [galgebra#533](https://github.com/pygae/galgebra/issues/533)
+\subtree[2025-03-13]{\mdnote{2025-03-13}{- learn about \citef{helmstetter2013minimal}, a paper about determining whether a multivector is a versor, as versors are invertible lipschitzian elements, related to [galgebra#533](https://github.com/pygae/galgebra/issues/533)
 }}
 
-\subtree[2025-03-11]{\mdnote{2025-03-11}{\tags{#agent #category #lean #proof #quantum #theory}
+\subtree[2025-03-11]{\mdnote{2025-03-11}{\tags{#agent #category #lean #os #proof #quantum #sec}
 - found
     - Math
         - [Category Theory Illustrated](https://github.com/abuseofnotation/category-theory-illustrated)
@@ -2065,11 +2061,11 @@
 \subtree[2025-02]{
 \title{February, 2025}
 
-\subtree[2025-02-27]{\mdnote{2025-02-27}{\tags{#raymarching}
+\subtree[2025-02-27]{\mdnote{2025-02-27}{\tags{#raymarching #rss}
 - [Raymarching The Gunk](https://jarllarsson.github.io/gen/gunkraymarcher.html)
 }}
 
-\subtree[2025-02-26]{\mdnote{2025-02-26}{\tags{#claude #proof #typst #z3}
+\subtree[2025-02-26]{\mdnote{2025-02-26}{\tags{#agent #codegen #news #proof #typst #z3}
 - [Uncensor any LLM with abliteration](https://huggingface.co/blog/mlabonne/abliteration)
 - [All the Transformer Math You Need to Know](https://jax-ml.github.io/scaling-book/transformers/)
 - [[AINews] Claude 3.7 Sonnet](https://buttondown.com/ainews/archive/ainews-claude-37-sonnet/)
@@ -2087,7 +2083,7 @@
 
 \title{January, 2025}
 
-\subtree[2025-01-23]{\mdnote{2025-01-23}{\tags{#typst #✍️}
+\subtree[2025-01-23]{\mdnote{2025-01-23}{\tags{#news #typst #✍️}
 - busy with Spring Festival
 - WeRead books and wrote some reviews
 - casual readings are starred in NetNewsWire
@@ -2096,7 +2092,7 @@
 - organize my Chinese ancient poetry collection (in LaTeX, wishing to port to Typst in the future)
 }
 
-\subtree[2025-01-11]{\mdnote{2025-01-11}{\tags{#gradient #physics #quantum #render #rust #theory #zig}
+\subtree[2025-01-11]{\mdnote{2025-01-11}{\tags{#os #physics #quantum #render #rust #zig}
 - articles on lobste.rs
     - [Elementary Water Rendering](https://jysandy.github.io/posts/gradient-water-rendering/)
     - [Prototyping in Rust](https://corrode.dev/blog/prototyping/)
@@ -2114,8 +2110,7 @@
 - found *Histoire de la philosophie* by Émile Bréhier
 }}
 
-\subtree[2025-01-01]{\mdnote{2025-01-01}{\tags{#misc}
-- 📦 move to new office and get used to everything
+\subtree[2025-01-01]{\mdnote{2025-01-01}{- 📦 move to new office and get used to everything
 - 🗓️ making plans for the new year
 }}
 
@@ -2131,7 +2126,7 @@
 \subtree[2024-12]{
 \title{December, 2024}
 
-\subtree[2024-12-30]{\mdnote{2024-12-30}{\tags{#galgebra #gpu #lean #rust}
+\subtree[2024-12-30]{\mdnote{2024-12-30}{\tags{#gpu #lean #rust}
 - [Fish 4.0: The Fish Of Theseus](https://fishshell.com/blog/rustport/), it's about Fish team porting Fish from C++ to Rust
 - found [cargo-gpu](https://github.com/rust-gpu/cargo-gpu)
 - [A letter to open-source maintainers](https://xuanwo.io/2024/10-a-letter-to-open-source-maintainers/)
@@ -2149,21 +2144,19 @@
 - [Gu Shi](https://clarkesworldmagazine.com/author/gu-shi/)'s *Möbius Continuum* and write a review on Weread
 }}
 
-\subtree[2024-12-24]{\mdnote{2024-12-24}{\tags{#misc}
-- found \citef{hutter2024introduction}
+\subtree[2024-12-24]{\mdnote{2024-12-24}{- found \citef{hutter2024introduction}
 }}
 
-\subtree[2024-12-13]{\mdnote{2024-12-13}{\tags{#clifford #galgebra}
-- recieved [pygae/galgebra#529](https://github.com/pygae/galgebra/issues/529) about Shirokov inverse, read \citef{shirokov2021computing}
+\subtree[2024-12-13]{\mdnote{2024-12-13}{- recieved [pygae/galgebra#529](https://github.com/pygae/galgebra/issues/529) about Shirokov inverse, read \citef{shirokov2021computing}
 }}
 
-\subtree[2024-12-17]{\mdnote{2024-12-17}{\tags{#misc}
+\subtree[2024-12-17]{\mdnote{2024-12-17}{\tags{#os}
 - 🎿🪂
 - reading Wang Guowei's philosophical works
 - [Ghostty Is Native—So What?](https://gpanders.com/blog/ghostty-is-native-so-what/)
 }}
 
-\subtree[2024-12-15]{\mdnote{2024-12-15}{\tags{#proof #rust #✍️}
+\subtree[2024-12-15]{\mdnote{2024-12-15}{\tags{#news #os #proof #rust #✍️}
 - [My Ph.D. advisor rewrote himself in bash](https://matt.might.net/articles/shell-scripts-for-passive-voice-weasel-words-duplicates/), and learn about how weasel words, passive voice, and lexical illusions can make technical writing less precise, clear, and convey a lack of proofreading
 - [Playground Wisdom: Threads Beat Async/Await](https://lucumr.pocoo.org/2024/11/18/threads-beat-async-await/), and learn that in imperative programming, structured concurrency might be better than async/await, we don't always need to introduce functional programming concepts
 - [From where I left](https://antirez.com/news/144) by antirez, the author of Redis, and learn that he likes the new license, and he does more work but better work by using AI to proofread and help testing the work instead of replace what he does better
@@ -2173,18 +2166,17 @@
 - learn about [git-backdate](https://github.com/rixx/git-backdate), which can help me date unpushed commits better
 }}
 
-\subtree[2024-12-12]{\mdnote{2024-12-12}{\tags{#agent #proof}
+\subtree[2024-12-12]{\mdnote{2024-12-12}{\tags{#agent #proof #software}
 - [How wide is a proof?](https://robwilson1.wordpress.com/2024/12/07/how-wide-is-a-proof/)
 - found [Notes on Geometric Algebra](https://github.com/cloudcell/GA_Notes)
 - skimmed \citef{wang2024agents} and related papers
 }}
 
-\subtree[2024-12-09]{\mdnote{2024-12-09}{\tags{#misc}
-- 🚧 busy
+\subtree[2024-12-09]{\mdnote{2024-12-09}{- 🚧 busy
 - reading 📘*Zen and the Art of Motorcycle Maintenance: An Inquiry into Values*
 }}
 
-\subtree[2024-12-01]{\mdnote{2024-12-01}{\tags{#clifford #git #render #rust #✍️}
+\subtree[2024-12-01]{\mdnote{2024-12-01}{\tags{#git #os #render #rust}
 - try Deepseek Deep Think, add [[uts-002I]]
 - rethinking self-hosted git repos, CI, and pages, found
     - [Forgejo](https://code.readeck.org/)
@@ -2208,7 +2200,7 @@
 - [Optimizing a Rust GPU matmul kernel](https://rust-gpu.github.io/blog/optimizing-matmul/)
 }}
 
-\subtree[2024-11-28]{\mdnote{2024-11-28}{\tags{#quantum #theory}
+\subtree[2024-11-28]{\mdnote{2024-11-28}{\tags{#idea #quantum}
 - found
     - \citef{broden2024knots}
     - \citef{etingof2024mathematical}
@@ -2220,17 +2212,16 @@
 - [Haskell: A Great Procedural Language](https://entropicthoughts.com/haskell-procedural-programming)
 }}
 
-\subtree[2024-11-23]{\mdnote{2024-11-23}{\tags{#misc}
-- 🚧 busy
+\subtree[2024-11-23]{\mdnote{2024-11-23}{- 🚧 busy
 }}
 
-\subtree[2024-11-22]{\mdnote{2024-11-22}{\tags{#shader}
+\subtree[2024-11-22]{\mdnote{2024-11-22}{\tags{#os #shader}
 - found [Slang](https://github.com/shader-slang/slang)
 - [Exploring Async Runtimes by Building our Own](https://blog.maguire.tech/posts/explorations/exploring-async-runtimes/)
 - found \citef{collas2018dirac}
 }}
 
-\subtree[2024-11-21]{\mdnote{2024-11-21}{\tags{#compiler #performance #vulkan}
+\subtree[2024-11-21]{\mdnote{2024-11-21}{\tags{#compiler #vulkan}
 - found [Impala](https://anydsl.github.io/Impala.html)
     - skimmed
         - \citef{leissa2018anydsl}
@@ -2240,13 +2231,13 @@
         - [Vulkan Clang Compiler](https://shady-gang.github.io/vcc/)
 }}
 
-\subtree[2024-11-20]{\mdnote{2024-11-20}{\tags{#clifford}
+\subtree[2024-11-20]{\mdnote{2024-11-20}{\tags{#os}
 - skimmed
     - \citef{pepe2024staresnet}
     - \citef{filimoshina2024note}
 }}
 
-\subtree[2024-11-12]{\mdnote{2024-11-12}{\tags{#citation #galgebra #lean #rust #✍️}
+\subtree[2024-11-12]{\mdnote{2024-11-12}{\tags{#citation #lean #os #rust #✍️}
 - experiments on using [aider](https://aider.chat/) for LLM assisted project-level pair programming
     - [this PR](https://github.com/utensil/lean4_jupyter/pull/2) is a most extensive one
 - finish citation trace for GAlgebra, see [this PR](https://github.com/pygae/galgebra/pull/528) for relevant readings
@@ -2254,19 +2245,19 @@
 - found [Cario](https://www.cairo-lang.org/), a provable Rust-like language
 }}
 
-\subtree[2024-11-11]{\mdnote{2024-11-11}{\tags{#ag}
+\subtree[2024-11-11]{\mdnote{2024-11-11}{\tags{#os}
 - found [Bartosz Ciechanowski's blog](https://ciechanow.ski/)
 - found \citef{michor2008topics} and \citef{milne2012algebraic}, helpful for [[ag-0001]]
 - plan to read \citef{mosto2024templex}
 }}
 
-\subtree[2024-11-10]{\mdnote{2024-11-10}{\tags{#lean #rust #wasm}
+\subtree[2024-11-10]{\mdnote{2024-11-10}{\tags{#idea #lean #rust #wasm}
 - contemplate the idea of better file management with Rust
 - meet datachain, extism, revisit mage-ai, should evaluate kestra, contemplate the idea of ML orchestration with Rust where each node is a WASM plugin, [BAML](https://github.com/BoundaryML/baml) has some potential
 - wish to get back more on Lean and Math in this month
 }}
 
-\subtree[2024-11-08]{\mdnote{2024-11-08}{\tags{#compiler #rust #✍️}
+\subtree[2024-11-08]{\mdnote{2024-11-08}{\tags{#compiler #idea #rust}
 - 🌴
 - contemplate the idea of a bot to keep me going back to work on my projects, triggered by
     - an update of a related project
@@ -2280,7 +2271,7 @@
 - [Isa Proof Shell](https://github.com/xqyww123/Isa-Proof-Shell)
 }}
 
-\subtree[2024-11-06]{\mdnote{2024-11-06}{\tags{#git #gpu #neovim #ocaml #render #rust #shader}
+\subtree[2024-11-06]{\mdnote{2024-11-06}{\tags{#git #gpu #neovim #ocaml #os #render #rust #shader}
 - [Forester 5.x git log](https://git.sr.ht/~jonsterling/ocaml-forester/log/forester-5.0-dev), not bumping to 5.x yet
 - evaluate [HTMX](https://htmx.org/server-examples/) a bit
 - [Why not just embed Neovim?](https://zed.dev/blog/zed-decoded-vim), will need to revisit Zed later
@@ -2296,7 +2287,7 @@
 - finish [[uts-002H]]
 }}
 
-\subtree[2024-10-25]{\mdnote{2024-10-25}{\tags{#benchmark #formal #rust #✍️}
+\subtree[2024-10-25]{\mdnote{2024-10-25}{\tags{#benchmark #formal #rust #tui}
 - work on native-land
     - trying to make GA and math benchmark work, also evaluating the feasibility of benchmarking C++ libraries from Rust
     - pass CI on runpod
@@ -2304,7 +2295,7 @@
 - debug various TUI tools
 }}
 
-\subtree[2024-10-18]{\mdnote{2024-10-18}{\tags{#formal #gpu #lean #neovim #rust #✍️}
+\subtree[2024-10-18]{\mdnote{2024-10-18}{\tags{#formal #gpu #lean #neovim #rust}
 - work on native-land, trying to make rust-gpu fully work
 - work on formal-land, trying to establish the infrastructure to explore multiple Lean 4 projects with independent toolchains and dependencies
 - switching to Neovim, make it work for Rust, Lean, and forester
@@ -2313,7 +2304,7 @@
 - start reading [Modern C++ Programming Course (C++03/11/14/17/20/23/26)](https://github.com/federico-busato/Modern-CPP-Programming)
 }}
 
-\subtree[2024-10-17]{\mdnote{2024-10-17}{\tags{#citation #haskell #physics #render #shader #vulkan #webgl}
+\subtree[2024-10-17]{\mdnote{2024-10-17}{\tags{#citation #haskell #physics #render #shader #vulkan #web #webgl}
 - initial citation trace for \citef{james2015gravitational} and \citef{james2015visualizing}
 - \citef{meseguer2023custom} (Vulkan, Ray-marching, Kerr black hole) [lrogerorrit/narwhalEngine](https://github.com/lrogerorrit/narwhalEngine)
 - \citef{bruneton2020real} (CPU precal, WebGL2, Schwarzschild black hole) [ebruneton/black_hole_shader](https://github.com/ebruneton/black_hole_shader)
@@ -2321,25 +2312,25 @@
 - learn about \citef{haftmann2013haskell}: the type class for Isabelle, but its expressiveness is limited, see discussions in \citef{schmoetten2024construction}
 }}
 
-\subtree[2024-10-16]{\mdnote{2024-10-16}{\tags{#arm #benchmark #gpu #gradient}
+\subtree[2024-10-16]{\mdnote{2024-10-16}{\tags{#benchmark #gpu #os}
 - \citef{siskind2019automatic} and \citef{naumann2024matrix}, seems limited, but have some good references
 - skim \citef{low2023gafro} (good library and benchmark) and \citef{eid2024developing} (good refs, but in C#)
 - skim \citef{sharma2024comprehensive}, an interesting area with sparse tensors as an in-memory database in mind
 - skim \citef{zhao2024felix} ([uiuc-arc/felix](https://github.com/uiuc-arc/felix)), which uses egg
 }}
 
-\subtree[2024-10-15]{\mdnote{2024-10-15}{\tags{#compiler #gradient}
+\subtree[2024-10-15]{\mdnote{2024-10-15}{\tags{#compiler}
 - found \citef{raptis2024functoriality}
 - found \citef{shaikhha2024tensor} and \citef{zhao2024felix}
 - SDQLite \citef{schleich2023optimizing} (based on [SDQL](https://github.com/edin-dal/sdql)) is an intermediate language that expresses sparse tensor workloads by separating the tensoropt computations from the storage formats
 - reminds me of \citef{wu2024multi}
 }}
 
-\subtree[2024-10-11]{\mdnote{2024-10-11}{\tags{#gpu #✍️}
+\subtree[2024-10-11]{\mdnote{2024-10-11}{\tags{#gpu}
 - work on [native-land](https://github.com/utensil/native-land) about GPU computation, see relavant README updates.
 }}
 
-\subtree[2024-10-10]{\mdnote{2024-10-10}{\tags{#bevy #game #rust}
+\subtree[2024-10-10]{\mdnote{2024-10-10}{\tags{#bevy #game #idea #rust}
 - watch [Chris Biscardi - Bevy: A case study in ergonomic Rust](https://www.youtube.com/watch?v=CnoDOc6ML0Y)
 - have a better idea about the game about fly, evade, slingshot, and shoot around black holes, 4D implicit surfaces
 - explore [sketchfab](https://sketchfab.com/3d-models/black-hole-e410da98b1e5445eae2acafaaa53587d), [polyhaven](https://polyhaven.com/), and [openverse](https://openverse.org/), and have a basic idea about how to use them in the early stage of the game
@@ -2347,13 +2338,13 @@
 - found \citef{garrity2013algebraic}
 }}
 
-\subtree[2024-10-09]{\mdnote{2024-10-09}{\tags{#lean}
+\subtree[2024-10-09]{\mdnote{2024-10-09}{\tags{#lean #os}
 - [C++ Package Managers: The Ultimate Roundup](https://moderncppdevops.com/pkg-mngr-roundup/), and start using [xrepo](https://xrepo.xmake.io/) for C/C++ package management, it also supports a wide range of [package repositories](https://xmake.io/#/home?id=supported-package-repositories), including Conan, Conda, Vcpkg, Homebrew, Apt, and Cargo. But not [BinaryBuilder.jl ecosystem](https://github.com/JuliaPackaging/BinaryBuilder.jl) (see also [this FAQ](https://docs.binarybuilder.org/dev/FAQ/#Hey,-this-is-cool,-can-I-use-this-for-my-non-Julia-related-project?)).
 - clarify the license for GinacLean, laying the ground for potential future work around [Cadabra 2](https://github.com/kpeeters/cadabra2), which is licensed under GPLv3
 - learn about [Kento Okura's forest and Glade](https://kentookura.srht.site/) and [Nota](https://nota-lang.org/)
 }}
 
-\subtree[2024-10-08]{\mdnote{2024-10-08}{\tags{#formal #gpu #lean #llvm #vulkan #z3}
+\subtree[2024-10-08]{\mdnote{2024-10-08}{\tags{#formal #gpu #lean #llvm #os #vulkan #web #z3}
 - add more plans in formal-land
 - recovered [Research Codebase Manifesto](https://www.moderndescartes.com/essays/research_code/) from [Lean-MLIR](https://github.com/opencompl/lean-mlir)
 - recovered [quotes from CICM 2020 Slack chat](https://gist.github.com/utensil/b4616dd5452d665318780c8a8b193dcc)
@@ -2362,7 +2353,7 @@
 - found [Lorenz and modular flows: a visual introduction](https://www.josleys.com/articles/ams_article/Lorenz3.htm)
 }}
 
-\subtree[2024-10-07]{\mdnote{2024-10-07}{\tags{#rust #✍️}
+\subtree[2024-10-07]{\mdnote{2024-10-07}{\tags{#news #os #rust}
 - learned about [lobste.rs](https://lobste.rs/), a computing-focused community centered around link aggregation and discussion, a bit like Hacker News but less noise maybe
 - [Rewriting Rust](https://lobste.rs/s/29a1eo/rewriting_rust) and [Josh Triplett's comment](https://www.reddit.com/r/rust/comments/1fpomvp/rewriting_rust/lozktuv/)
 - \citef{wu2024multi} and learn about [mirage](https://github.com/mirage-project/mirage)
@@ -2370,19 +2361,19 @@
 - make [the Railscasts theme for Zed](https://gist.github.com/utensil/a279928e07fe23558fa688ca4d82181e)
 }}
 
-\subtree[2024-10-06]{\mdnote{2024-10-06}{\tags{#apl #tla #z3}
+\subtree[2024-10-06]{\mdnote{2024-10-06}{\tags{#apl #os #tla #z3}
 - found [ipe](https://github.com/otfried/ipe) that is used extensively in [tungsteno](https://www.tungsteno.io/post/exp-classification_compact_surfaces/) ([source](https://github.com/TungstenHub/tngt-ipe/tree/master))
 - [Why I use TLA+ and not(TLA+)](https://protocols-made-fun.com/specification/modelchecking/tlaplus/quint/2024/10/05/tla-and-not-tla.html), learn about PlusCal, [Quint](https://quint-lang.org/) and [Apalache](https://apalache-mc.org/) (TLA+ to Z3)
 - trying to figure out if TLA+ can be run in browser via [TeaVM](https://www.teavm.org/) or [CheerpJ](https://cheerpj.com/cheerpj-core/)
 }}
 
-\subtree[2024-10-05]{\mdnote{2024-10-05}{\tags{#render}
+\subtree[2024-10-05]{\mdnote{2024-10-05}{\tags{#os #render #web}
 - \citef{wang2024simple}
 - \citef{estep2024rose}, and learn about \citef{paszke2021getting} [dex-lang](https://github.com/google-research/dex-lang)
 - they are read on mobile app [Reflow](https://apps.apple.com/us/app/pdf-reflow/id1461144444) which has good PDF reflow support for math formulas in Arxiv papers, but not so good for other math book PDFs
 }}
 
-\subtree[2024-10-04]{\mdnote{2024-10-04}{\tags{#category #game}
+\subtree[2024-10-04]{\mdnote{2024-10-04}{\tags{#category #game #idea}
 - learn about [catcolab.org](https://catcolab.org/) and double category
 - learn about [Curved Diffusion: A Generative Model With Optical Geometry Control](https://anylens-diffusion.github.io/) from ECCV 2024
 - [Reusing Styles from Tailwind CSS](https://tailwindcss.com/docs/reusing-styles), decide to use it for CSS refactor
@@ -2390,7 +2381,7 @@
 - learn about the game [sgued/slingshot](https://codeberg.org/sgued/slingshot) (just like a recent idea about black hole puzzle game inspired by Star Trek: Discovery)
 }}
 
-\subtree[2024-10-03]{\mdnote{2024-10-03}{\tags{#gradient #render #rust #shader}
+\subtree[2024-10-03]{\mdnote{2024-10-03}{\tags{#os #render #rust #sci #shader}
 - Differentiable Programming
     - found [Differentiable Programming for Image Processing and Deep Learning in Halide](http://gradient.halide.ai/) and [gradient-halide autodiff](https://github.com/jrk/gradient-halide/blob/master/test/correctness/autodiff.cpp) for halide
     - [Adelta: Automatic Differentiation for Discontinuous Programs](https://medium.com/@yutingyang.wh/adelta-automatic-differentiation-for-discontinuous-programs-de68b4bb8119) for [A𝛿: Autodiff for Discontinuous Programs – Applied to Shaders](https://pixl.cs.princeton.edu/pubs/Yang_2022_AAF/) \citef{yang2022delta}
@@ -2402,7 +2393,7 @@
 - found \citef{bennett2024anything}
 }}
 
-\subtree[2024-10-01]{\mdnote{2024-10-01}{\tags{#render #rust #shader #✍️}
+\subtree[2024-10-01]{\mdnote{2024-10-01}{\tags{#render #rust #shader}
 - found \citef{wang2024simple} and \citef{tricard2024interval}
 - work on Rust stuff, particularly read about [dioxus](https://github.com/DioxusLabs/dioxus)
 }}
@@ -2417,7 +2408,7 @@
 - skim [read-lean](https://github.com/madvorak/read-lean)
 }}
 
-\subtree[2024-09-29]{\mdnote{2024-09-29}{\tags{#gpu}
+\subtree[2024-09-29]{\mdnote{2024-09-29}{\tags{#gpu #os}
 - watch [Coding Adventure: Optimizing a Ray Tracer (by building a BVH)](https://www.youtube.com/watch?v=C1H4zIiCOaI) and learn about the importance of BVH in ray tracing, and [gkjohnson/three-mesh-bvh](https://github.com/gkjohnson/three-mesh-bvh)
 - collect [autodiff in GPU](https://github.com/stars/utensil/lists/ad-gpu)
 - submit [a bug report to Chromium](https://issues.chromium.org/issues/370153438)
@@ -2425,7 +2416,7 @@
 - thinking about turning my playground repos to monorepos by language/stack
 }}
 
-\subtree[2024-09-27]{\mdnote{2024-09-27}{\tags{#lean}
+\subtree[2024-09-27]{\mdnote{2024-09-27}{\tags{#lean #sci}
 - found \citef{massot2024teaching}
 - noticed that [Scientific Computing in Lean](https://lecopivo.github.io/scientific-computing-lean/) is now written in Verso!
 - checked some progress in [Type Checking in Lean 4](https://ammkrn.github.io/type_checking_in_lean4/)
@@ -2433,7 +2424,7 @@
 - improve the VSCode Forester extension to have [Hover, Go to definition, Search by title, and user-defined patterns for triggering completion](https://github.com/Trebor-Huang/vscode-forester/issues/9)
 }}
 
-\subtree[2024-09-26]{\mdnote{2024-09-26}{\tags{#bevy #rust #wasm #✍️}
+\subtree[2024-09-26]{\mdnote{2024-09-26}{\tags{#bevy #os #rust #wasm #web}
 - add [[uts-001N]]
     - [Compiling C to WebAssembly without Emscripten](https://surma.dev/things/c-to-webassembly/) and [WebAssembly without Emscripten](https://schellcode.github.io/webassembly-without-emscripten), a bit dead-end for me
     - found [twr-wasm](https://github.com/twiddlingbits/twr-wasm), a lightweight emscripten
@@ -2445,32 +2436,32 @@
 - learn about [WLJS](https://jerryi.github.io/wljs-docs/) for Wolfram Mathematica, recalled [my early Mathematica notebooks](https://github.com/utensil/mathematica-notebooks), and wish to do SSR for them
 }}
 
-\subtree[2024-09-25]{\mdnote{2024-09-25}{\tags{#biome #✍️}
+\subtree[2024-09-25]{\mdnote{2024-09-25}{\tags{#biome #web}
 - use `biome` for linting web source files
 - add [[uts-001K]]
 }}
 
-\subtree[2024-09-24]{\mdnote{2024-09-24}{\tags{#theory #webgl}
+\subtree[2024-09-24]{\mdnote{2024-09-24}{\tags{#web #webgl}
 - add live reload
 - improve various loading and WebGL animation experience
 - found [David Tong: Lectures on Gauge Theory](https://www.damtp.cam.ac.uk/user/tong/gaugetheory.html)
 }}
 
-\subtree[2024-09-23]{\mdnote{2024-09-23}{\tags{#ag #gpu #render #shader #✍️}
+\subtree[2024-09-23]{\mdnote{2024-09-23}{\tags{#gpu #render #shader #✍️}
 - more progress on [[ag-000G]], particularly on [[ag-001J]]
 - found [shaderfrog](https://shaderfrog.com/)
 - found [three-gpu-pathtracer](https://github.com/gkjohnson/three-gpu-pathtracer) and related projects, particularly [Physically Based Materials](https://gkjohnson.github.io/three-gpu-pathtracer/example/bundle/index.html), and that [Steve Trettel](https://x.com/stevejtrettel) uses it to render black holes and Hopf fibrations
 - found \citef{yariv2020multiview} ([lioryariv/idr](https://github.com/lioryariv/idr))
 }}
 
-\subtree[2024-09-22]{\mdnote{2024-09-22}{\tags{#quantum #theory}
+\subtree[2024-09-22]{\mdnote{2024-09-22}{\tags{#os #quantum}
 - skimmed \citef{carosso2018geometric}: "Geometric quantization is an attempt at using the differential-geometric ingredients of classical phase spaces regarded as symplectic manifolds in order to define a corresponding quantum theory."
 - skimmed \citef{pinkall2024differential}: "Unlike the common approach in existing textbooks on this topic, there is a strong focus on variational problems, ranging from elastic curves to surface that minimize area or Willmore functional."
 - found [demo-geodesic-heat](https://github.com/davreev/demo-geodesic-heat) and [mesh-parameterize](https://github.com/davreev/demo-mesh-parameterize)
 - found \citef{broue2024rings}
 }}
 
-\subtree[2024-09-19]{\mdnote{2024-09-19}{\tags{#ag #✍️}
+\subtree[2024-09-19]{\mdnote{2024-09-19}{\tags{#diagram #✍️}
 Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, diagrams, algorithms, and readable working code).
 }}
 
@@ -2478,7 +2469,7 @@ Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, 
 - skimmed \citef{love2024role} \citef{quevedo2024cambridge} \citef{faddeev2009lectures} \citef{takhtajan2008quantum} \citef{komech2019lectures}, and \citef{madrid2005role}
 }}
 
-\subtree[2024-09-16]{\mdnote{2024-09-16}{\tags{#bevy #game #render #rust #shader #symbolica #visualization}
+\subtree[2024-09-16]{\mdnote{2024-09-16}{\tags{#bevy #cg #game #os #render #rust #shader #visualization}
 - found
   - [symbolica](https://github.com/benruijl/symbolica) for Rust and Python
   - [Rusph](https://github.com/JackNarvaez/Rusph): SPH algorithm in Rust for astrophysical simulations
@@ -2492,7 +2483,7 @@ Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, 
   - [Normals and the Inverse Transpose, Part 1: Grassmann Algebra](https://www.reedbeta.com/blog/normals-inverse-transpose-part-1/) in 2018
 }}
 
-\subtree[2024-09-15]{\mdnote{2024-09-15}{\tags{#apl #benchmark #compiler #faer #gpu #performance #render #rust #shader #webgl}
+\subtree[2024-09-15]{\mdnote{2024-09-15}{\tags{#apl #benchmark #compiler #gpu #os #render #rust #sci #shader #web}
 - found [Compile Julia code to WebAssembly](https://tshort.github.io/WebAssemblyCompiler.jl/stable/)
 - found [SHADERed](https://shadered.org/shaders) as another source of shader examples, particularly some are written in Rust, supported via one of its plugins
 - looking for ways to include 3D models in LaTeX, found
@@ -2524,18 +2515,18 @@ Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, 
 - learned about [fpgatoy](https://github.com/davidar/fpgatoy)
 }}
 
-\subtree[2024-09-12]{\mdnote{2024-09-12}{\tags{#ag #✍️}
+\subtree[2024-09-12]{\mdnote{2024-09-12}{\tags{#✍️}
 - make a start on [[ag-000G]]
 - make [[ag-000O]]
 }}
 
-\subtree[2024-09-11]{\mdnote{2024-09-11}{\tags{#gradient #shader}
+\subtree[2024-09-11]{\mdnote{2024-09-11}{\tags{#os #shader}
 - trying to figure out curvature calculation in shaders
   - [Screen Space Curvature Shader](https://madebyevan.com/shaders/curvature/) is a trick to mimic curvature calculation in shaders,using [dFdx, dFdy in GLSL](https://registry.khronos.org/OpenGL-Refpages/gl4/html/dFdx.xhtml), [Curvature shader by iY0Yi](https://www.shadertoy.com/view/fsGXzc) used it but it shows certain shower door effect
   - [glsl-autodiff](https://github.com/sibaku/glsl-autodiff) properly uses forward auto differentiation to calculate curvature in shaders, but it requires rewrite every math function for bookkeeping the gradient and the Hessian
 }}
 
-\subtree[2024-09-10]{\mdnote{2024-09-10}{\tags{#shader #✍️}
+\subtree[2024-09-10]{\mdnote{2024-09-10}{\tags{#shader}
 - work out shader for [[uts-001D]]
 - inspired by [Surface Plotter](https://github.com/jaxry/surface-plotter) ([demo](https://jaxry.github.io/surface-plotter/)), read
   - [Marching Cubes](http://algorithm-interest-group.com/assets/slides/marching_cubes.pdf)
@@ -2544,12 +2535,12 @@ Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, 
   - [Marching Cubes Part 1: Explaining marching cubes](https://polycoding.net/marching-cubes/part-1/)
 }}
 
-\subtree[2024-09-09]{\mdnote{2024-09-09}{\tags{#formal #lean #optimization #rust #wasm}
+\subtree[2024-09-09]{\mdnote{2024-09-09}{\tags{#formal #lean #optimization #os #rust #wasm}
 - add `egglog` and `ginac`, and streamline the build process of Rust WASM dependencies
 - reading source of projects using egg: `jafioti/luminal`, `marcusrossel/lean-egg`, `verified-optimization/CvxLean` etc. TODO: read more egg papers: \citef{rossel2024bridging}\citef{rossel2024equality}\citef{bentkamp2023verified}
 }}
 
-\subtree[2024-09-08]{\mdnote{2024-09-08}{\tags{#gpu #render #z3 #✍️}
+\subtree[2024-09-08]{\mdnote{2024-09-08}{\tags{#gpu #render #web #z3}
 - mark candidates for rendering PDB: [[uts-001A]]
 - fail to run Z3 in browser (due to `SharedArrayBuffer` again)
 - the source of examples of [uwal](https://github.com/UstymUkhman/uwal) and the corresponding articles at [webgpufundamentals.org](https://webgpufundamentals.org/)
@@ -2561,7 +2552,7 @@ Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, 
 - experiments on compute shaders
 }}
 
-\subtree[2024-09-06]{\mdnote{2024-09-06}{\tags{#clifford #✍️}
+\subtree[2024-09-06]{\mdnote{2024-09-06}{\tags{#idea}
 - Polish [[ca-0001]]
 - Some more on [[uts-000C]]
 - Re-skim \citef{trautman1997clifford}
@@ -2569,7 +2560,7 @@ Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, 
 - [Notes on Distributed Systems for Young Bloods (2013)](https://www.somethingsimilar.com/2013/01/14/notes-on-distributed-systems-for-young-bloods/)
 }}
 
-\subtree[2024-09-05]{\mdnote{2024-09-05}{\tags{#formal #lean #spin #✍️}
+\subtree[2024-09-05]{\mdnote{2024-09-05}{\tags{#formal #lean #sec #✍️}
 \ul{
 \li{Ported the rest of the prelimilary part of \citef{wieser2024blueprint} to [[ca-0001]], except [#{Z_2}-graded derivations #{i_f}, anti-derivation](https://utensil.github.io/lean-ga/blueprint/sec-ops.html#antiDeriv)
 }
@@ -2577,7 +2568,7 @@ Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, 
 }
 }}
 
-\subtree[2024-09-04]{\mdnote{2024-09-04}{\tags{#citation #clifford #theory}
+\subtree[2024-09-04]{\mdnote{2024-09-04}{\tags{#citation #idea #os}
 - \citef{hamilton2023supergeometric} and \citef{hamilton2023unification}: illuminating path towards a unified theory of four fundamental forces, the first theory seemingly capable of reaching the same level of elegance and simplicity as \citef{wilson2024discrete}, the authors are also aware of potential issues and worked out viable solutions to address them. Unfortunately, there are no citations as of now.
   - \citef{trautman1997clifford} has certain historical remarks and a unusual approach that spinor representations are treated first for odd-dimensional spaces
 spaces
@@ -2588,7 +2579,7 @@ spaces
 - Meta Flow Matching: Integrating Vector Fields on the Wasserstein Manifold
 }}
 
-\subtree[2024-09-03]{\mdnote{2024-09-03}{\tags{#clifford #formal #physics}
+\subtree[2024-09-03]{\mdnote{2024-09-03}{\tags{#cg #formal #physics #sci #sec}
 - \citet{ch. 1-4}{grassmann2000extension}
 - \citet{sec. 1.1-2.8}{browne2012grassmann}
 - \citef{loret2024universe}
@@ -2614,8 +2605,7 @@ spaces
 \subtree[2024-01~08]{
 \title{January to August, 2024}
 
-\subtree[2024-08-11]{\mdnote{2024-08-11}{\tags{#✍️}
-The readings during this period are reflected in
+\subtree[2024-08-11]{\mdnote{2024-08-11}{The readings during this period are reflected in
 
 - [[uts-000G]]
 - [[uts-000H]]
@@ -2625,21 +2615,18 @@ Many experiments on Forester are done, as summarized in [[uts-000X]].
 }}
 
 
-\subtree[2024-07-27]{\mdnote{2024-07-27}{\tags{#ag}
-The readings during this period are yet to be reflected in [[ag-0001]].
+\subtree[2024-07-27]{\mdnote{2024-07-27}{The readings during this period are yet to be reflected in [[ag-0001]].
 }}
 
-\subtree[2024-05-09]{\mdnote{2024-05-09}{\tags{#tt #✍️}
-The readings during this period are reflected in [[tt-0001]].
+\subtree[2024-05-09]{\mdnote{2024-05-09}{The readings during this period are reflected in [[tt-0001]].
 
 [[uts-000C]] was ported to Forester on 07-22.
 }}
 
-\subtree[2024-04-25]{\mdnote{2024-04-25}{\tags{#hopf #spin}
-The readings during this period are reflected in [[spin-0001]]. Some are yet to be reflected in [[hopf-0001]].
+\subtree[2024-04-25]{\mdnote{2024-04-25}{The readings during this period are reflected in [[spin-0001]]. Some are yet to be reflected in [[hopf-0001]].
 }}
 
-\subtree[2024-01-01]{\mdnote{2024-01-01}{\tags{#misc}
+\subtree[2024-01-01]{\mdnote{2024-01-01}{\tags{#os}
 The readings during this period are reflected in
 
 - [My math interests in 2024](https://utensil.github.io/blog/posts/math-2024/)


### PR DESCRIPTION
- **refactor: unify tag extraction and merging logic in til.py [AGENT]**
- **Add task 2 about til.py**
- **refactor: explicit #tag extraction, deduplication, and CLI flags in til.py [AGENT]**
- **fix: remove unwanted tags and map all project prefixes to ✍️ in til.py [AGENT]**
- **fix: concise verbose log for kept tags in til.py [AGENT]**
- **fix: only log merge and kept tags in til.py verbose mode [AGENT]**
- **feat: print top 20 monthly tag stats in til.py [AGENT]**
- **fix: only include #misc in monthly tag stats if explicitly present [AGENT]**
- **fix: show all months in monthly tag stats, even if no tags present [AGENT]**
- **feat: monthly tag stats use #tag xN and ANSI color in TTY [AGENT]**
- **style: monthly tag stats use #tag N and ANSI color [AGENT]**
- **feat: monthly tag stats only with --stat [N], show YYYYMM (N tags): #tag1, ... [AGENT]**
- **fix: show ellipsis in monthly tag stats when tag count exceeds N [AGENT]**
- **style: use #98c379 green for tag color in TTY monthly stats [AGENT]**
