### PR TITLE
docs: fix jj template syntax example [AGENT]

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,8 @@ ALWAYS follow this `jj` commit workflow:
 - Before committing:
     - use `jj` (which combines `jj status` and `jj log` in a customized way) to learn about status and recent revisions
         - so it's clear which revision to commit, and won't commit an empty or unrelated revision
-        - fallback to use `jj log --no-graph -T '{commit_id} {description}' -n <N>` to view the last N revisions in a concise format
+        - fallback to use `jj log --no-graph -T 'commit_id.short(7) ++ " | " ++ author.email().local() ++ " | " ++ description.first_line()' -n <N>` to view the last N revisions in a concise format
+    - **jj Template Syntax**: Use the `++` operator to concatenate fields. Common fields: `commit_id.short(N)`, `description.first_line()`, `author.email().local()`, `local_bookmarks()`, `empty()`. See [jj templates documentation](https://jj-vcs.github.io/jj/latest/templates/) for the complete field reference.
     - run `jj diff` or `jj diff -r <rev>` to review all changes in the working copy or the revision to commit.
 - During committing:
     - **Granular commits**: One logical change per commit.


### PR DESCRIPTION
## 问题
在 AGENTS.md 中 jj 模板的示例使用了错误的语法。

## 修改内容
修正 Commit discipline 部分的 jj 模板示例，将错误的 f-string 风格语法替换为正确的 jj 模板语法：

❌ 错误：`jj log --no-graph -T '{commit_id} {description}'`
✅ 正确：`jj log --no-graph -T 'commit_id.short(7) ++ " | " ++ description.first_line()'`

## 技术细节
- 使用 `++` 操作符进行模板拼接
- 展示实用方法：CommitId 的 `.short()`、String 的 `.first_line()`
- 提供了可实际使用的示例命令

## 验证
已根据官方文档验证语法正确性：
- https://jj-vcs.github.io/jj/latest/templates/