### PR TITLE
chore: Remove G-skill content from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,17 +78,6 @@ ALWAYS cite the rules which have been actually followed during the reply at the 
 - ❌ **Must NOT**: Remove files without backup mechanism
 - ❌ **Must NOT**: Modify system-critical files or permissions
 
-### G-skill: Always check and use SKILLS.md for skill management
-
-- ✅ **Should**: When the content of SKILLS.md or confirmation that it doesn't exist is not visible from context, ALWAYS load the content of SKILLS.md
-- ✅ **Should**: ALWAYS use `bunx openskills` to install, list skills, and read a skill or manage them
-- ✅ **Should**: ALWAYS install skills with `--global` and `--universal` flags
-- ✅ **Should**: ALWAYS use `bunx openskills list` to learn about available tools
-- ✅ **Should**: When lacking tools for requested tasks or when users explicitly mention skills, find and use proper skills from SKILLS.md recommendations
-- ❌ **Must NOT**: Ignore SKILLS.md when it exists in the project
-- ❌ **Must NOT**: Use other methods for skill management when `bunx openskills` is available
-- ❌ **Must NOT**: Use `bunx openskills sync` - always use `bunx openskills list` instead
-
 ---
 
 ## 2. Anchor comments


### PR DESCRIPTION
This PR removes the G-skill section and all related references from AGENTS.md to clean up deprecated rules as requested.