### PR TITLE
test: verify TeX Live 2026 fix from setup-texlive-action

### DIFF
--- a/.github/workflows/test-texlive-2026.yml
+++ b/.github/workflows/test-texlive-2026.yml
@@ -1,0 +1,27 @@
+name: Test TeX Live 2026 Support
+
+on:
+  push:
+    branches:
+      - test/verify-texlive-2026-fix
+  pull_request:
+
+jobs:
+  test-texlive-2026:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup TeX Live 2026 (with fixed action)
+        uses: utiberious/setup-texlive-action@fix/support-texlive-2026
+        with:
+          version: '2026'
+          packages: scheme-full
+
+      - name: Verify TeX Live Installation
+        run: |
+          echo "Checking TeX Live version..."
+          tlmgr --version
+          which latex
+          latex --version | head -1


### PR DESCRIPTION
This PR adds a test workflow that verifies the fix for TeX Live 2026 support.

The workflow uses the patched setup-texlive-action (from PR #1 in that repo) which now properly supports version 2026.

Once the setup-texlive-action PR is merged and released, this test workflow can be:
1. Updated to use the released version
2. Migrated into the main CI workflow
3. Deleted if validation is no longer needed

This serves as validation that the version mismatch error is resolved.