### PR TITLE
ci: run CI for fix-ci/* branches without deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -7,6 +7,12 @@ on:
       - "README.md"
     branches:
       - main
+  pull_request:
+    paths-ignore:
+      - "LICENSE"
+      - "README.md"
+    branches:
+      - fix-ci/**
 
 # Allow one concurrent deployment
 concurrency:
@@ -134,7 +140,7 @@ jobs:
             echo "::warning title=Invalid file permissions automatically fixed::$line"
           done
       - name: Upload Pages artifact
-        if: ${{ !env.ACT }}
+        if: ${{ !env.ACT && github.event_name == 'push' }}
         uses: actions/upload-pages-artifact@v3
         with:
           path: ./output/forest
@@ -151,6 +157,7 @@ jobs:
 
     # Specify runner + deployment step
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
     steps:
       - name: Deploy to GitHub Pages
         id: deployment


### PR DESCRIPTION
Resolves #16

## Changes

- Add pull_request trigger for branches matching `fix-ci/**` pattern
- Skip Pages artifact upload and deployment on pull_request events  
- This allows validation of CI without publishing to GitHub Pages

## How to test

1. Create a branch matching the `fix-ci/\*` pattern
2. The CI workflow will run to validate all build steps
3. No deployment to GitHub Pages will occur

This facilitates validation of issue #15 (TeX Live 2026 fix) and other fixes that need CI testing before full deployment.