### PR TITLE
feat: add docker-socket-proxy stack for VM-to-host Docker access

### DIFF
--- a/dotfiles/term.just
+++ b/dotfiles/term.just
@@ -804,6 +804,23 @@ prep-pod:
 pod CMD="start --vm-type=vz --vz-rosetta --network-address":
     colima {{CMD}}
 
+# Expose Colima docker socket to lume VM via docker-socket-proxy
+# Listens only on 192.168.64.1:2375 (isolated Host-VM network, not exposed externally)
+# VM end: export DOCKER_HOST=tcp://192.168.64.1:2375
+#
+pod-proxy CMD="up -d":
+    #!/usr/bin/env bash
+    # Find actual Colima socket — docker context may report wrong path when using --vm-type=vz
+    # Actual path is ~/.config/colima/, not ~/.colima/
+    COLIMA_SOCKET=$(find ~/.config/colima ~/.colima -name "docker.sock" 2>/dev/null | head -1)
+    if [ -z "$COLIMA_SOCKET" ]; then
+        echo "Error: Colima docker.sock not found. Is Colima running? (just pod)"
+        exit 1
+    fi
+    echo "Using Colima socket: $COLIMA_SOCKET"
+    cd {{justfile_directory()}}/../stacks/docker-socket-proxy
+    COLIMA_SOCKET=$COLIMA_SOCKET docker compose {{CMD}}
+
 # tested in lima
 # distrobox create --name test --init --image quay.io/toolbx-images/alpine-toolbox:latest
 # distrobox enter test

--- a/dotfiles/term.just
+++ b/dotfiles/term.just
@@ -810,16 +810,27 @@ pod CMD="start --vm-type=vz --vz-rosetta --network-address":
 #
 pod-proxy CMD="up -d":
     #!/usr/bin/env bash
-    # Find actual Colima socket — docker context may report wrong path when using --vm-type=vz
-    # Actual path is ~/.config/colima/, not ~/.colima/
+    # Auto-detect Colima socket — docker context may report wrong path for --vm-type=vz
+    # vz type stores socket at ~/.config/colima/, not ~/.colima/
     COLIMA_SOCKET=$(find ~/.config/colima ~/.colima -name "docker.sock" 2>/dev/null | head -1)
     if [ -z "$COLIMA_SOCKET" ]; then
         echo "Error: Colima docker.sock not found. Is Colima running? (just pod)"
         exit 1
     fi
+    # Auto-detect Host IP on the VM-facing network (typically 192.168.x.x)
+    DOCKER_PROXY_BIND=$(/sbin/ifconfig 2>/dev/null | grep "inet 192.168" | awk '{print $2}' | head -1)
+    if [ -z "$DOCKER_PROXY_BIND" ]; then
+        echo "Error: Could not detect Host-VM network IP. Set DOCKER_PROXY_BIND manually."
+        exit 1
+    fi
+    if [ "$DOCKER_PROXY_BIND" = "0.0.0.0" ]; then
+        echo "Error: DOCKER_PROXY_BIND must not be 0.0.0.0 (would expose docker to all interfaces)"
+        exit 1
+    fi
     echo "Using Colima socket: $COLIMA_SOCKET"
+    echo "Binding proxy to: $DOCKER_PROXY_BIND:2375 (Host-VM network only)"
     cd {{justfile_directory()}}/../stacks/docker-socket-proxy
-    COLIMA_SOCKET=$COLIMA_SOCKET docker compose {{CMD}}
+    COLIMA_SOCKET=$COLIMA_SOCKET DOCKER_PROXY_BIND=$DOCKER_PROXY_BIND docker compose {{CMD}}
 
 # tested in lima
 # distrobox create --name test --init --image quay.io/toolbx-images/alpine-toolbox:latest

--- a/stacks/docker-socket-proxy/.env.example
+++ b/stacks/docker-socket-proxy/.env.example
@@ -1,0 +1,12 @@
+# Copy this file to .env and fill in your values.
+
+# Colima docker socket path on the host.
+# Find with: find ~/.config/colima ~/.colima -name "docker.sock" 2>/dev/null | head -1
+# When using --vm-type=vz (Apple VZ), typically: ~/.config/colima/default/docker.sock
+# When using QEMU (default),               typically: ~/.colima/default/docker.sock
+COLIMA_SOCKET=/Users/YOUR_USERNAME/.config/colima/default/docker.sock
+
+# Host IP on the VM-facing isolated network (NOT your external/Tailscale IP).
+# This is where the proxy will listen. The VM connects here via DOCKER_HOST.
+# Find with: /sbin/ifconfig | grep "inet 192.168"
+DOCKER_PROXY_BIND=192.168.X.X

--- a/stacks/docker-socket-proxy/.gitignore
+++ b/stacks/docker-socket-proxy/.gitignore
@@ -1,0 +1,2 @@
+# Local config with real values — never commit
+.env

--- a/stacks/docker-socket-proxy/README.md
+++ b/stacks/docker-socket-proxy/README.md
@@ -1,0 +1,85 @@
+# docker-socket-proxy
+
+Exposes the Colima Docker socket as a TCP endpoint on the isolated Host-VM network,
+allowing AI agents (e.g. OpenClaw) running in a VM to call Docker on the host's
+Colima runtime — without exposing anything to external networks or Tailscale.
+
+## Network Topology
+
+```
+Host Mac  (Host-VM network IP, e.g. 192.168.64.1)
+  └─ Colima VM (docker daemon)
+       └─ socket: ~/.config/colima/default/docker.sock  (vz type)
+            └─ docker-socket-proxy (this stack)
+                 └─ listens on <DOCKER_PROXY_BIND>:2375 only
+
+VM Mac  (Host-VM network IP, e.g. 192.168.64.9)
+  └─ AI agent (OpenClaw etc.)
+       └─ DOCKER_HOST=tcp://<DOCKER_PROXY_BIND>:2375
+```
+
+The Host-VM network (e.g. `192.168.64.0/24`) is a private NAT network isolated from:
+- The external internet
+- Tailscale (only the VM connects to Tailscale, not the host)
+
+## Setup
+
+### 1. Find your values
+
+On the Host Mac:
+
+```bash
+# Find Colima socket path
+find ~/.config/colima ~/.colima -name "docker.sock" 2>/dev/null | head -1
+
+# Find Host IP on the VM-facing network
+/sbin/ifconfig | grep "inet 192.168"
+```
+
+### 2. Configure .env
+
+```bash
+cp .env.example .env
+# Edit .env: set COLIMA_SOCKET and DOCKER_PROXY_BIND
+```
+
+### 3. Start the proxy
+
+```bash
+# From stacks/docker-socket-proxy/
+docker compose up -d
+
+# Or using the just task (from forest root):
+just pod-proxy
+```
+
+The `just pod-proxy` task auto-detects the socket path — no manual `.env` editing needed.
+
+### 4. Configure the VM
+
+On the VM, set `DOCKER_HOST` to point at the host:
+
+```bash
+# In ~/.zshrc or equivalent:
+export DOCKER_HOST="tcp://<DOCKER_PROXY_BIND>:2375"
+
+# Test:
+docker ps
+docker info
+```
+
+## Colima Socket Path Note
+
+| Colima VM type | Socket location |
+|---|---|
+| `--vm-type=vz` (Apple VZ) | `~/.config/colima/default/docker.sock` |
+| Default (QEMU) | `~/.colima/default/docker.sock` |
+
+`docker context ls` may report the wrong path. Use `find` to locate the actual socket.
+
+## Security Notes
+
+- Port 2375 is bound **only to the Host-VM network interface** — not reachable from external network or Tailscale
+- Socket is mounted **read-only** at the OS level
+- Fine-grained API permission control via environment variables in `compose.yaml`
+- `BUILD` and `COMMIT` are disabled by default

--- a/stacks/docker-socket-proxy/compose.yaml
+++ b/stacks/docker-socket-proxy/compose.yaml
@@ -29,35 +29,38 @@ services:
       # Find it: /sbin/ifconfig | grep "inet 192.168"
       - "${DOCKER_PROXY_BIND}:2375:2375"
     environment:
-      # POST: 0 = fully read-only (GET/HEAD only, all write operations blocked)
-      # POST: 1 = allow write operations for endpoints explicitly enabled below
-      POST: 1
+      # Security model: container CREATION is human-gated (via PR review + manual start);
+      # container LIFECYCLE ops are agent-delegated (safe once the container is vetted).
+      #
+      # POST: 0 = block all HTTP POST → no docker create/run, no new containers possible.
+      # Lifecycle ops (start/stop/exec) use their own specific allow-list below.
+      POST: 0
 
-      # ── Read operations (low risk) ──────────────────────────────────────────
+      # ── Read operations ─────────────────────────────────────────────────────
       PING: 1
       VERSION: 1
       INFO: 1
       EVENTS: 1
-      CONTAINERS: 1   # list/inspect containers
+      CONTAINERS: 1   # docker ps / docker inspect
       IMAGES: 1
       NETWORKS: 1
       VOLUMES: 1
 
-      # ── Write operations — enable only what agents actually need ────────────
-      ALLOW_START: 1      # start existing containers
-      ALLOW_STOP: 1       # stop containers
-      ALLOW_RESTARTS: 0   # restart/kill — disabled, enable if needed
-      ALLOW_PAUSE: 0      # pause/unpause — disabled
+      # ── Lifecycle ops on pre-approved containers (safe: no new containers possible) ──
+      ALLOW_START: 1      # docker start
+      ALLOW_STOP: 1       # docker stop
+      ALLOW_RESTARTS: 1   # docker restart / docker kill
+      ALLOW_PAUSE: 1      # docker pause / unpause
 
-      # ── Dangerous — disabled by default ────────────────────────────────────
-      # EXEC: allows running arbitrary commands inside containers (= shell access)
-      # Enable only if the agent explicitly needs exec (e.g. running scripts in containers)
-      EXEC: 0
+      # EXEC is safe here: container boundaries (mounts, privileges) were set at creation
+      # time and reviewed by the human. exec cannot exceed those boundaries.
+      EXEC: 1
 
-      BUILD: 0        # build images from Dockerfile
-      COMMIT: 0       # commit container state as image
-      CONFIGS: 0      # swarm configs
-      DISTRIBUTION: 0 # registry access
+      # ── Disabled — container creation is human-only via PR + manual docker compose ───
+      BUILD: 0
+      COMMIT: 0
+      CONFIGS: 0
+      DISTRIBUTION: 0
       GRPC: 0
       NODES: 0
       PLUGINS: 0

--- a/stacks/docker-socket-proxy/compose.yaml
+++ b/stacks/docker-socket-proxy/compose.yaml
@@ -1,0 +1,53 @@
+# Docker Socket Proxy
+# Exposes the Colima docker socket as TCP on the Host-VM isolated network,
+# so that AI agents running in a VM can call docker without exposing to external networks.
+#
+# Setup: copy .env.example to .env and fill in your values, then:
+#   docker compose up -d
+# Or use: just pod-proxy
+#
+# Permissions reference: https://github.com/Tecnativa/docker-socket-proxy#not-always-needed
+# Set env vars to 1 to enable each capability.
+#
+services:
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy
+    restart: unless-stopped
+    volumes:
+      # Colima socket path — set COLIMA_SOCKET in .env or environment
+      # When using --vm-type=vz, actual path is ~/.config/colima/default/docker.sock
+      # (docker context may report ~/.colima/default/docker.sock which is wrong for vz type)
+      # Find it with: find ~/.config/colima ~/.colima -name "docker.sock" 2>/dev/null | head -1
+      - ${COLIMA_SOCKET}:/var/run/docker.sock:ro
+    ports:
+      # Only listen on the Host-VM isolated network interface — never exposed externally
+      # Set DOCKER_PROXY_BIND to your Host's IP on the VM-facing network (e.g. 192.168.64.1)
+      # Find it with: /sbin/ifconfig | grep "inet 192.168"
+      - "${DOCKER_PROXY_BIND}:2375:2375"
+    environment:
+      # Read-only ops (safe defaults)
+      CONTAINERS: 1
+      IMAGES: 1
+      NETWORKS: 1
+      VOLUMES: 1
+      INFO: 1
+      PING: 1
+      VERSION: 1
+      SERVICES: 1
+      TASKS: 1
+      # Write ops (enable only what agents need)
+      POST: 1       # allow POST (run containers, exec, etc.)
+      BUILD: 0      # disable build
+      COMMIT: 0     # disable commit
+      CONFIGS: 0    # disable swarm configs
+      DISTRIBUTION: 0
+      EXEC: 1       # allow exec into containers
+      GRPC: 0
+      NODES: 0
+      PLUGINS: 0
+      SECRETS: 0
+      SESSION: 0
+      SWARM: 0
+      SYSTEM: 0
+      EVENTS: 1     # allow event streaming
+      AUTH: 0

--- a/stacks/docker-socket-proxy/compose.yaml
+++ b/stacks/docker-socket-proxy/compose.yaml
@@ -2,52 +2,69 @@
 # Exposes the Colima docker socket as TCP on the Host-VM isolated network,
 # so that AI agents running in a VM can call docker without exposing to external networks.
 #
+# ⚠️  SECURITY WARNING: Docker socket access = potential host root access.
+#     An agent with CONTAINERS+POST enabled can run a privileged container and
+#     mount the host filesystem. Enable only what you actually need.
+#
 # Setup: copy .env.example to .env and fill in your values, then:
 #   docker compose up -d
-# Or use: just pod-proxy
+# Or use: just pod-proxy  (auto-detects COLIMA_SOCKET)
 #
 # Permissions reference: https://github.com/Tecnativa/docker-socket-proxy#not-always-needed
-# Set env vars to 1 to enable each capability.
+# POST: 0 = read-only (GET/HEAD only); POST: 1 = allow writes for enabled endpoints.
 #
 services:
   docker-socket-proxy:
     image: tecnativa/docker-socket-proxy
     restart: unless-stopped
     volumes:
-      # Colima socket path — set COLIMA_SOCKET in .env or environment
-      # When using --vm-type=vz, actual path is ~/.config/colima/default/docker.sock
-      # (docker context may report ~/.colima/default/docker.sock which is wrong for vz type)
-      # Find it with: find ~/.config/colima ~/.colima -name "docker.sock" 2>/dev/null | head -1
+      # Colima socket path — set COLIMA_SOCKET in .env or via just pod-proxy (auto-detect).
+      # Note: ':ro' prevents modification of the socket file itself, but does NOT restrict
+      # Docker API write operations (docker run, docker stop, etc.) — those go over the socket.
+      # API restrictions are controlled by the environment variables below.
       - ${COLIMA_SOCKET}:/var/run/docker.sock:ro
     ports:
-      # Only listen on the Host-VM isolated network interface — never exposed externally
-      # Set DOCKER_PROXY_BIND to your Host's IP on the VM-facing network (e.g. 192.168.64.1)
-      # Find it with: /sbin/ifconfig | grep "inet 192.168"
+      # ⚠️  NEVER set DOCKER_PROXY_BIND to 0.0.0.0 — it would expose docker to all interfaces.
+      # Set to the Host IP on the isolated VM-facing network only (e.g. 192.168.64.1).
+      # Find it: /sbin/ifconfig | grep "inet 192.168"
       - "${DOCKER_PROXY_BIND}:2375:2375"
     environment:
-      # Read-only ops (safe defaults)
-      CONTAINERS: 1
+      # POST: 0 = fully read-only (GET/HEAD only, all write operations blocked)
+      # POST: 1 = allow write operations for endpoints explicitly enabled below
+      POST: 1
+
+      # ── Read operations (low risk) ──────────────────────────────────────────
+      PING: 1
+      VERSION: 1
+      INFO: 1
+      EVENTS: 1
+      CONTAINERS: 1   # list/inspect containers
       IMAGES: 1
       NETWORKS: 1
       VOLUMES: 1
-      INFO: 1
-      PING: 1
-      VERSION: 1
-      SERVICES: 1
-      TASKS: 1
-      # Write ops (enable only what agents need)
-      POST: 1       # allow POST (run containers, exec, etc.)
-      BUILD: 0      # disable build
-      COMMIT: 0     # disable commit
-      CONFIGS: 0    # disable swarm configs
-      DISTRIBUTION: 0
-      EXEC: 1       # allow exec into containers
+
+      # ── Write operations — enable only what agents actually need ────────────
+      ALLOW_START: 1      # start existing containers
+      ALLOW_STOP: 1       # stop containers
+      ALLOW_RESTARTS: 0   # restart/kill — disabled, enable if needed
+      ALLOW_PAUSE: 0      # pause/unpause — disabled
+
+      # ── Dangerous — disabled by default ────────────────────────────────────
+      # EXEC: allows running arbitrary commands inside containers (= shell access)
+      # Enable only if the agent explicitly needs exec (e.g. running scripts in containers)
+      EXEC: 0
+
+      BUILD: 0        # build images from Dockerfile
+      COMMIT: 0       # commit container state as image
+      CONFIGS: 0      # swarm configs
+      DISTRIBUTION: 0 # registry access
       GRPC: 0
       NODES: 0
       PLUGINS: 0
       SECRETS: 0
       SESSION: 0
+      SERVICES: 0
       SWARM: 0
       SYSTEM: 0
-      EVENTS: 1     # allow event streaming
+      TASKS: 0
       AUTH: 0


### PR DESCRIPTION
## Summary

Adds a `docker-socket-proxy` stack that exposes the Colima Docker socket as TCP on the isolated Host-VM network, so AI agents (e.g. OpenClaw) running in a VM can call Docker on the host — without exposing to external networks or Tailscale.

## Changes

- `stacks/docker-socket-proxy/compose.yaml`: proxy binding only to Host-VM network interface via `DOCKER_PROXY_BIND` env var
- `stacks/docker-socket-proxy/.env.example`: template with discovery commands for `COLIMA_SOCKET` and `DOCKER_PROXY_BIND`
- `stacks/docker-socket-proxy/README.md`: network topology diagram, setup guide, note on vz vs QEMU socket paths
- `dotfiles/term.just`: `pod-proxy` task that auto-detects Colima socket path (handles both `--vm-type=vz` → `~/.config/colima/` and QEMU default → `~/.colima/`)

## Security

- Port 2375 bound only to the Host-VM network interface (not external/Tailscale)
- Socket mounted read-only
- Fine-grained API permissions via tecnativa/docker-socket-proxy env vars