### PR TITLE
fix(pod-proxy): correct stacks path in just task

### DIFF
--- a/dotfiles/term.just
+++ b/dotfiles/term.just
@@ -829,7 +829,7 @@ pod-proxy CMD="up -d":
     fi
     echo "Using Colima socket: $COLIMA_SOCKET"
     echo "Binding proxy to: $DOCKER_PROXY_BIND:2375 (Host-VM network only)"
-    cd {{justfile_directory()}}/../stacks/docker-socket-proxy
+    cd {{justfile_directory()}}/stacks/docker-socket-proxy
     COLIMA_SOCKET=$COLIMA_SOCKET DOCKER_PROXY_BIND=$DOCKER_PROXY_BIND docker compose {{CMD}}
 
 # tested in lima


### PR DESCRIPTION
## Problem

`just pod-proxy` failed with:
```
cd: /Users/utensil/projects/forest/../stacks/docker-socket-proxy: No such file or directory
```

## Root Cause

In `dotfiles/term.just`, `justfile_directory()` returns the directory of the **main** `justfile` (i.e. `forest/`), not the directory of the included file (`dotfiles/`).

So `{{justfile_directory()}}/../stacks` resolved to `projects/stacks` instead of `forest/stacks`.

## Fix

Change `{{justfile_directory()}}/../stacks/docker-socket-proxy` → `{{justfile_directory()}}/stacks/docker-socket-proxy`