### PR TITLE
fix(pod-proxy): use docker-compose instead of docker compose

### DIFF
--- a/dotfiles/term.just
+++ b/dotfiles/term.just
@@ -830,7 +830,7 @@ pod-proxy CMD="up -d":
     echo "Using Colima socket: $COLIMA_SOCKET"
     echo "Binding proxy to: $DOCKER_PROXY_BIND:2375 (Host-VM network only)"
     cd {{justfile_directory()}}/stacks/docker-socket-proxy
-    COLIMA_SOCKET=$COLIMA_SOCKET DOCKER_PROXY_BIND=$DOCKER_PROXY_BIND docker compose {{CMD}}
+    COLIMA_SOCKET=$COLIMA_SOCKET DOCKER_PROXY_BIND=$DOCKER_PROXY_BIND docker-compose {{CMD}}
 
 # tested in lima
 # distrobox create --name test --init --image quay.io/toolbx-images/alpine-toolbox:latest


### PR DESCRIPTION
## Problem

`just pod-proxy` failed with:
```
docker: unknown command: docker compose
```

## Root Cause

`docker compose` (v2 plugin syntax) is not installed on host.
Only `docker-compose` (v2 standalone) is available.

## Fix

Replace `docker compose` with `docker-compose` in the `pod-proxy` task.