### PR TITLE
fix(pod-proxy): bypass ControlMaster for SSH tunnel

### DIFF
--- a/dotfiles/term.just
+++ b/dotfiles/term.just
@@ -864,16 +864,16 @@ pod-proxy CMD="start":
         fi
         # Write SSH config to a persistent path (not temp) — SSH reads it after backgrounding
         colima ssh-config > "$SSH_CONF"
-        echo "  SSH config:"
-        cat "$SSH_CONF"
-        echo "  Binding: $PROXY_BIND:2375 → Colima localhost:2375"
         # Forward Host Mac <PROXY_BIND>:2375 → Colima VM localhost:2375 (docker-socket-proxy)
-        ssh -F "$SSH_CONF" colima -N \
+        # -o ControlMaster=no: colima ssh-config sets ControlMaster=auto + ControlPersist=yes;
+        # a -N session multiplexed over the existing master exits immediately (no command = done),
+        # so port forwarding is never established. Force a standalone direct connection.
+        ssh -F "$SSH_CONF" colima -N -o ControlMaster=no \
             -L "$PROXY_BIND:2375:localhost:2375" \
             2>"$SSH_LOG" &
         SSH_PID=$!
         echo $SSH_PID > "$PID_FILE"
-        sleep 1
+        sleep 0.5
         if kill -0 $SSH_PID 2>/dev/null; then
             echo "  SSH tunnel:          started (PID: $SSH_PID) → $PROXY_BIND:2375"
         else


### PR DESCRIPTION
Fixes the SSH tunnel silently exiting immediately on start.

## Root cause

`colima ssh-config` outputs `ControlMaster auto` + `ControlPersist yes`. When `ssh -N` runs multiplexed over an existing ControlMaster connection, the session exits immediately — there is no remote command, so the mux channel closes right away. Port forwarding is never established.

## Fix

Add `-o ControlMaster=no` to force a standalone direct SSH connection for the tunnel, bypassing the mux entirely.

## Also

Removes the debug SSH config dump added in #25 (root cause now known). Retains SSH stderr capture to log file for future error reporting.