### PR TITLE
feat(sstore): add secure SFTP storage stack for Kopia backend

### DIFF
--- a/stacks/sstore/.env.in
+++ b/stacks/sstore/.env.in
@@ -1,0 +1,36 @@
+# sstore — secure SFTP storage endpoint
+# Used as the SFTP backend for Kopia backup repositories
+# Copy to .env and fill in values
+
+# Host path to the storage directory (NAS mount or external disk)
+# This is mounted read-write into the container at /storage
+STORAGE_PATH=/path/to/external/storage
+
+# Listen address and port for the SFTP service
+#
+# SSTORE_LISTEN_ADDR controls which network interface Docker binds the port to.
+#
+#   127.0.0.1   — loopback only; NOTE: VMs on the same host cannot reach this —
+#                 if Kopia runs inside a VM, set this to the host-VM bridge IP instead
+#   <bridge IP> — host-VM bridge interface; reachable from VM, not from LAN
+#   <LAN IP>    — accessible from LAN; only if a firewall restricts further
+#   0.0.0.0     — all interfaces including LAN; do NOT use without a firewall
+#
+SSTORE_LISTEN_ADDR=127.0.0.1
+SSTORE_PORT=2222
+
+# Container user (should match the UID/GID of the storage directory owner)
+SSTORE_PUID=1000
+SSTORE_PGID=1000
+
+# SFTP username Kopia will connect as
+SSTORE_USER=kopia
+
+# Timezone
+TZ=UTC
+
+# Authorized SSH public keys (one per line, one per Kopia instance)
+# Generate a dedicated keypair on each host: ssh-keygen -t ed25519 -C "kopia-<hostname>"
+# Add the public key here; keep the private key on the host at ~/.kopia/sftp_id
+SSH_PUBKEYS="ssh-ed25519 AAAA... kopia-host-1
+ssh-ed25519 AAAA... kopia-host-2"

--- a/stacks/sstore/README.md
+++ b/stacks/sstore/README.md
@@ -1,0 +1,74 @@
+# sstore — Secure SFTP Storage
+
+A lightweight SFTP endpoint used as the storage backend for [Kopia](../kopia/) backup repositories.
+
+Deploy one instance wherever storage lives:
+- On a NAS (primary repository storage)
+- On a host's external disk (replica storage)
+
+Kopia connects to this container over SFTP using a dedicated keypair — no password auth, no internet exposure.
+
+## Setup
+
+1. Copy `.env.in` to `.env` and fill in values:
+
+    ```sh
+    cp .env.in .env
+    # Edit .env: set STORAGE_PATH, SSTORE_PORT, SSTORE_PUID/PGID, SSH_PUBKEYS
+    ```
+
+2. `STORAGE_PATH` should be the host path to the storage directory (NAS mount or external disk).
+   The container mounts it at `/storage`.
+
+3. `SSH_PUBKEYS` should contain one public key per line — one for each Kopia instance that needs access.
+   (`SSH_PUBKEYS` is the `.env` variable; it maps to `PUBLIC_KEY_MULTI_LINE` inside the container, which is the linuxserver image's native variable name.)
+   Generate a dedicated keypair on each Kopia host (do not reuse regular SSH keys):
+
+    ```sh
+    ssh-keygen -t ed25519 -C "kopia-<hostname>" -f ~/.kopia/sftp_id
+    # Add the contents of ~/.kopia/sftp_id.pub to SSH_PUBKEYS in .env
+    ```
+
+    ```
+    SSH_PUBKEYS="ssh-ed25519 AAAA... kopia-host-1
+    ssh-ed25519 AAAA... kopia-host-2"
+    ```
+
+4. `SSTORE_PUID`/`SSTORE_PGID` should match the owner of the files under `STORAGE_PATH`
+   so files created by Kopia are owned correctly on the host.
+
+5. Start:
+
+    ```sh
+    docker compose up -d
+    ```
+
+6. Verify connectivity from the Kopia host:
+
+    ```sh
+    ssh -p ${SSTORE_PORT} -i ~/.kopia/sftp_id ${SSTORE_USER}@<SSTORE_LISTEN_ADDR> ls /storage
+    ```
+
+## Kopia SFTP backend URL
+
+When connecting Kopia to this storage:
+
+```sh
+kopia repository create sftp \
+  --host=<host> --port=<SSTORE_PORT> \
+  --username=<SSTORE_USER> --keyfile=~/.kopia/sftp_id \
+  --path=/storage --known-hosts-file=/dev/null
+```
+
+## Security notes
+
+- `SSTORE_LISTEN_ADDR` controls which interface the port is bound to. `127.0.0.1` (loopback) is the default, but note that VMs on the same host **cannot** reach a loopback-bound port — if Kopia runs inside a VM, set this to the host-VM bridge IP for your environment. Never use `0.0.0.0` without a firewall.
+- `PASSWORD_ACCESS=false` and `SUDO_ACCESS=false` are hardcoded; the container user has no shell or sudo rights.
+- The private key (`~/.kopia/sftp_id`) never leaves the Kopia host. The container only holds public keys.
+- Each Kopia host should generate its own dedicated keypair. Regular SSH keys should not be reused here.
+
+## References
+
+- [linuxserver/openssh-server](https://docs.linuxserver.io/images/docker-openssh-server/)
+- [Kopia SFTP repository](https://kopia.io/docs/repositories/#sftp)
+- [Kopia stack](../kopia/)

--- a/stacks/sstore/compose.yaml
+++ b/stacks/sstore/compose.yaml
@@ -1,0 +1,27 @@
+services:
+  sstore:
+    image: lscr.io/linuxserver/openssh-server:latest
+    container_name: sstore
+    restart: unless-stopped
+    environment:
+      - PUID=${SSTORE_PUID:-1000}
+      - PGID=${SSTORE_PGID:-1000}
+      - TZ=${TZ:-UTC}
+      - PUBLIC_KEY_MULTI_LINE=${SSH_PUBKEYS}  # linuxserver native var; value comes from SSH_PUBKEYS in .env
+      - USER_NAME=${SSTORE_USER:-kopia}
+      - PASSWORD_ACCESS=false
+      - SUDO_ACCESS=false
+      - LOG_STDOUT=true
+    ports:
+      - "${SSTORE_LISTEN_ADDR:-127.0.0.1}:${SSTORE_PORT:-2222}:2222"
+    volumes:
+      - ${STORAGE_PATH}:/storage
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+    cap_add:
+      - SETUID
+      - SETGID
+      - CHOWN
+      - DAC_OVERRIDE


### PR DESCRIPTION
## Summary

Adds `stacks/sstore/` — a lightweight SFTP endpoint used as the storage backend for Kopia backup repositories.

## Why

Kopia's SFTP backend needs an SSH endpoint to store repository data. This stack provides an isolated, purpose-built SFTP container:
- Storage directory is isolated — container only sees the backup path, nothing else
- Auth is SSH key only, no passwords, no shell, no sudo
- Avoids OS-level SMB/NFS mount instability on macOS

## Design decisions

- **No key injection via env vars** — authorized keys are added directly via `docker exec` after the container is up. This keeps the compose file free of any sensitive data and avoids multiline env var issues.
- **`STORAGE_PATH`** — host path injected via `.env`, mounted as `/storage` inside the container
- **`SSTORE_LISTEN_ADDR`** — controls which interface the port binds to; defaults to `127.0.0.1` with an explicit warning that VMs need the host-VM bridge IP
- **`SSTORE_PUID`/`SSTORE_PGID`** — match storage directory owner for correct file ownership
- `PASSWORD_ACCESS=false`, `SUDO_ACCESS=false` hardcoded
- `no-new-privileges` + `cap_drop`/`cap_add` for container hardening

## Adding authorized keys

After the container is running, add one key per Kopia host:

```sh
docker exec sstore sh -c 'echo "ssh-ed25519 AAAA... kopia-hostname" >> /config/.ssh/authorized_keys'
```

## Files

```
stacks/sstore/
  compose.yaml    SFTP container service
  .env.in         Example env with all variables
  README.md       Setup guide, key management, security notes
```

## Related

- `stacks/kopia/` — Kopia Docker stack (unchanged)