### PR TITLE
fix(sstore): remove env-based key injection, use docker exec instead

### DIFF
--- a/stacks/sstore/.env.in
+++ b/stacks/sstore/.env.in
@@ -28,9 +28,3 @@ SSTORE_USER=kopia
 
 # Timezone
 TZ=UTC
-
-# Authorized SSH public keys (one per line, one per Kopia instance)
-# Generate a dedicated keypair on each host: ssh-keygen -t ed25519 -C "kopia-<hostname>"
-# Add the public key here; keep the private key on the host at ~/.kopia/sftp_id
-SSH_PUBKEYS="ssh-ed25519 AAAA... kopia-host-1
-ssh-ed25519 AAAA... kopia-host-2"

--- a/stacks/sstore/README.md
+++ b/stacks/sstore/README.md
@@ -14,25 +14,16 @@ Kopia connects to this container over SFTP using a dedicated keypair — no pass
 
     ```sh
     cp .env.in .env
-    # Edit .env: set STORAGE_PATH, SSTORE_PORT, SSTORE_PUID/PGID, SSH_PUBKEYS
+    # Edit .env: set STORAGE_PATH, SSTORE_LISTEN_ADDR, SSTORE_PORT, SSTORE_PUID/PGID
     ```
 
 2. `STORAGE_PATH` should be the host path to the storage directory (NAS mount or external disk).
    The container mounts it at `/storage`.
 
-3. `SSH_PUBKEYS` should contain one public key per line — one for each Kopia instance that needs access.
-   (`SSH_PUBKEYS` is the `.env` variable; it maps to `PUBLIC_KEY_MULTI_LINE` inside the container, which is the linuxserver image's native variable name.)
-   Generate a dedicated keypair on each Kopia host (do not reuse regular SSH keys):
-
-    ```sh
-    ssh-keygen -t ed25519 -C "kopia-<hostname>" -f ~/.kopia/sftp_id
-    # Add the contents of ~/.kopia/sftp_id.pub to SSH_PUBKEYS in .env
-    ```
-
-    ```
-    SSH_PUBKEYS="ssh-ed25519 AAAA... kopia-host-1
-    ssh-ed25519 AAAA... kopia-host-2"
-    ```
+3. `SSTORE_LISTEN_ADDR` controls which interface the port is bound to. `127.0.0.1` (loopback) is
+   the default, but note that VMs on the same host **cannot** reach a loopback-bound port — if Kopia
+   runs inside a VM, set this to the host-VM bridge IP for your environment. Never use `0.0.0.0`
+   without a firewall.
 
 4. `SSTORE_PUID`/`SSTORE_PGID` should match the owner of the files under `STORAGE_PATH`
    so files created by Kopia are owned correctly on the host.
@@ -43,13 +34,29 @@ Kopia connects to this container over SFTP using a dedicated keypair — no pass
     docker compose up -d
     ```
 
-6. Verify connectivity from the Kopia host:
+6. Add authorized public keys for each Kopia host that needs access.
+   Run this on the Docker host after the container is up:
+
+    ```sh
+    # Add one key at a time (repeat for each Kopia host)
+    docker exec sstore sh -c 'echo "ssh-ed25519 AAAA... kopia-hostname" >> /config/.ssh/authorized_keys'
+    ```
+
+   Keys persist inside the container at `/config/.ssh/authorized_keys` across restarts.
+   Each Kopia host should generate a dedicated keypair (not a regular SSH key):
+
+    ```sh
+    ssh-keygen -t ed25519 -C "kopia-<hostname>" -f ~/.kopia/sftp_id
+    # Add the contents of ~/.kopia/sftp_id.pub using the docker exec command above
+    ```
+
+7. Verify connectivity from the Kopia host:
 
     ```sh
     ssh -p ${SSTORE_PORT} -i ~/.kopia/sftp_id ${SSTORE_USER}@<SSTORE_LISTEN_ADDR> ls /storage
     ```
 
-## Kopia SFTP backend URL
+## Kopia SFTP backend
 
 When connecting Kopia to this storage:
 
@@ -62,10 +69,16 @@ kopia repository create sftp \
 
 ## Security notes
 
-- `SSTORE_LISTEN_ADDR` controls which interface the port is bound to. `127.0.0.1` (loopback) is the default, but note that VMs on the same host **cannot** reach a loopback-bound port — if Kopia runs inside a VM, set this to the host-VM bridge IP for your environment. Never use `0.0.0.0` without a firewall.
-- `PASSWORD_ACCESS=false` and `SUDO_ACCESS=false` are hardcoded; the container user has no shell or sudo rights.
-- The private key (`~/.kopia/sftp_id`) never leaves the Kopia host. The container only holds public keys.
-- Each Kopia host should generate its own dedicated keypair. Regular SSH keys should not be reused here.
+- `SSTORE_LISTEN_ADDR` controls which interface the port is bound to. `127.0.0.1` (loopback) is the
+  default, but VMs on the same host **cannot** reach it — set to the host-VM bridge IP when needed.
+  Never use `0.0.0.0` without a firewall.
+- `PASSWORD_ACCESS=false` and `SUDO_ACCESS=false` are hardcoded; the container user has no shell or
+  sudo rights.
+- The private key (`~/.kopia/sftp_id`) never leaves the Kopia host. The container only holds public
+  keys in `/config/.ssh/authorized_keys`.
+- Each Kopia host should generate its own dedicated keypair. Regular SSH keys should not be reused.
+- Public keys are added via `docker exec` on the host — no injection via environment variables,
+  keeping the compose file free of any sensitive data.
 
 ## References
 

--- a/stacks/sstore/compose.yaml
+++ b/stacks/sstore/compose.yaml
@@ -7,7 +7,6 @@ services:
       - PUID=${SSTORE_PUID:-1000}
       - PGID=${SSTORE_PGID:-1000}
       - TZ=${TZ:-UTC}
-      - PUBLIC_KEY_MULTI_LINE=${SSH_PUBKEYS}  # linuxserver native var; value comes from SSH_PUBKEYS in .env
       - USER_NAME=${SSTORE_USER:-kopia}
       - PASSWORD_ACCESS=false
       - SUDO_ACCESS=false


### PR DESCRIPTION
## Problem

The `PUBLIC_KEY_MULTI_LINE` env var approach in the initial PR did not work reliably — multiline values in `.env` files are not supported by Docker Compose, and the linuxserver image silently wrote nothing to `authorized_keys`.

## Fix

Remove all env-based key injection. Authorized keys are added directly via `docker exec` on the host after the container is up:

```sh
docker exec sstore sh -c 'echo "ssh-ed25519 AAAA... kopia-hostname" >> /config/.ssh/authorized_keys'
```

This is simpler, always works, and keeps the compose file free of any sensitive data.

## Changes

- `compose.yaml`: remove `PUBLIC_KEY_MULTI_LINE` env var
- `.env.in`: remove `SSH_PUBKEYS` variable
- `README.md`: replace key injection instructions with `docker exec` approach