### PR TITLE
fix(sstore): chown /storage on startup via custom-cont-init.d

### DIFF
--- a/stacks/sstore/compose.yaml
+++ b/stacks/sstore/compose.yaml
@@ -16,6 +16,7 @@ services:
       - "${SSTORE_LISTEN_ADDR:-127.0.0.1}:${SSTORE_PORT:-2222}:2222"
     volumes:
       - ${STORAGE_PATH}:/storage
+      - ./custom-cont-init.d:/custom-cont-init.d:ro
     security_opt:
       - no-new-privileges:true
     cap_drop:

--- a/stacks/sstore/custom-cont-init.d/01-fix-storage.sh
+++ b/stacks/sstore/custom-cont-init.d/01-fix-storage.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+# Fix /storage ownership on every container start.
+# Needed when the storage backend (e.g. exFAT disk) resets ownership on remount.
+chown "${PUID}:${PGID}" /storage


### PR DESCRIPTION
## Problem

Storage backends like exFAT reset directory ownership on every remount.
This caused SFTP writes to fail with `permission denied` even when
`SSTORE_PUID`/`SSTORE_PGID` were set correctly.

## Fix

Add `custom-cont-init.d/01-fix-storage.sh` — linuxserver images run
scripts in this directory on every container start:

```sh
chown "${PUID}:${PGID}" /storage
```

The script runs before sshd starts, so the directory is always writable
by the time Kopia connects.

## Changes

- `compose.yaml`: mount `./custom-cont-init.d` read-only
- `custom-cont-init.d/01-fix-storage.sh`: new init script