### PR TITLE
fix(sstore): persist /config via volume mount for authorized_keys and host keys

### DIFF
--- a/stacks/sstore/.env.in
+++ b/stacks/sstore/.env.in
@@ -26,5 +26,10 @@ SSTORE_PGID=1000
 # SFTP username Kopia will connect as
 SSTORE_USER=kopia
 
+# Directory for persistent container config (authorized_keys, SSH host keys).
+# Defaults to ./config (alongside this .env file) if not set.
+# This directory is git-ignored — do not commit it.
+# SSTORE_CONFIG_PATH=./config
+
 # Timezone
 TZ=UTC

--- a/stacks/sstore/.gitignore
+++ b/stacks/sstore/.gitignore
@@ -1,0 +1,5 @@
+# Persistent container config — contains authorized_keys and SSH host keys
+config/
+
+# Local environment overrides
+.env

--- a/stacks/sstore/README.md
+++ b/stacks/sstore/README.md
@@ -34,7 +34,17 @@ Kopia connects to this container over SFTP using a dedicated keypair — no pass
     docker compose up -d
     ```
 
-6. Add authorized public keys for each Kopia host that needs access.
+6. Create the persistent config directory (alongside your `.env`):
+
+    ```sh
+    mkdir -p config
+    ```
+
+   This directory is git-ignored and will hold `authorized_keys` and SSH host keys
+   across container restarts. The default path is `./config` (relative to `compose.yaml`).
+   Override with `SSTORE_CONFIG_PATH` in `.env` if needed.
+
+7. Add authorized public keys for each Kopia host that needs access.
    Run this on the Docker host after the container is up:
 
     ```sh
@@ -42,13 +52,16 @@ Kopia connects to this container over SFTP using a dedicated keypair — no pass
     docker exec sstore sh -c 'echo "ssh-ed25519 AAAA... kopia-hostname" >> /config/.ssh/authorized_keys'
     ```
 
-   Keys persist inside the container at `/config/.ssh/authorized_keys` across restarts.
+   Keys now persist across restarts via the mounted `config/` directory.
    Each Kopia host should generate a dedicated keypair (not a regular SSH key):
 
     ```sh
     ssh-keygen -t ed25519 -C "kopia-<hostname>" -f ~/.kopia/sftp_id
     # Add the contents of ~/.kopia/sftp_id.pub using the docker exec command above
     ```
+
+   Side benefit: SSH host keys also persist, so Kopia won't see
+   "REMOTE HOST IDENTIFICATION CHANGED" warnings after container restarts.
 
 7. Verify connectivity from the Kopia host:
 

--- a/stacks/sstore/compose.yaml
+++ b/stacks/sstore/compose.yaml
@@ -15,6 +15,7 @@ services:
       - "${SSTORE_LISTEN_ADDR:-127.0.0.1}:${SSTORE_PORT:-2222}:2222"
     volumes:
       - ${STORAGE_PATH}:/storage
+      - ${SSTORE_CONFIG_PATH:-./config}:/config
       - ./custom-cont-init.d:/custom-cont-init.d:ro
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
## Problem

Without a persistent `/config` volume, two things are lost on every container restart:
1. `/config/.ssh/authorized_keys` — requires manual re-injection after every restart
2. SSH host keys — causes `REMOTE HOST IDENTIFICATION CHANGED` warnings in Kopia

## Fix

Mount `./config` (alongside `.env`, git-ignored) as `/config` inside the container.

Default path: `./config` (relative to `compose.yaml`).
Override via `SSTORE_CONFIG_PATH` in `.env`.

## Changes

- `compose.yaml`: add `${SSTORE_CONFIG_PATH:-./config}:/config` volume
- `.env.in`: document `SSTORE_CONFIG_PATH` variable
- `.gitignore`: git-ignore `config/` and `.env`
- `README.md`: add `mkdir -p config` setup step; note host key persistence benefit

## Usage

```sh
# One-time setup (alongside .env)
mkdir -p config

# Start container
docker-compose up -d

# Add keys once — persists across restarts
docker exec sstore sh -c 'echo "ssh-ed25519 AAAA..." >> /config/.ssh/authorized_keys'
```