### PR TITLE
feat: add Mattermost stack with PostgreSQL streaming replication

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,8 @@ ALWAYS follow this `jj` commit workflow:
 - Before committing:
     - use `jj` (which combines `jj status` and `jj log` in a customized way) to learn about status and recent revisions
         - so it's clear which revision to commit, and won't commit an empty or unrelated revision
-        - fallback to use `jj log --no-graph -T '{commit_id} {description}' -n <N>` to view the last N revisions in a concise format
+        - fallback to use `jj log --no-graph -T 'commit_id.short(7) ++ " | " ++ author.email().local() ++ " | " ++ description.first_line()' -n <N>` to view the last N revisions in a concise format
+    - **jj Template Syntax**: Use the `++` operator to concatenate fields. Common fields: `commit_id.short(N)`, `description.first_line()`, `author.email().local()`, `local_bookmarks()`, `empty()`. See [jj templates documentation](https://jj-vcs.github.io/jj/latest/templates/) for the complete field reference.
     - run `jj diff` or `jj diff -r <rev>` to review all changes in the working copy or the revision to commit.
 - During committing:
     - **Granular commits**: One logical change per commit.

--- a/stacks/mattermost/.env.example
+++ b/stacks/mattermost/.env.example
@@ -33,8 +33,8 @@ MATTERMOST_IMAGE=mattermost-team-edition
 MATTERMOST_IMAGE_TAG=10.11.8
 
 # Site URL — set to the Tailscale URL of the VM that reverse-proxies this host
-# e.g. http://100.111.158.20:8065  (mimi)
-#      http://100.68.246.64:8065   (clawlet)
+# e.g. http://<NODE_A_TAILSCALE_IP>:8065
+#      http://<NODE_B_TAILSCALE_IP>:8065
 MM_SERVICESETTINGS_SITEURL=http://localhost:8065
 
 # Port exposed on the host

--- a/stacks/mattermost/.env.example
+++ b/stacks/mattermost/.env.example
@@ -1,0 +1,50 @@
+# Mattermost Stack — environment variables
+# Copy to .env and fill in values before running docker compose up.
+
+# ── General ──────────────────────────────────────────────────────────────────
+TZ=Asia/Singapore
+RESTART_POLICY=unless-stopped
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+POSTGRES_IMAGE_TAG=17-alpine
+
+# Host path for persistent data (create before first run)
+POSTGRES_DATA_PATH=./volumes/db/var/lib/postgresql/data
+
+# Credentials — change before first start; cannot be changed after DB is created
+POSTGRES_USER=mmuser
+POSTGRES_PASSWORD=change_me_strong_password
+POSTGRES_DB=mattermost
+
+# Port exposed to the host (also used by streaming replication tunnel)
+# Primary:  5432 (default)
+# Standby:  5432 (same, local access only; replication connects via SSH tunnel)
+POSTGRES_PORT=5432
+
+# Role: "primary" or "standby"
+# Controls whether pg_hba.conf allows replication connections.
+# Mattermost connects to the local PG regardless of role;
+# a standby PG will reject writes from Mattermost automatically.
+POSTGRES_ROLE=primary
+
+# ── Mattermost ────────────────────────────────────────────────────────────────
+# Team Edition is free and open source; use mattermost-enterprise-edition for E0/E10/E20
+MATTERMOST_IMAGE=mattermost-team-edition
+MATTERMOST_IMAGE_TAG=10.11.8
+
+# Site URL — set to the Tailscale URL of the VM that reverse-proxies this host
+# e.g. http://100.111.158.20:8065  (mimi)
+#      http://100.68.246.64:8065   (clawlet)
+MM_SERVICESETTINGS_SITEURL=http://localhost:8065
+
+# Port exposed on the host
+APP_PORT=8065
+CALLS_PORT=8443
+
+# Host paths for Mattermost persistent data (create before first run)
+MATTERMOST_CONFIG_PATH=./volumes/app/mattermost/config
+MATTERMOST_DATA_PATH=./volumes/app/mattermost/data
+MATTERMOST_LOGS_PATH=./volumes/app/mattermost/logs
+MATTERMOST_PLUGINS_PATH=./volumes/app/mattermost/plugins
+MATTERMOST_CLIENT_PLUGINS_PATH=./volumes/app/mattermost/client/plugins
+MATTERMOST_BLEVE_INDEXES_PATH=./volumes/app/mattermost/bleve-indexes

--- a/stacks/mattermost/README.md
+++ b/stacks/mattermost/README.md
@@ -1,0 +1,184 @@
+# Mattermost Stack
+
+Self-hosted Mattermost (Team Edition) with PostgreSQL, designed for a two-node
+primary/standby setup across macOS hosts (mimi + clawlet) running Colima Docker.
+
+## Architecture
+
+```
+Tailscale (phone / laptop)
+        |
+        | :8065  (via Tailscale IP of the VM)
+        ▼
+macOS VM  ──nginx reverse proxy──▶  192.168.64.1:8065
+                                            |
+                                     macOS HOST (Colima)
+                                      ┌────────────────┐
+                                      │  mattermost    │
+                                      │  postgres:5432 │
+                                      └────────────────┘
+
+Two hosts: mimi (primary) and clawlet (standby).
+PostgreSQL streaming replication is tunnelled over SSH between the two VMs.
+```
+
+## Steps
+
+### Step 1 — mimi host: first run
+
+```bash
+# On mimi macOS HOST (Colima must be running)
+cd ~/projects/forest/stacks/mattermost
+cp .env.example .env
+# Edit .env: set POSTGRES_PASSWORD, POSTGRES_REPLICATION_PASSWORD, MM_SERVICESETTINGS_SITEURL
+
+# Create volume directories
+mkdir -p volumes/db/var/lib/postgresql/data
+mkdir -p volumes/app/mattermost/{config,data,logs,plugins,client/plugins,bleve-indexes}
+
+# Fix permissions (Mattermost runs as uid 2000 inside container)
+sudo chown -R 2000:2000 volumes/app/mattermost
+
+docker compose up -d
+docker compose logs -f
+```
+
+Open `http://192.168.64.1:8065` from the mimi macOS VM to complete the Setup Wizard.
+
+### Step 2 — mimi VM: nginx reverse proxy for Tailscale access
+
+Install nginx on the mimi macOS VM and proxy Tailscale IP → HOST bridge:
+
+```nginx
+# /etc/nginx/conf.d/mattermost.conf  (or Homebrew nginx equivalent)
+server {
+    listen <MIMI_TAILSCALE_IP>:8065;
+    location / {
+        proxy_pass http://192.168.64.1:8065;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 600s;
+    }
+}
+```
+
+Access from phone/laptop: `http://<MIMI_TAILSCALE_IP>:8065`
+
+### Step 3 — clawlet host: second node
+
+Same as Step 1 on clawlet's HOST, but set `POSTGRES_ROLE=standby` in `.env`
+and use the clawlet Tailscale IP in `MM_SERVICESETTINGS_SITEURL`.
+
+> **Note:** On the standby node, start only postgres first (comment out the
+> mattermost service). PostgreSQL streaming replication must be set up before
+> starting Mattermost on the standby.
+
+### Step 4 — Set up PostgreSQL streaming replication
+
+#### On mimi VM: open a reverse SSH tunnel so clawlet can reach mimi's PG
+
+```bash
+# Run on mimi macOS VM (keep alive, or add to launchd)
+ssh -N -R 0.0.0.0:5433:192.168.64.1:5432 lume@<CLAWLET_TAILSCALE_IP> \
+  -o ServerAliveInterval=10 -o ExitOnForwardFailure=yes
+```
+
+This exposes mimi's PG as `localhost:5433` on clawlet VM (and its HOST via bridge).
+
+#### On clawlet HOST: base backup from mimi
+
+```bash
+# Inside clawlet's postgres container (or via docker exec)
+docker exec -it mattermost-postgres bash
+
+# Stop postgres, wipe data, take base backup from mimi primary
+pg_ctl stop -D "$PGDATA"
+rm -rf "$PGDATA"/*
+
+PGPASSWORD=<POSTGRES_REPLICATION_PASSWORD> \
+  pg_basebackup -h 192.168.64.1 -p 5433 -U replicator \
+    -D "$PGDATA" -Fp -Xs -P -R
+# -R writes standby.signal + primary_conninfo automatically
+
+pg_ctl start -D "$PGDATA"
+```
+
+Verify replication:
+```sql
+-- On mimi primary
+SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn
+FROM pg_stat_replication;
+```
+
+### Step 5 — Failover & pg_rewind
+
+#### Promote clawlet standby to primary
+
+```bash
+docker exec mattermost-postgres pg_ctl promote -D "$PGDATA"
+```
+
+Then update `.env` on clawlet: `POSTGRES_ROLE=primary` and restart Mattermost.
+
+#### Rejoin old primary (mimi) as new standby using pg_rewind
+
+```bash
+# On mimi HOST, after clawlet is new primary:
+docker exec -it mattermost-postgres bash
+
+pg_ctl stop -D "$PGDATA"
+PGPASSWORD=<POSTGRES_REPLICATION_PASSWORD> \
+  pg_rewind \
+    --target-pgdata="$PGDATA" \
+    --source-server="host=192.168.64.1 port=5433 user=replicator dbname=postgres" \
+    -P
+
+# Write standby.signal and update primary_conninfo
+touch "$PGDATA/standby.signal"
+cat >> "$PGDATA/postgresql.conf" <<EOF
+primary_conninfo = 'host=192.168.64.1 port=5433 user=replicator password=<REPL_PW>'
+EOF
+
+pg_ctl start -D "$PGDATA"
+```
+
+## Ports
+
+| Service    | Container port | Host port (configurable) |
+|------------|---------------|--------------------------|
+| Mattermost | 8065          | `APP_PORT` (default 8065)|
+| Mattermost calls | 8443   | `CALLS_PORT` (default 8443)|
+| PostgreSQL | 5432          | `POSTGRES_PORT` (default 5432)|
+
+## OpenClaw Integration
+
+After Mattermost is running, install the OpenClaw plugin and configure each bot:
+
+```bash
+openclaw plugins install @openclaw/mattermost
+```
+
+Add to `~/.openclaw/openclaw.json`:
+```json5
+{
+  channels: {
+    mattermost: {
+      enabled: true,
+      botToken: "<bot-token>",
+      baseUrl: "http://<VM_TAILSCALE_IP>:8065",
+      chatmode: "oncall",
+    }
+  }
+}
+```
+
+## Security notes
+
+- PostgreSQL port (`5432`) is bound to `0.0.0.0` inside Colima but only reachable
+  from the macOS HOST via the bridge (`192.168.64.1`). Use `pf` if you want to
+  restrict it further (see kopia sstore lesson).
+- Mattermost port (`8065`) is similarly only accessible via bridge from the VM;
+  the VM's nginx reverse proxy controls Tailscale exposure.
+- Change all default passwords in `.env` before first run.

--- a/stacks/mattermost/README.md
+++ b/stacks/mattermost/README.md
@@ -10,7 +10,7 @@ Tailscale (phone / laptop)
         |
         | :8065  (via Tailscale IP of the VM)
         ▼
-macOS VM  ──nginx reverse proxy──▶  192.168.64.1:8065
+macOS VM  ──nginx reverse proxy──▶  <HOST_BRIDGE_IP>:8065
                                             |
                                      macOS HOST (Colima)
                                       ┌────────────────┐
@@ -43,7 +43,7 @@ docker compose up -d
 docker compose logs -f
 ```
 
-Open `http://192.168.64.1:8065` from the macOS VM to complete the Setup Wizard.
+Open `http://<HOST_BRIDGE_IP>:8065` from the macOS VM to complete the Setup Wizard.
 
 ### Step 2 — node-a VM: nginx reverse proxy for Tailscale access
 
@@ -54,7 +54,7 @@ Install nginx on the macOS VM and proxy Tailscale IP → HOST bridge:
 server {
     listen <NODE_A_TAILSCALE_IP>:8065;
     location / {
-        proxy_pass http://192.168.64.1:8065;
+        proxy_pass http://<HOST_BRIDGE_IP>:8065;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";
@@ -81,7 +81,7 @@ and use the node-b Tailscale IP in `MM_SERVICESETTINGS_SITEURL`.
 
 ```bash
 # Run on node-a macOS VM (keep alive, or add to launchd)
-ssh -N -R 0.0.0.0:5433:192.168.64.1:5432 lume@<NODE_B_TAILSCALE_IP> \
+ssh -N -R 0.0.0.0:5433:<HOST_BRIDGE_IP>:5432 <USER>@<NODE_B_TAILSCALE_IP> \
   -o ServerAliveInterval=10 -o ExitOnForwardFailure=yes
 ```
 
@@ -98,7 +98,7 @@ pg_ctl stop -D "$PGDATA"
 rm -rf "$PGDATA"/*
 
 PGPASSWORD=<POSTGRES_REPLICATION_PASSWORD> \
-  pg_basebackup -h 192.168.64.1 -p 5433 -U replicator \
+  pg_basebackup -h <HOST_BRIDGE_IP> -p 5433 -U replicator \
     -D "$PGDATA" -Fp -Xs -P -R
 # -R writes standby.signal + primary_conninfo automatically
 
@@ -132,13 +132,13 @@ pg_ctl stop -D "$PGDATA"
 PGPASSWORD=<POSTGRES_REPLICATION_PASSWORD> \
   pg_rewind \
     --target-pgdata="$PGDATA" \
-    --source-server="host=192.168.64.1 port=5433 user=replicator dbname=postgres" \
+    --source-server="host=<HOST_BRIDGE_IP> port=5433 user=replicator dbname=postgres" \
     -P
 
 # Write standby.signal and update primary_conninfo
 touch "$PGDATA/standby.signal"
 cat >> "$PGDATA/postgresql.conf" <<EOF
-primary_conninfo = 'host=192.168.64.1 port=5433 user=replicator password=<REPL_PW>'
+primary_conninfo = 'host=<HOST_BRIDGE_IP> port=5433 user=replicator password=<REPL_PW>'
 EOF
 
 pg_ctl start -D "$PGDATA"
@@ -177,7 +177,7 @@ Add to `~/.openclaw/openclaw.json`:
 ## Security notes
 
 - PostgreSQL port (`5432`) is bound to `0.0.0.0` inside Colima but only reachable
-  from the macOS HOST via the bridge (`192.168.64.1`). Use `pf` if you want to
+  from the macOS HOST via the bridge (`<HOST_BRIDGE_IP>`). Use `pf` if you want to
   restrict it further (see kopia sstore lesson).
 - Mattermost port (`8065`) is similarly only accessible via bridge from the VM;
   the VM's nginx reverse proxy controls Tailscale exposure.

--- a/stacks/mattermost/README.md
+++ b/stacks/mattermost/README.md
@@ -1,7 +1,7 @@
 # Mattermost Stack
 
 Self-hosted Mattermost (Team Edition) with PostgreSQL, designed for a two-node
-primary/standby setup across macOS hosts (mimi + clawlet) running Colima Docker.
+primary/standby setup across two macOS hosts running Colima Docker.
 
 ## Architecture
 
@@ -18,16 +18,16 @@ macOS VM  ──nginx reverse proxy──▶  192.168.64.1:8065
                                       │  postgres:5432 │
                                       └────────────────┘
 
-Two hosts: mimi (primary) and clawlet (standby).
+Two hosts: node-a (primary) and node-b (standby).
 PostgreSQL streaming replication is tunnelled over SSH between the two VMs.
 ```
 
 ## Steps
 
-### Step 1 — mimi host: first run
+### Step 1 — node-a host: first run
 
 ```bash
-# On mimi macOS HOST (Colima must be running)
+# On the primary macOS HOST (Colima must be running)
 cd ~/projects/forest/stacks/mattermost
 cp .env.example .env
 # Edit .env: set POSTGRES_PASSWORD, POSTGRES_REPLICATION_PASSWORD, MM_SERVICESETTINGS_SITEURL
@@ -43,16 +43,16 @@ docker compose up -d
 docker compose logs -f
 ```
 
-Open `http://192.168.64.1:8065` from the mimi macOS VM to complete the Setup Wizard.
+Open `http://192.168.64.1:8065` from the macOS VM to complete the Setup Wizard.
 
-### Step 2 — mimi VM: nginx reverse proxy for Tailscale access
+### Step 2 — node-a VM: nginx reverse proxy for Tailscale access
 
-Install nginx on the mimi macOS VM and proxy Tailscale IP → HOST bridge:
+Install nginx on the macOS VM and proxy Tailscale IP → HOST bridge:
 
 ```nginx
 # /etc/nginx/conf.d/mattermost.conf  (or Homebrew nginx equivalent)
 server {
-    listen <MIMI_TAILSCALE_IP>:8065;
+    listen <NODE_A_TAILSCALE_IP>:8065;
     location / {
         proxy_pass http://192.168.64.1:8065;
         proxy_http_version 1.1;
@@ -64,12 +64,12 @@ server {
 }
 ```
 
-Access from phone/laptop: `http://<MIMI_TAILSCALE_IP>:8065`
+Access from phone/laptop: `http://<NODE_A_TAILSCALE_IP>:8065`
 
-### Step 3 — clawlet host: second node
+### Step 3 — node-b host: second node
 
-Same as Step 1 on clawlet's HOST, but set `POSTGRES_ROLE=standby` in `.env`
-and use the clawlet Tailscale IP in `MM_SERVICESETTINGS_SITEURL`.
+Same as Step 1 on the standby HOST, but set `POSTGRES_ROLE=standby` in `.env`
+and use the node-b Tailscale IP in `MM_SERVICESETTINGS_SITEURL`.
 
 > **Note:** On the standby node, start only postgres first (comment out the
 > mattermost service). PostgreSQL streaming replication must be set up before
@@ -77,23 +77,23 @@ and use the clawlet Tailscale IP in `MM_SERVICESETTINGS_SITEURL`.
 
 ### Step 4 — Set up PostgreSQL streaming replication
 
-#### On mimi VM: open a reverse SSH tunnel so clawlet can reach mimi's PG
+#### On node-a VM: open a reverse SSH tunnel so node-b can reach node-a's PG
 
 ```bash
-# Run on mimi macOS VM (keep alive, or add to launchd)
-ssh -N -R 0.0.0.0:5433:192.168.64.1:5432 lume@<CLAWLET_TAILSCALE_IP> \
+# Run on node-a macOS VM (keep alive, or add to launchd)
+ssh -N -R 0.0.0.0:5433:192.168.64.1:5432 lume@<NODE_B_TAILSCALE_IP> \
   -o ServerAliveInterval=10 -o ExitOnForwardFailure=yes
 ```
 
-This exposes mimi's PG as `localhost:5433` on clawlet VM (and its HOST via bridge).
+This exposes node-a's PG as `localhost:5433` on node-b VM (and its HOST via bridge).
 
-#### On clawlet HOST: base backup from mimi
+#### On node-b HOST: base backup from node-a
 
 ```bash
-# Inside clawlet's postgres container (or via docker exec)
+# Inside node-b's postgres container (or via docker exec)
 docker exec -it mattermost-postgres bash
 
-# Stop postgres, wipe data, take base backup from mimi primary
+# Stop postgres, wipe data, take base backup from node-a primary
 pg_ctl stop -D "$PGDATA"
 rm -rf "$PGDATA"/*
 
@@ -107,25 +107,25 @@ pg_ctl start -D "$PGDATA"
 
 Verify replication:
 ```sql
--- On mimi primary
+-- On node-a primary
 SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn
 FROM pg_stat_replication;
 ```
 
 ### Step 5 — Failover & pg_rewind
 
-#### Promote clawlet standby to primary
+#### Promote node-b standby to primary
 
 ```bash
 docker exec mattermost-postgres pg_ctl promote -D "$PGDATA"
 ```
 
-Then update `.env` on clawlet: `POSTGRES_ROLE=primary` and restart Mattermost.
+Then update `.env` on node-b: `POSTGRES_ROLE=primary` and restart Mattermost.
 
-#### Rejoin old primary (mimi) as new standby using pg_rewind
+#### Rejoin old primary (node-a) as new standby using pg_rewind
 
 ```bash
-# On mimi HOST, after clawlet is new primary:
+# On node-a HOST, after node-b is the new primary:
 docker exec -it mattermost-postgres bash
 
 pg_ctl stop -D "$PGDATA"
@@ -146,11 +146,11 @@ pg_ctl start -D "$PGDATA"
 
 ## Ports
 
-| Service    | Container port | Host port (configurable) |
-|------------|---------------|--------------------------|
-| Mattermost | 8065          | `APP_PORT` (default 8065)|
-| Mattermost calls | 8443   | `CALLS_PORT` (default 8443)|
-| PostgreSQL | 5432          | `POSTGRES_PORT` (default 5432)|
+| Service          | Container port | Host port (configurable)      |
+|------------------|---------------|-------------------------------|
+| Mattermost       | 8065          | `APP_PORT` (default 8065)     |
+| Mattermost calls | 8443          | `CALLS_PORT` (default 8443)   |
+| PostgreSQL       | 5432          | `POSTGRES_PORT` (default 5432)|
 
 ## OpenClaw Integration
 

--- a/stacks/mattermost/compose.yaml
+++ b/stacks/mattermost/compose.yaml
@@ -1,6 +1,6 @@
 # Mattermost + PostgreSQL stack
 # Designed for single-node deployment on macOS host via Colima Docker.
-# Two instances (mimi-primary, clawlet-standby) form a primary/standby pair
+# Two instances (node-a primary, node-b standby) form a primary/standby pair
 # with PostgreSQL streaming replication tunnelled over SSH between VMs.
 #
 # Usage:

--- a/stacks/mattermost/compose.yaml
+++ b/stacks/mattermost/compose.yaml
@@ -1,0 +1,74 @@
+# Mattermost + PostgreSQL stack
+# Designed for single-node deployment on macOS host via Colima Docker.
+# Two instances (mimi-primary, clawlet-standby) form a primary/standby pair
+# with PostgreSQL streaming replication tunnelled over SSH between VMs.
+#
+# Usage:
+#   cp .env.example .env   # fill in secrets
+#   docker compose up -d
+#
+# Role is controlled by POSTGRES_ROLE (primary | standby).
+# When POSTGRES_ROLE=standby, Mattermost is started but connects to a read-only
+# replica; it will refuse writes from clients (PG returns read-only errors).
+# Mattermost on the standby node is kept running so it can serve existing
+# connections during failover and be promoted quickly.
+
+services:
+  postgres:
+    image: postgres:${POSTGRES_IMAGE_TAG:-17-alpine}
+    container_name: mattermost-postgres
+    restart: ${RESTART_POLICY:-unless-stopped}
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 2G
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/run/postgresql
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - ${POSTGRES_DATA_PATH}:/var/lib/postgresql/data
+      - ${POSTGRES_INIT_PATH:-./initdb}:/docker-entrypoint-initdb.d:ro
+    environment:
+      - TZ
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB
+      # Allow replication connections from the standby
+      - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  mattermost:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    image: mattermost/${MATTERMOST_IMAGE:-mattermost-team-edition}:${MATTERMOST_IMAGE_TAG:-10.11.8}
+    container_name: mattermost
+    restart: ${RESTART_POLICY:-unless-stopped}
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 2G
+    read_only: false
+    ports:
+      - "${APP_PORT:-8065}:8065"
+      - "${CALLS_PORT:-8443}:8443/udp"
+      - "${CALLS_PORT:-8443}:8443/tcp"
+    volumes:
+      - ${MATTERMOST_CONFIG_PATH}:/mattermost/config:rw
+      - ${MATTERMOST_DATA_PATH}:/mattermost/data:rw
+      - ${MATTERMOST_LOGS_PATH}:/mattermost/logs:rw
+      - ${MATTERMOST_PLUGINS_PATH}:/mattermost/plugins:rw
+      - ${MATTERMOST_CLIENT_PLUGINS_PATH}:/mattermost/client/plugins:rw
+      - ${MATTERMOST_BLEVE_INDEXES_PATH}:/mattermost/bleve-indexes:rw
+    environment:
+      - TZ
+      - MM_SQLSETTINGS_DRIVERNAME=postgres
+      - MM_SQLSETTINGS_DATASOURCE=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable&connect_timeout=10
+      - MM_BLEVESETTINGS_INDEXDIR=/mattermost/bleve-indexes
+      - MM_SERVICESETTINGS_SITEURL=${MM_SERVICESETTINGS_SITEURL}

--- a/stacks/mattermost/initdb/01-replication.sh
+++ b/stacks/mattermost/initdb/01-replication.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Runs once on first DB init (inside the postgres container).
+# Creates a dedicated replication user so the standby can connect
+# without using the superuser credentials.
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    -- Replication user (password set via PGPASSWORD or .pgpass on the standby)
+    DO \$\$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'replicator') THEN
+            CREATE ROLE replicator WITH REPLICATION LOGIN PASSWORD '${POSTGRES_REPLICATION_PASSWORD:-replicator_change_me}';
+        END IF;
+    END
+    \$\$;
+EOSQL
+
+# Allow replication connections in pg_hba.conf
+# (The official postgres image writes pg_hba.conf from POSTGRES_INITDB_ARGS;
+#  we append here for clarity and reliability.)
+cat >> "$PGDATA/pg_hba.conf" <<-EOF
+
+# Allow streaming replication from any host using scram-sha-256
+host    replication     replicator      0.0.0.0/0       scram-sha-256
+EOF
+
+# Enable WAL streaming replication settings in postgresql.conf
+cat >> "$PGDATA/postgresql.conf" <<-EOF
+
+# Streaming replication — primary settings
+wal_level = replica
+max_wal_senders = 5
+wal_keep_size = 256MB      # keep 256 MB of WAL for lagging standbys
+hot_standby = on           # allow read-only queries on standby
+EOF


### PR DESCRIPTION
## Summary

Adds a self-hosted Mattermost (Team Edition) + PostgreSQL stack under `stacks/mattermost/`, following existing conventions (`compose.yaml`, `.env.example`, `README.md`).

## Design

Designed for a **two-node primary/standby** setup across two macOS hosts (Colima Docker), with PostgreSQL streaming replication tunnelled over SSH between VMs. Mattermost itself runs as a single-node stack on each host — it connects to its local PG, which is either primary (writable) or standby (read-only; Mattermost writes will be rejected automatically by PG).

### Architecture

```
Tailscale (phone / laptop)
        |
        | :8065  (via Tailscale IP of the VM)
        ▼
macOS VM  ──nginx reverse proxy──▶  192.168.64.1:8065
                                            |
                                     macOS HOST (Colima)
                                      ┌────────────────┐
                                      │  mattermost    │
                                      │  postgres:5432 │
                                      └────────────────┘
```

## Files

| File | Purpose |
|------|---------|
| `compose.yaml` | Mattermost + PostgreSQL with healthcheck |
| `.env.example` | All variables with comments |
| `initdb/01-replication.sh` | Creates `replicator` role + WAL settings on first DB init |
| `README.md` | Step-by-step guide: single node → VM proxy → second node → streaming replication → failover/pg_rewind |

## Deployment steps (in README)

1. node-a host: first run + Setup Wizard
2. node-a VM: nginx reverse proxy for Tailscale access
3. node-b host: second node (standby)
4. PostgreSQL streaming replication via SSH tunnel
5. Failover (`pg_ctl promote`) + pg_rewind for rejoining old primary as new standby