### PR TITLE
feat: add Mattermost stack with PostgreSQL streaming replication

### DIFF
--- a/stacks/mattermost/.env.example
+++ b/stacks/mattermost/.env.example
@@ -11,21 +11,18 @@ POSTGRES_IMAGE_TAG=17-alpine
 # Host path for persistent data (create before first run)
 POSTGRES_DATA_PATH=./volumes/db/var/lib/postgresql/data
 
-# Credentials — change before first start; cannot be changed after DB is created
+# Credentials — change before first start; cannot be changed after DB is created.
 POSTGRES_USER=mmuser
 POSTGRES_PASSWORD=change_me_strong_password
 POSTGRES_DB=mattermost
 
-# Port exposed to the host (also used by streaming replication tunnel)
-# Primary:  5432 (default)
-# Standby:  5432 (same, local access only; replication connects via SSH tunnel)
-POSTGRES_PORT=5432
+# Replication user password — required on the primary node before first DB init.
+# The initdb script will exit with an error if this is not set.
+# Must also be set on the standby so pg_basebackup and WAL receiver can authenticate.
+POSTGRES_REPLICATION_PASSWORD=change_me_replication_password
 
-# Role: "primary" or "standby"
-# Controls whether pg_hba.conf allows replication connections.
-# Mattermost connects to the local PG regardless of role;
-# a standby PG will reject writes from Mattermost automatically.
-POSTGRES_ROLE=primary
+# Port exposed to the host (also used by streaming replication tunnel).
+POSTGRES_PORT=5432
 
 # ── Mattermost ────────────────────────────────────────────────────────────────
 # Team Edition is free and open source; use mattermost-enterprise-edition for E0/E10/E20

--- a/stacks/mattermost/.env.example
+++ b/stacks/mattermost/.env.example
@@ -1,0 +1,50 @@
+# Mattermost Stack — environment variables
+# Copy to .env and fill in values before running docker compose up.
+
+# ── General ──────────────────────────────────────────────────────────────────
+TZ=Asia/Singapore
+RESTART_POLICY=unless-stopped
+
+# ── PostgreSQL ────────────────────────────────────────────────────────────────
+POSTGRES_IMAGE_TAG=17-alpine
+
+# Host path for persistent data (create before first run)
+POSTGRES_DATA_PATH=./volumes/db/var/lib/postgresql/data
+
+# Credentials — change before first start; cannot be changed after DB is created
+POSTGRES_USER=mmuser
+POSTGRES_PASSWORD=change_me_strong_password
+POSTGRES_DB=mattermost
+
+# Port exposed to the host (also used by streaming replication tunnel)
+# Primary:  5432 (default)
+# Standby:  5432 (same, local access only; replication connects via SSH tunnel)
+POSTGRES_PORT=5432
+
+# Role: "primary" or "standby"
+# Controls whether pg_hba.conf allows replication connections.
+# Mattermost connects to the local PG regardless of role;
+# a standby PG will reject writes from Mattermost automatically.
+POSTGRES_ROLE=primary
+
+# ── Mattermost ────────────────────────────────────────────────────────────────
+# Team Edition is free and open source; use mattermost-enterprise-edition for E0/E10/E20
+MATTERMOST_IMAGE=mattermost-team-edition
+MATTERMOST_IMAGE_TAG=10.11.8
+
+# Site URL — set to the Tailscale URL of the VM that reverse-proxies this host
+# e.g. http://<NODE_A_TAILSCALE_IP>:8065
+#      http://<NODE_B_TAILSCALE_IP>:8065
+MM_SERVICESETTINGS_SITEURL=http://localhost:8065
+
+# Port exposed on the host
+APP_PORT=8065
+CALLS_PORT=8443
+
+# Host paths for Mattermost persistent data (create before first run)
+MATTERMOST_CONFIG_PATH=./volumes/app/mattermost/config
+MATTERMOST_DATA_PATH=./volumes/app/mattermost/data
+MATTERMOST_LOGS_PATH=./volumes/app/mattermost/logs
+MATTERMOST_PLUGINS_PATH=./volumes/app/mattermost/plugins
+MATTERMOST_CLIENT_PLUGINS_PATH=./volumes/app/mattermost/client/plugins
+MATTERMOST_BLEVE_INDEXES_PATH=./volumes/app/mattermost/bleve-indexes

--- a/stacks/mattermost/README.md
+++ b/stacks/mattermost/README.md
@@ -1,0 +1,184 @@
+# Mattermost Stack
+
+Self-hosted Mattermost (Team Edition) with PostgreSQL, designed for a two-node
+primary/standby setup across two macOS hosts running Colima Docker.
+
+## Architecture
+
+```
+Tailscale (phone / laptop)
+        |
+        | :8065  (via Tailscale IP of the VM)
+        ▼
+macOS VM  ──nginx reverse proxy──▶  <HOST_BRIDGE_IP>:8065
+                                            |
+                                     macOS HOST (Colima)
+                                      ┌────────────────┐
+                                      │  mattermost    │
+                                      │  postgres:5432 │
+                                      └────────────────┘
+
+Two hosts: node-a (primary) and node-b (standby).
+PostgreSQL streaming replication is tunnelled over SSH between the two VMs.
+```
+
+## Steps
+
+### Step 1 — node-a host: first run
+
+```bash
+# On the primary macOS HOST (Colima must be running)
+cd ~/projects/forest/stacks/mattermost
+cp .env.example .env
+# Edit .env: set POSTGRES_PASSWORD, POSTGRES_REPLICATION_PASSWORD, MM_SERVICESETTINGS_SITEURL
+
+# Create volume directories
+mkdir -p volumes/db/var/lib/postgresql/data
+mkdir -p volumes/app/mattermost/{config,data,logs,plugins,client/plugins,bleve-indexes}
+
+# Fix permissions (Mattermost runs as uid 2000 inside container)
+sudo chown -R 2000:2000 volumes/app/mattermost
+
+docker compose up -d
+docker compose logs -f
+```
+
+Open `http://<HOST_BRIDGE_IP>:8065` from the macOS VM to complete the Setup Wizard.
+
+### Step 2 — node-a VM: nginx reverse proxy for Tailscale access
+
+Install nginx on the macOS VM and proxy Tailscale IP → HOST bridge:
+
+```nginx
+# /etc/nginx/conf.d/mattermost.conf  (or Homebrew nginx equivalent)
+server {
+    listen <NODE_A_TAILSCALE_IP>:8065;
+    location / {
+        proxy_pass http://<HOST_BRIDGE_IP>:8065;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_read_timeout 600s;
+    }
+}
+```
+
+Access from phone/laptop: `http://<NODE_A_TAILSCALE_IP>:8065`
+
+### Step 3 — node-b host: second node
+
+Same as Step 1 on the standby HOST, but set `POSTGRES_ROLE=standby` in `.env`
+and use the node-b Tailscale IP in `MM_SERVICESETTINGS_SITEURL`.
+
+> **Note:** On the standby node, start only postgres first (comment out the
+> mattermost service). PostgreSQL streaming replication must be set up before
+> starting Mattermost on the standby.
+
+### Step 4 — Set up PostgreSQL streaming replication
+
+#### On node-a VM: open a reverse SSH tunnel so node-b can reach node-a's PG
+
+```bash
+# Run on node-a macOS VM (keep alive, or add to launchd)
+ssh -N -R 0.0.0.0:5433:<HOST_BRIDGE_IP>:5432 <USER>@<NODE_B_TAILSCALE_IP> \
+  -o ServerAliveInterval=10 -o ExitOnForwardFailure=yes
+```
+
+This exposes node-a's PG as `localhost:5433` on node-b VM (and its HOST via bridge).
+
+#### On node-b HOST: base backup from node-a
+
+```bash
+# Inside node-b's postgres container (or via docker exec)
+docker exec -it mattermost-postgres bash
+
+# Stop postgres, wipe data, take base backup from node-a primary
+pg_ctl stop -D "$PGDATA"
+rm -rf "$PGDATA"/*
+
+PGPASSWORD=<POSTGRES_REPLICATION_PASSWORD> \
+  pg_basebackup -h <HOST_BRIDGE_IP> -p 5433 -U replicator \
+    -D "$PGDATA" -Fp -Xs -P -R
+# -R writes standby.signal + primary_conninfo automatically
+
+pg_ctl start -D "$PGDATA"
+```
+
+Verify replication:
+```sql
+-- On node-a primary
+SELECT client_addr, state, sent_lsn, write_lsn, flush_lsn, replay_lsn
+FROM pg_stat_replication;
+```
+
+### Step 5 — Failover & pg_rewind
+
+#### Promote node-b standby to primary
+
+```bash
+docker exec mattermost-postgres pg_ctl promote -D "$PGDATA"
+```
+
+Then update `.env` on node-b: `POSTGRES_ROLE=primary` and restart Mattermost.
+
+#### Rejoin old primary (node-a) as new standby using pg_rewind
+
+```bash
+# On node-a HOST, after node-b is the new primary:
+docker exec -it mattermost-postgres bash
+
+pg_ctl stop -D "$PGDATA"
+PGPASSWORD=<POSTGRES_REPLICATION_PASSWORD> \
+  pg_rewind \
+    --target-pgdata="$PGDATA" \
+    --source-server="host=<HOST_BRIDGE_IP> port=5433 user=replicator dbname=postgres" \
+    -P
+
+# Write standby.signal and update primary_conninfo
+touch "$PGDATA/standby.signal"
+cat >> "$PGDATA/postgresql.conf" <<EOF
+primary_conninfo = 'host=<HOST_BRIDGE_IP> port=5433 user=replicator password=<REPL_PW>'
+EOF
+
+pg_ctl start -D "$PGDATA"
+```
+
+## Ports
+
+| Service          | Container port | Host port (configurable)      |
+|------------------|---------------|-------------------------------|
+| Mattermost       | 8065          | `APP_PORT` (default 8065)     |
+| Mattermost calls | 8443          | `CALLS_PORT` (default 8443)   |
+| PostgreSQL       | 5432          | `POSTGRES_PORT` (default 5432)|
+
+## OpenClaw Integration
+
+After Mattermost is running, install the OpenClaw plugin and configure each bot:
+
+```bash
+openclaw plugins install @openclaw/mattermost
+```
+
+Add to `~/.openclaw/openclaw.json`:
+```json5
+{
+  channels: {
+    mattermost: {
+      enabled: true,
+      botToken: "<bot-token>",
+      baseUrl: "http://<VM_TAILSCALE_IP>:8065",
+      chatmode: "oncall",
+    }
+  }
+}
+```
+
+## Security notes
+
+- PostgreSQL port (`5432`) is bound to `0.0.0.0` inside Colima but only reachable
+  from the macOS HOST via the bridge (`<HOST_BRIDGE_IP>`). Use `pf` if you want to
+  restrict it further (see kopia sstore lesson).
+- Mattermost port (`8065`) is similarly only accessible via bridge from the VM;
+  the VM's nginx reverse proxy controls Tailscale exposure.
+- Change all default passwords in `.env` before first run.

--- a/stacks/mattermost/README.md
+++ b/stacks/mattermost/README.md
@@ -68,8 +68,15 @@ Access from phone/laptop: `http://<NODE_A_TAILSCALE_IP>:8065`
 
 ### Step 3 — node-b host: second node
 
-Same as Step 1 on the standby HOST, but set `POSTGRES_ROLE=standby` in `.env`
-and use the node-b Tailscale IP in `MM_SERVICESETTINGS_SITEURL`.
+Same as Step 1 on the standby HOST, use the node-b Tailscale IP in
+`MM_SERVICESETTINGS_SITEURL`.
+
+> **Note on `POSTGRES_ROLE`:** This variable is informational — it documents intent
+> but does not change container behaviour. The standby becomes read-only via
+> `standby.signal` written by `pg_basebackup -R`, not via this variable.
+> The `initdb/01-replication.sh` script (which creates the replicator role and WAL
+> settings) should only be present on the primary node's `./initdb/` directory;
+> on the standby, omit or remove it.
 
 > **Note:** On the standby node, start only postgres first (comment out the
 > mattermost service). PostgreSQL streaming replication must be set up before
@@ -80,12 +87,16 @@ and use the node-b Tailscale IP in `MM_SERVICESETTINGS_SITEURL`.
 #### On node-a VM: open a reverse SSH tunnel so node-b can reach node-a's PG
 
 ```bash
-# Run on node-a macOS VM (keep alive, or add to launchd)
-ssh -N -R 0.0.0.0:5433:<HOST_BRIDGE_IP>:5432 <USER>@<NODE_B_TAILSCALE_IP> \
+# Run on node-a macOS VM (keep alive, or add to launchd).
+# -R binds on 127.0.0.1 only (loopback) on the remote side, matching the
+# 127.0.0.1/32 pg_hba rule in initdb/01-replication.sh.
+ssh -N -R 127.0.0.1:5433:<HOST_BRIDGE_IP>:5432 <USER>@<NODE_B_TAILSCALE_IP> \
   -o ServerAliveInterval=10 -o ExitOnForwardFailure=yes
 ```
 
-This exposes node-a's PG as `localhost:5433` on node-b VM (and its HOST via bridge).
+This exposes node-a's PG as `127.0.0.1:5433` on node-b VM.
+The tunnel arrives on loopback, which matches the `127.0.0.1/32` replication entry
+in `pg_hba.conf` — no wider network exposure is needed.
 
 #### On node-b HOST: base backup from node-a
 
@@ -98,7 +109,7 @@ pg_ctl stop -D "$PGDATA"
 rm -rf "$PGDATA"/*
 
 PGPASSWORD=<POSTGRES_REPLICATION_PASSWORD> \
-  pg_basebackup -h <HOST_BRIDGE_IP> -p 5433 -U replicator \
+  pg_basebackup -h 127.0.0.1 -p 5433 -U replicator \
     -D "$PGDATA" -Fp -Xs -P -R
 # -R writes standby.signal + primary_conninfo automatically
 
@@ -120,25 +131,32 @@ FROM pg_stat_replication;
 docker exec mattermost-postgres pg_ctl promote -D "$PGDATA"
 ```
 
-Then update `.env` on node-b: `POSTGRES_ROLE=primary` and restart Mattermost.
+Then start Mattermost on node-b (`docker compose up -d mattermost`).
 
 #### Rejoin old primary (node-a) as new standby using pg_rewind
 
+`pg_rewind` requires superuser access (or the `pg_rewind` privilege on PG 14+).
+Use `$POSTGRES_USER` (the superuser created at DB init), not the replicator role.
+
 ```bash
-# On node-a HOST, after node-b is the new primary:
+# On node-a HOST, after node-b is the new primary.
+# First ensure the SSH tunnel runs from node-b VM to node-a VM (reverse direction):
+#   ssh -N -R 127.0.0.1:5433:<HOST_BRIDGE_IP>:5432 <USER>@<NODE_A_TAILSCALE_IP>
 docker exec -it mattermost-postgres bash
 
 pg_ctl stop -D "$PGDATA"
-PGPASSWORD=<POSTGRES_REPLICATION_PASSWORD> \
+
+# Use the superuser (POSTGRES_USER) for pg_rewind, not the replicator role.
+PGPASSWORD=<POSTGRES_PASSWORD> \
   pg_rewind \
     --target-pgdata="$PGDATA" \
-    --source-server="host=<HOST_BRIDGE_IP> port=5433 user=replicator dbname=postgres" \
+    --source-server="host=127.0.0.1 port=5433 user=${POSTGRES_USER} dbname=postgres" \
     -P
 
-# Write standby.signal and update primary_conninfo
+# Write standby.signal and update primary_conninfo (replicator is fine here).
 touch "$PGDATA/standby.signal"
 cat >> "$PGDATA/postgresql.conf" <<EOF
-primary_conninfo = 'host=<HOST_BRIDGE_IP> port=5433 user=replicator password=<REPL_PW>'
+primary_conninfo = 'host=127.0.0.1 port=5433 user=replicator password=<POSTGRES_REPLICATION_PASSWORD>'
 EOF
 
 pg_ctl start -D "$PGDATA"

--- a/stacks/mattermost/compose.yaml
+++ b/stacks/mattermost/compose.yaml
@@ -7,11 +7,9 @@
 #   cp .env.example .env   # fill in secrets
 #   docker compose up -d
 #
-# Role is controlled by POSTGRES_ROLE (primary | standby).
-# When POSTGRES_ROLE=standby, Mattermost is started but connects to a read-only
-# replica; it will refuse writes from clients (PG returns read-only errors).
-# Mattermost on the standby node is kept running so it can serve existing
-# connections during failover and be promoted quickly.
+# Node role (primary | standby) is documentation-only and not wired into
+# container behaviour. The standby becomes read-only via standby.signal written
+# by pg_basebackup -R; see README for the full replication setup procedure.
 
 services:
   postgres:
@@ -35,7 +33,8 @@ services:
       - POSTGRES_USER
       - POSTGRES_PASSWORD
       - POSTGRES_DB
-      # Allow replication connections from the standby
+      # Passed through to initdb/01-replication.sh on first DB init.
+      - POSTGRES_REPLICATION_PASSWORD
       - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]

--- a/stacks/mattermost/compose.yaml
+++ b/stacks/mattermost/compose.yaml
@@ -1,0 +1,74 @@
+# Mattermost + PostgreSQL stack
+# Designed for single-node deployment on macOS host via Colima Docker.
+# Two instances (node-a primary, node-b standby) form a primary/standby pair
+# with PostgreSQL streaming replication tunnelled over SSH between VMs.
+#
+# Usage:
+#   cp .env.example .env   # fill in secrets
+#   docker compose up -d
+#
+# Role is controlled by POSTGRES_ROLE (primary | standby).
+# When POSTGRES_ROLE=standby, Mattermost is started but connects to a read-only
+# replica; it will refuse writes from clients (PG returns read-only errors).
+# Mattermost on the standby node is kept running so it can serve existing
+# connections during failover and be promoted quickly.
+
+services:
+  postgres:
+    image: postgres:${POSTGRES_IMAGE_TAG:-17-alpine}
+    container_name: mattermost-postgres
+    restart: ${RESTART_POLICY:-unless-stopped}
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 2G
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /var/run/postgresql
+    ports:
+      - "${POSTGRES_PORT:-5432}:5432"
+    volumes:
+      - ${POSTGRES_DATA_PATH}:/var/lib/postgresql/data
+      - ${POSTGRES_INIT_PATH:-./initdb}:/docker-entrypoint-initdb.d:ro
+    environment:
+      - TZ
+      - POSTGRES_USER
+      - POSTGRES_PASSWORD
+      - POSTGRES_DB
+      # Allow replication connections from the standby
+      - POSTGRES_INITDB_ARGS=--auth-host=scram-sha-256
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+
+  mattermost:
+    depends_on:
+      postgres:
+        condition: service_healthy
+    image: mattermost/${MATTERMOST_IMAGE:-mattermost-team-edition}:${MATTERMOST_IMAGE_TAG:-10.11.8}
+    container_name: mattermost
+    restart: ${RESTART_POLICY:-unless-stopped}
+    security_opt:
+      - no-new-privileges:true
+    mem_limit: 2G
+    read_only: false
+    ports:
+      - "${APP_PORT:-8065}:8065"
+      - "${CALLS_PORT:-8443}:8443/udp"
+      - "${CALLS_PORT:-8443}:8443/tcp"
+    volumes:
+      - ${MATTERMOST_CONFIG_PATH}:/mattermost/config:rw
+      - ${MATTERMOST_DATA_PATH}:/mattermost/data:rw
+      - ${MATTERMOST_LOGS_PATH}:/mattermost/logs:rw
+      - ${MATTERMOST_PLUGINS_PATH}:/mattermost/plugins:rw
+      - ${MATTERMOST_CLIENT_PLUGINS_PATH}:/mattermost/client/plugins:rw
+      - ${MATTERMOST_BLEVE_INDEXES_PATH}:/mattermost/bleve-indexes:rw
+    environment:
+      - TZ
+      - MM_SQLSETTINGS_DRIVERNAME=postgres
+      - MM_SQLSETTINGS_DATASOURCE=postgres://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}?sslmode=disable&connect_timeout=10
+      - MM_BLEVESETTINGS_INDEXDIR=/mattermost/bleve-indexes
+      - MM_SERVICESETTINGS_SITEURL=${MM_SERVICESETTINGS_SITEURL}

--- a/stacks/mattermost/initdb/01-replication.sh
+++ b/stacks/mattermost/initdb/01-replication.sh
@@ -1,0 +1,35 @@
+#!/bin/bash
+# Runs once on first DB init (inside the postgres container).
+# Creates a dedicated replication user so the standby can connect
+# without using the superuser credentials.
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    -- Replication user (password set via PGPASSWORD or .pgpass on the standby)
+    DO \$\$
+    BEGIN
+        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'replicator') THEN
+            CREATE ROLE replicator WITH REPLICATION LOGIN PASSWORD '${POSTGRES_REPLICATION_PASSWORD:-replicator_change_me}';
+        END IF;
+    END
+    \$\$;
+EOSQL
+
+# Allow replication connections in pg_hba.conf
+# (The official postgres image writes pg_hba.conf from POSTGRES_INITDB_ARGS;
+#  we append here for clarity and reliability.)
+cat >> "$PGDATA/pg_hba.conf" <<-EOF
+
+# Allow streaming replication from any host using scram-sha-256
+host    replication     replicator      0.0.0.0/0       scram-sha-256
+EOF
+
+# Enable WAL streaming replication settings in postgresql.conf
+cat >> "$PGDATA/postgresql.conf" <<-EOF
+
+# Streaming replication — primary settings
+wal_level = replica
+max_wal_senders = 5
+wal_keep_size = 256MB      # keep 256 MB of WAL for lagging standbys
+hot_standby = on           # allow read-only queries on standby
+EOF

--- a/stacks/mattermost/initdb/01-replication.sh
+++ b/stacks/mattermost/initdb/01-replication.sh
@@ -39,4 +39,7 @@ wal_level = replica
 max_wal_senders = 5
 wal_keep_size = 256MB
 hot_standby = on
+# Required by pg_rewind (allows it to read pages that changed between divergence
+# and the point where the old primary stopped, without needing data checksums).
+wal_log_hints = on
 EOF

--- a/stacks/mattermost/initdb/01-replication.sh
+++ b/stacks/mattermost/initdb/01-replication.sh
@@ -1,35 +1,42 @@
 #!/bin/bash
 # Runs once on first DB init (inside the postgres container).
-# Creates a dedicated replication user so the standby can connect
-# without using the superuser credentials.
+# Creates a dedicated replication user and enables WAL for streaming replication.
+# This script is only needed on the primary node.
 set -e
 
-psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
-    -- Replication user (password set via PGPASSWORD or .pgpass on the standby)
-    DO \$\$
-    BEGIN
-        IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = 'replicator') THEN
-            CREATE ROLE replicator WITH REPLICATION LOGIN PASSWORD '${POSTGRES_REPLICATION_PASSWORD:-replicator_change_me}';
-        END IF;
-    END
-    \$\$;
-EOSQL
+# Require the replication password to be explicitly set — no insecure fallback.
+if [ -z "$POSTGRES_REPLICATION_PASSWORD" ]; then
+    echo "ERROR: POSTGRES_REPLICATION_PASSWORD must be set before first DB init." >&2
+    exit 1
+fi
 
-# Allow replication connections in pg_hba.conf
-# (The official postgres image writes pg_hba.conf from POSTGRES_INITDB_ARGS;
-#  we append here for clarity and reliability.)
+# Create the replication role via createuser + ALTER ROLE to avoid
+# embedding the password as a SQL string literal (single-quote injection risk).
+createuser --username "$POSTGRES_USER" --replication replicator 2>/dev/null || true
+
+# Set password separately using PGPASSWORD env var so no quoting issues.
+PGPASSWORD="$POSTGRES_REPLICATION_PASSWORD" \
+    psql -v ON_ERROR_STOP=1 \
+         --username "$POSTGRES_USER" \
+         --dbname "$POSTGRES_DB" \
+         --no-password \
+         -c "ALTER ROLE replicator WITH LOGIN PASSWORD \$repl_pw\$${POSTGRES_REPLICATION_PASSWORD}\$repl_pw\$;"
+
+# Restrict replication connections to localhost only (tunnel arrives on loopback).
+# Adjust the CIDR if your tunnel setup uses a different source address.
 cat >> "$PGDATA/pg_hba.conf" <<-EOF
 
-# Allow streaming replication from any host using scram-sha-256
-host    replication     replicator      0.0.0.0/0       scram-sha-256
+# Allow streaming replication from localhost only (SSH tunnel termination point).
+# The standby connects via an SSH reverse tunnel that arrives on 127.0.0.1.
+host    replication     replicator      127.0.0.1/32    scram-sha-256
 EOF
 
-# Enable WAL streaming replication settings in postgresql.conf
+# Enable WAL streaming replication in postgresql.conf.
 cat >> "$PGDATA/postgresql.conf" <<-EOF
 
-# Streaming replication — primary settings
+# Streaming replication -- primary settings
 wal_level = replica
 max_wal_senders = 5
-wal_keep_size = 256MB      # keep 256 MB of WAL for lagging standbys
-hot_standby = on           # allow read-only queries on standby
+wal_keep_size = 256MB
+hot_standby = on
 EOF


### PR DESCRIPTION
## Summary

Adds a self-hosted Mattermost (Team Edition) + PostgreSQL stack under `stacks/mattermost/`, following existing conventions (`compose.yaml`, `.env.example`, `README.md`).

## Design

Designed for a **two-node primary/standby** setup across two macOS hosts running Colima Docker, with PostgreSQL streaming replication tunnelled over SSH between VMs. Mattermost runs as a single-node stack on each host, connecting to its local PG. A standby PG automatically rejects writes from Mattermost without any application-level changes.

### Architecture

```
Tailscale (phone / laptop)
        |
        | :8065  (via Tailscale IP of the VM)
        ▼
macOS VM  ──nginx reverse proxy──▶  <HOST_BRIDGE_IP>:8065
                                            |
                                     macOS HOST (Colima)
                                      ┌────────────────┐
                                      │  mattermost    │
                                      │  postgres:5432 │
                                      └────────────────┘
```

## Files

| File | Purpose |
|------|---------|
| `compose.yaml` | Mattermost + PostgreSQL with healthcheck |
| `.env.example` | All variables with inline comments |
| `initdb/01-replication.sh` | Creates `replicator` role + WAL settings on first DB init |
| `README.md` | Five-step deployment guide: single node → VM nginx proxy → second node → streaming replication → failover/pg_rewind |

## Deployment steps (in README)

1. node-a host: first run + Setup Wizard
2. node-a VM: nginx reverse proxy for Tailscale access
3. node-b host: second node (standby)
4. PostgreSQL streaming replication via SSH tunnel
5. Failover (`pg_ctl promote`) + pg_rewind for rejoining old primary as new standby