### PR TITLE
feat: add lody-box stack (lody + claude + codex + gemini)

### DIFF
--- a/stacks/lody-box/.env.in
+++ b/stacks/lody-box/.env.in
@@ -1,0 +1,27 @@
+# lody-box — sandboxed AI coding agents
+# Copy to .env and fill in values
+
+# ── Workspace ────────────────────────────────────────────────────────────────
+# Host path to the directory containing your repos (mounted at /workspace).
+# Defaults to ./workspace (alongside this .env file) if not set.
+# WORKSPACE_PATH=./workspace
+
+# ── Lody ─────────────────────────────────────────────────────────────────────
+# CLI token from https://lody.ai — required for `lody serve`
+# LODY_CLI_TOKEN=
+
+# Disable PostHog analytics (optional)
+LODY_POSTHOG_DISABLED=1
+
+# ── Claude Code ───────────────────────────────────────────────────────────────
+# API key for Anthropic. Alternatively, run `docker exec -it lody-box claude auth`
+# ANTHROPIC_API_KEY=
+
+# ── Codex ─────────────────────────────────────────────────────────────────────
+# API key for OpenAI. No interactive auth needed when this is set.
+# OPENAI_API_KEY=
+
+# ── Gemini CLI ────────────────────────────────────────────────────────────────
+# API key for Google Gemini. Alternatively, run `docker exec -it lody-box gemini auth`
+# GEMINI_API_KEY=
+# GOOGLE_API_KEY=

--- a/stacks/lody-box/.gitignore
+++ b/stacks/lody-box/.gitignore
@@ -1,0 +1,5 @@
+# Local environment overrides (contains secrets)
+.env
+
+# Local workspace directory (repos mounted into the container)
+workspace/

--- a/stacks/lody-box/Dockerfile
+++ b/stacks/lody-box/Dockerfile
@@ -1,0 +1,26 @@
+# Bun binary — copy from official image to avoid remote install script
+FROM oven/bun:1-debian AS bun
+
+FROM node:22-slim
+
+# Copy bun binary from official image (no curl, no unpinned remote script)
+COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
+ENV PATH="/root/.bun/bin:$PATH"
+
+RUN apt-get update && apt-get install -y \
+    git unzip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install all four AI agents via bun (consistent with host-side prep tasks)
+RUN bun add -g \
+    @anthropic-ai/claude-code \
+    @openai/codex \
+    @google/gemini-cli \
+    lody
+
+WORKDIR /workspace
+
+# Default to bash — run agents explicitly:
+#   lody:        docker compose run lody-box lody start
+#   claude/codex/gemini: docker exec -it lody-box <agent>
+CMD ["bash"]

--- a/stacks/lody-box/README.md
+++ b/stacks/lody-box/README.md
@@ -1,0 +1,127 @@
+# lody-box — Sandboxed AI Coding Agents
+
+A Docker sandbox for running AI coding agents ([Lody](https://lody.ai),
+[Claude Code](https://docs.anthropic.com/claude-code),
+[Codex](https://github.com/openai/codex), and
+[Gemini CLI](https://github.com/google-gemini/gemini-cli))
+in an isolated environment.
+
+The container defaults to `bash` — all four agents are available via `docker exec` or
+`docker compose run`. Start the lody daemon explicitly when needed.
+
+## Why Docker?
+
+Lody is a remote-controlled local execution platform: when you chat via the
+lody.ai web UI, the server sends commands to your machine's daemon, which spawns
+the underlying agent and executes its tool calls. Docker limits the blast radius:
+
+- **Filesystem** — agents only see what you mount in; host `~/.ssh`, `~/.aws`, etc. are
+  out of scope by default
+- **Process** — agents cannot inspect or kill host processes
+- **Agent auth** — named volumes persist login state across rebuilds without
+  touching your host config files
+
+## Setup
+
+1. Copy `.env.in` to `.env` and fill in your tokens/keys:
+
+    ```sh
+    cp .env.in .env
+    ```
+
+2. Create the workspace directory (or set `WORKSPACE_PATH` in `.env` to an existing path):
+
+    ```sh
+    mkdir -p workspace
+    # or: put your repos directly under workspace/
+    ```
+
+3. Build and start:
+
+    ```sh
+    docker compose up -d --build
+    ```
+
+4. Auth each agent once (stored in named volumes, survives rebuilds):
+
+    ```sh
+    # Lody
+    docker exec -it lody-box lody login
+
+    # Claude Code (or set ANTHROPIC_API_KEY in .env instead)
+    docker exec -it lody-box claude auth
+
+    # Gemini (or set GEMINI_API_KEY in .env instead)
+    docker exec -it lody-box gemini auth
+
+    # Codex — no interactive auth needed when OPENAI_API_KEY is set in .env
+    ```
+
+5. Verify:
+
+    ```sh
+    docker exec lody-box lody --version
+    docker exec lody-box claude --version
+    docker exec lody-box codex --version
+    docker exec lody-box gemini --version
+    ```
+
+## Day-to-day usage
+
+```sh
+# Open a shell
+docker exec -it lody-box bash
+
+# Start the lody daemon (connects to lody.ai; manages claude and codex agents)
+docker compose run lody-box lody start
+
+# Run Claude Code on a repo
+docker exec -it lody-box claude --print "explain this codebase"
+
+# Run Codex
+docker exec -it lody-box codex "add tests for src/utils.ts"
+
+# Run Gemini (standalone — not managed by the lody daemon)
+docker exec -it lody-box gemini "review this PR diff"
+```
+
+## Re-auth a single agent
+
+```sh
+# Remove just that agent's auth volume, then re-auth
+docker volume rm lody-box_claude-auth
+docker compose up -d
+docker exec -it lody-box claude auth
+```
+
+> **Note:** To re-auth lody specifically: `docker volume rm lody-box_lody-auth`, then
+> `docker exec -it lody-box lody login`.
+
+## Agents
+
+| Agent | Package | Auth |
+|-------|---------|------|
+| [Lody](https://lody.ai) | `lody` | `lody login` + `LODY_CLI_TOKEN` |
+| [Claude Code](https://docs.anthropic.com/claude-code) | `@anthropic-ai/claude-code` | `claude auth` or `ANTHROPIC_API_KEY` |
+| [Codex](https://github.com/openai/codex) | `@openai/codex` | `OPENAI_API_KEY` env var |
+| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `@google/gemini-cli` | `gemini auth` or `GEMINI_API_KEY` |
+
+> **Lody agent types:** `lody start --cli-types` only accepts `claude` or `codex`. Gemini is
+> available in the container but runs standalone — it is not managed by the lody daemon.
+
+## Base image
+
+Runtime base: `node:22-slim` (Debian slim, ~220 MB uncompressed). Node.js is required by all
+four agents; bun is used for package management via `bun add -g`.
+
+`oven/bun:1-debian` is used as a **build stage only** to copy the bun binary —
+it is not the runtime base, so the ~70 MB overhead doesn't apply. This avoids
+the unpinned `curl | bash` install script while keeping `node:22-slim` as the
+final image.
+
+## References
+
+- [Lody documentation](https://lody.ai/docs)
+- [Claude Code documentation](https://docs.anthropic.com/claude-code)
+- [Codex (OpenAI)](https://github.com/openai/codex)
+- [Gemini CLI](https://github.com/google-gemini/gemini-cli)

--- a/stacks/lody-box/compose.yaml
+++ b/stacks/lody-box/compose.yaml
@@ -1,0 +1,32 @@
+services:
+  lody-box:
+    build: .
+    image: lody-box:latest
+    container_name: lody-box
+    restart: unless-stopped
+    stdin_open: true
+    tty: true
+    env_file: .env
+    volumes:
+      # Working repos — bind-mount so host files are directly accessible
+      - ${WORKSPACE_PATH:-./workspace}:/workspace
+
+      # Agent auth/state — named volumes so auth persists across rebuilds
+      - lody-auth:/root/.lody
+      - claude-auth:/root/.claude
+      - codex-auth:/root/.codex
+      - gemini-auth:/root/.gemini
+
+      # Bun global installs and cache
+      - bun-data:/root/.bun
+    security_opt:
+      - no-new-privileges:true
+    cap_drop:
+      - ALL
+
+volumes:
+  lody-auth:
+  claude-auth:
+  codex-auth:
+  gemini-auth:
+  bun-data:


### PR DESCRIPTION
## Summary

Adds a new `stacks/lody-box` stack — a Docker sandbox for running AI coding agents in an isolated environment.

### Agents included
| Agent | Package | Auth |
|-------|---------|------|
| [Lody](https://lody.ai) | `lody` | `lody auth` + `LODY_CLI_TOKEN` |
| [Claude Code](https://docs.anthropic.com/claude-code) | `@anthropic-ai/claude-code` | `claude auth` or `ANTHROPIC_API_KEY` |
| [Codex](https://github.com/openai/codex) | `@openai/codex` | `OPENAI_API_KEY` env var |
| [Gemini CLI](https://github.com/google-gemini/gemini-cli) | `@google/gemini-cli` | `gemini auth` or `GEMINI_API_KEY` |

### Design decisions
- **`node:22-slim` base** over `oven/bun:1-debian`: Node is required by all four agents, so bun-first base adds ~70 MB with no benefit; Bun is installed on top via the install script
- **`lody serve` as default CMD**: Lody daemon starts automatically; other agents accessed via `docker exec`
- **Named volumes for agent auth** (`lody-auth`, `claude-auth`, `codex-auth`, `gemini-auth`): auth state persists across `docker compose down` and image rebuilds without touching host config files; individual agents can be re-authed by removing just their volume
- **Bind mount for `workspace/`**: repos are accessible from host without re-mounting; path configurable via `WORKSPACE_PATH` in `.env`

### Security rationale
Lody is a remote-controlled local execution platform — the lody.ai server sends commands that the local daemon executes via `bash -lc`. Docker contains the filesystem and process blast radius: agents only see mounted paths, cannot reach host processes, and host secrets (`~/.ssh`, `~/.aws`) stay out of scope by default.

### Files
```
stacks/lody-box/
├── Dockerfile
├── compose.yaml
├── .env.in
├── .gitignore
└── README.md
```

Follows conventions from `stacks/sstore` (`.env.in`, `.gitignore`, README structure).