### PR TITLE
feat(lody-box): add gh CLI to Dockerfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ dotfiles/.config/chawan/cookies.txt
 dotfiles/.config/chawan/history.uri
 dotfiles/.config/tattoy/shaders
 
+.omc/state/

--- a/stacks/lody-box/Dockerfile
+++ b/stacks/lody-box/Dockerfile
@@ -8,7 +8,14 @@ COPY --from=bun /usr/local/bin/bun /usr/local/bin/bun
 ENV PATH="/root/.bun/bin:$PATH"
 
 RUN apt-get update && apt-get install -y \
-    git unzip \
+    git unzip curl gnupg \
+    && mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+       | dd of=/etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+       > /etc/apt/sources.list.d/github-cli.list \
+    && apt-get update && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install all four AI agents via bun (consistent with host-side prep tasks)


### PR DESCRIPTION
## Summary

- Adds `gh` CLI to the `lody-box` container via the official GitHub CLI apt repository
- Adds `curl` and `gnupg` to the apt install (needed for GPG key setup during build)

## Test plan

- [x] Built image successfully
- [x] `docker exec lody-box gh --version` → `gh version 2.89.0`
- [x] All four agents still respond to `--version`