### PR TITLE
fix: content rendering and XSL theme cleanup (issue #9 phases 1+2)

### DIFF
--- a/assets/uts-layout.xsl
+++ b/assets/uts-layout.xsl
@@ -89,6 +89,9 @@
                 </header>
 
                 <div id="grid-wrapper">
+                    <blockquote>
+                        NOTE: This site has just upgraded to Forester 5.x and is still having some style and functionality <span class="link external"><a href="https://github.com/utensil/forest/issues/9">issues</a></span>, we will fix them ASAP.
+                    </blockquote>
                     <article>
                         <xsl:apply-templates select="fr:tree" />
                     </article>

--- a/assets/uts-layout.xsl
+++ b/assets/uts-layout.xsl
@@ -14,7 +14,6 @@
         <html xmlns="http://www.w3.org/1999/xhtml" data-base-url="{/fr:tree/@base-url}">
             <head>
                 <meta name="viewport" content="width=device-width" />
-                <!-- <style> :root { background-color: #262626 !important; }</style> -->
                 <link rel="stylesheet" href="{/fr:tree/@base-url}style.css" />
                 <link rel="stylesheet" href="{/fr:tree/@base-url}katex.min.css" />
                 <!-- uts-begin -->
@@ -29,14 +28,10 @@
                 </script>
                 <script type="module" src="{/fr:tree/@base-url}forester.js"></script>
                 <title>
-                    <xsl:value-of select="/fr:tree/fr:frontmatter/fr:title" />
+                    <xsl:value-of select="/fr:tree/fr:frontmatter/fr:title/@text" />
                 </title>
-                <!-- <script
-                src="https://cdn.jsdelivr.net/gh/iconfu/svg-inject@v1.2.3/dist/svg-inject.min.js"></script> -->
                 <script src="{/fr:tree/@base-url}uts-forester.js"></script>
                 <script src="{/fr:tree/@base-url}uts-ondemand.js"></script>
-                <!-- <script type="module" src="shiki.js"></script>
-        <script type="module" src="glsl.js"></script> -->
             </head>
             <body>
                 <ninja-keys placeholder="Start typing a note title or ID"></ninja-keys>
@@ -94,9 +89,6 @@
                 </header>
 
                 <div id="grid-wrapper">
-                    <blockquote>
-                        NOTE: This site has just upgraded to Forester 5.x and is still having some style and functionality <span class="link external"><a href="https://github.com/utensil/forest/issues/9">issues</a></span>, we will fix them ASAP.
-                    </blockquote>
                     <article>
                         <xsl:apply-templates select="fr:tree" />
                     </article>

--- a/assets/uts-overrides.xsl
+++ b/assets/uts-overrides.xsl
@@ -7,29 +7,6 @@
     xmlns:fr="http://www.forester-notes.org"
     xmlns:html="http://www.w3.org/1999/xhtml"
 >
-
-    <!-- <xsl:template name="numbered-taxon">
-        <span class="taxon">
-            <xsl:apply-templates select="fr:taxon" />
-            <xsl:if test="count(ancestor::*) > 1 and (not(ancestor-or-selfr::fr:tree[@numbered='false' or
-    @toc='false']) and count(../../fr:tree) >= 1) or fr:number">
-                <xsl:if test="fr:taxon">
-                    <xsl:text>&#160;</xsl:text>
-                </xsl:if>
-                <xsl:choose>
-                    <xsl:when test="fr:number">
-                        <xsl:value-of select="fr:number" />
-                    </xsl:when>
-                    <xsl:otherwise>
-                        <xsl:number format="1.1" count="fr:tree[ancestor::fr:tree and not(@toc='false') and
-    not(@numbered='false')]" level="multiple" />
-                    </xsl:otherwise>
-                </xsl:choose>
-                <xsl:text>.&#160;</xsl:text>
-            </xsl:if>
-        </span>
-    </xsl:template> -->
-
     <xsl:template name="splitlean">
         <xsl:param name="pText" select="." />
         <xsl:param name="sep" select="." />
@@ -173,35 +150,11 @@
         </li>
     </xsl:template>
 
-    <!-- <xsl:template match="html:span[@class='todo']" mode="render">
-        <span class="rendered-todo">
-            <xsl:apply-templates />
-        </span>
-    </xsl:template> -->
     <xsl:template match="html:span[@class='todo']">
         <span class="todo">
             <xsl:apply-templates />
         </span>
     </xsl:template>
-
-    <!-- <xsl:template match="html:div[@class='embeded-shader']">
-        <xsl:element namespace="http://www.w3.org/1999/xhtml" name="{local-name()}">
-        <xsl:apply-templates select="@* | node()" />
-        </xsl:element>
-    </xsl:template> -->
-
-    <!-- uts-begin: extend mainmatter -->
-    <!-- <xsl:template match="fr:mainmatter">
-        <div class="tree-content">
-            <xsl:if test="../*/html:span[@class='todo']">
-                <xsl:for-each select="../*/html:span[@class='todo']">
-                    <xsl:apply-templates select="." mode="render" />
-                </xsl:for-each>
-            </xsl:if>
-            <xsl:apply-templates />
-        </div>
-    </xsl:template> -->
-    <!-- uts-end -->
 
     <xsl:template match="fr:resource">
         <xsl:apply-templates select="fr:resource-content" />
@@ -262,17 +215,5 @@
         <xsl:text>]]))</xsl:text>
     </xsl:template>
 
-    <!-- A simple hack to make fr:tex pass through markdown-it, but not handling more escape cases
-    yet -->
-    <!-- <xsl:template match="html:div[@class='markdownit grace-loading']//fr:tex[@display='block']">
-    <xsl:text>\\[</xsl:text>
-    <xsl:value-of select="." />
-    <xsl:text>\\]</xsl:text>
-    </xsl:template>
-    <xsl:template match="html:div[@class='markdownit grace-loading']//fr:tex[not(@display='block')]">
-    <xsl:text>\\(</xsl:text>
-    <xsl:value-of select="." />
-    <xsl:text>\\)</xsl:text>
-    </xsl:template> -->
 
 </xsl:stylesheet>

--- a/assets/uts-overrides.xsl
+++ b/assets/uts-overrides.xsl
@@ -7,6 +7,29 @@
     xmlns:fr="http://www.forester-notes.org"
     xmlns:html="http://www.w3.org/1999/xhtml"
 >
+
+    <!-- <xsl:template name="numbered-taxon">
+        <span class="taxon">
+            <xsl:apply-templates select="fr:taxon" />
+            <xsl:if test="count(ancestor::*) > 1 and (not(ancestor-or-selfr::fr:tree[@numbered='false' or
+    @toc='false']) and count(../../fr:tree) >= 1) or fr:number">
+                <xsl:if test="fr:taxon">
+                    <xsl:text>&#160;</xsl:text>
+                </xsl:if>
+                <xsl:choose>
+                    <xsl:when test="fr:number">
+                        <xsl:value-of select="fr:number" />
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:number format="1.1" count="fr:tree[ancestor::fr:tree and not(@toc='false') and
+    not(@numbered='false')]" level="multiple" />
+                    </xsl:otherwise>
+                </xsl:choose>
+                <xsl:text>.&#160;</xsl:text>
+            </xsl:if>
+        </span>
+    </xsl:template> -->
+
     <xsl:template name="splitlean">
         <xsl:param name="pText" select="." />
         <xsl:param name="sep" select="." />
@@ -150,11 +173,35 @@
         </li>
     </xsl:template>
 
+    <!-- <xsl:template match="html:span[@class='todo']" mode="render">
+        <span class="rendered-todo">
+            <xsl:apply-templates />
+        </span>
+    </xsl:template> -->
     <xsl:template match="html:span[@class='todo']">
         <span class="todo">
             <xsl:apply-templates />
         </span>
     </xsl:template>
+
+    <!-- <xsl:template match="html:div[@class='embeded-shader']">
+        <xsl:element namespace="http://www.w3.org/1999/xhtml" name="{local-name()}">
+        <xsl:apply-templates select="@* | node()" />
+        </xsl:element>
+    </xsl:template> -->
+
+    <!-- uts-begin: extend mainmatter -->
+    <!-- <xsl:template match="fr:mainmatter">
+        <div class="tree-content">
+            <xsl:if test="../*/html:span[@class='todo']">
+                <xsl:for-each select="../*/html:span[@class='todo']">
+                    <xsl:apply-templates select="." mode="render" />
+                </xsl:for-each>
+            </xsl:if>
+            <xsl:apply-templates />
+        </div>
+    </xsl:template> -->
+    <!-- uts-end -->
 
     <xsl:template match="fr:resource">
         <xsl:apply-templates select="fr:resource-content" />
@@ -215,5 +262,17 @@
         <xsl:text>]]))</xsl:text>
     </xsl:template>
 
+    <!-- A simple hack to make fr:tex pass through markdown-it, but not handling more escape cases
+    yet -->
+    <!-- <xsl:template match="html:div[@class='markdownit grace-loading']//fr:tex[@display='block']">
+    <xsl:text>\\[</xsl:text>
+    <xsl:value-of select="." />
+    <xsl:text>\\]</xsl:text>
+    </xsl:template>
+    <xsl:template match="html:div[@class='markdownit grace-loading']//fr:tex[not(@display='block')]">
+    <xsl:text>\\(</xsl:text>
+    <xsl:value-of select="." />
+    <xsl:text>\\)</xsl:text>
+    </xsl:template> -->
 
 </xsl:stylesheet>

--- a/trees/ag-0001.tree
+++ b/trees/ag-0001.tree
@@ -14,7 +14,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-0002.tree
+++ b/trees/ag-0002.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\card{remark}{the grand plan}{
+\card{Remark}{the grand plan}{
 \p{We will use \citek{kriz2021introduction} as a holistic guide to the organization of materials, which has done a great job of having the minimal prerequisites, being self-contained, and covering most of the topics that concern us, including the geometric motivation.
 }
 

--- a/trees/ag-0003.tree
+++ b/trees/ag-0003.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-0004.tree
+++ b/trees/ag-0004.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-0005.tree
+++ b/trees/ag-0005.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-0006.tree
+++ b/trees/ag-0006.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-0007.tree
+++ b/trees/ag-0007.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals
 
-\refcardt{remark}{polynomial ring}{1.1.3}{cox1997ideals}{
+\refcardt{Remark}{polynomial ring}{1.1.3}{cox1997ideals}{
 \p{
 Under addition and multiplication, #{R\left[x_1, \ldots, x_n\right]} satisfies all axioms of a commutative ring, and for this reason we will refer to #{R\left[x_1, \ldots, x_n\right]} as a \newvocab{polynomial ring}.
 }

--- a/trees/ag-0008.tree
+++ b/trees/ag-0008.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals
 
-\refcardt{convention}{rings and fields}{0.1}{gathmann2013commutative}{
+\refcardt{Convention}{rings and fields}{0.1}{gathmann2013commutative}{
 
 \p{A ring, usually denoted #{R}, is always assumed to be a \newvocab{commutative ring} (i.e. #{a+b=b+a} and #{a b=b a} for all #{ a, b \in R}) with 1 (i.e. the multiplicative identity element, or called multiplicative unit).
 }

--- a/trees/ag-0009.tree
+++ b/trees/ag-0009.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{formal variable, formal expression}{
+\card{Definition}{formal variable, formal expression}{
 \p{A \newvocab{formal variable} is an arbitrary symbol that is used to represent some mathematical object, and assumes nothing about the value or nature of the object.
 }
 

--- a/trees/ag-000A.tree
+++ b/trees/ag-000A.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000B.tree
+++ b/trees/ag-000B.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000C.tree
+++ b/trees/ag-000C.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative
 
-\title{drafts for [[ag-0001]]}
+\title{Drafts for [[ag-0001]]}
 
 \scope{
     \put\transclude/toc{true}

--- a/trees/ag-000C.tree
+++ b/trees/ag-000C.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000D.tree
+++ b/trees/ag-000D.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000E.tree
+++ b/trees/ag-000E.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\refcardt{remark}{affine v.s. projective}{ch. 2}{michalek2021invitation}{
+\refcardt{Remark}{affine v.s. projective}{ch. 2}{michalek2021invitation}{
 \p{The prefix "affine" of \vocab{affine variety} is used to distinguish it from a \vocab{projective variety}. Affine varieties arise from arbitrary polynomials, while projective varieties arise from systems of \em{homogeneous} polynomials, i.e. linear combinations of monomials of fixed degree.
 }
 

--- a/trees/ag-000F.tree
+++ b/trees/ag-000F.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
@@ -32,7 +32,7 @@
 }
 }
 
-\card{example}{varieties}{
+\card{Example}{varieties}{
 
 % \p{#{\mathbf{V}\left(x^3-y\right)}:}
 

--- a/trees/ag-000G.tree
+++ b/trees/ag-000G.tree
@@ -11,7 +11,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000H.tree
+++ b/trees/ag-000H.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000I.tree
+++ b/trees/ag-000I.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{signed distance function \citewiki{sdf}{Signed_distance_function}}{
+\card{Definition}{signed distance function \citewiki{sdf}{Signed_distance_function}}{
 
 \p{
 Let #{\Omega} be a subset of a [metric space](https://en.wikipedia.org/wiki/Metric_space) #{X} with metric #{d}, and #{\partial \Omega} be its boundary. The distance between a point #{\point{p}} of #{X} and the subset #{\partial \Omega} of #{X} is defined as usual as

--- a/trees/ag-000J.tree
+++ b/trees/ag-000J.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{convention}{sign}{
+\card{Convention}{sign}{
 \p{Simply put, SDFs are the minimum possible distance from a point to an implicit surface defined by #{f(\point{p})=0}.}
 
 \p{The convention adopted in this note is that the #{+} and #{-} signs indicate whether the point is outside or inside the surface, respectively, so that when a ray marches towards the surface from the outside, the distance is positive, becomes smaller when approaching the surface.

--- a/trees/ag-000K.tree
+++ b/trees/ag-000K.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000L.tree
+++ b/trees/ag-000L.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere
 
-\card{example}{SDF of a sphere}{
+\card{Example}{SDF of a sphere}{
 \p{The SDF of a sphere with radius #{r} centered at the origin #{\point{o}} is
 ##{
 f(\point{p})=\norm{\point{p}}-r

--- a/trees/ag-000N.tree
+++ b/trees/ag-000N.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000O.tree
+++ b/trees/ag-000O.tree
@@ -3,9 +3,9 @@
 % clifford hopf spin tt ag math draft cg
 \tag{cg}
 
-\taxon{figure}
+\taxon{Figure}
 
-\title{ray marching (naïve)}
+\title{Ray marching (naïve)}
 
 \let\ball/screen{
   \patch{\ball/new}{

--- a/trees/ag-000P.tree
+++ b/trees/ag-000P.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000Q.tree
+++ b/trees/ag-000Q.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere
 
-\card{remark}{ }{
+\card{Remark}{ }{
 \p{\ref{ag-000U} means that \vocab{sphere tracing} requires the function to be Lipschitz, i.e. has a known \vocab{Lipschitz bound}.
 }
 \p{Not all functions are \vocab{Lipschitz}, e.g. Harmonic Functions are not globally Lipschitz, many may have no local \vocab{Lipschitz bound} even within small neighborhoods, thus requires a new technique named \newvocab{Harnack tracing} developed in \citek{gillespie2024ray}.

--- a/trees/ag-000R.tree
+++ b/trees/ag-000R.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000S.tree
+++ b/trees/ag-000S.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000T.tree
+++ b/trees/ag-000T.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray
 
-\refcardt{theorem}{ }{thm. 1}{gillespie2024ray}{
+\refcardt{Theorem}{ }{thm. 1}{gillespie2024ray}{
 
 \p{
 Let #{f} be Lipschitz with Lipschitz bound #{\lambda \geq} Lip #{f}. Then the function #{f / \lambda} is a \vocab{signed distance bound} of its implicit surface.

--- a/trees/ag-000U.tree
+++ b/trees/ag-000U.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray
 
-\refcardt{theorem}{ }{thm. 2}{gillespie2024ray}{
+\refcardt{Theorem}{ }{thm. 2}{gillespie2024ray}{
 
 \p{
 Given a function #{F: \mathbb{R} \rightarrow \mathbb{R}} with Lipschitz bound #{\lambda \geq} Lip #{F}, and an initial point #{t_0}, \vocab{sphere tracing} converges linearly to the smallest root greater than #{t_0}.

--- a/trees/ag-000V.tree
+++ b/trees/ag-000V.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000W.tree
+++ b/trees/ag-000W.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000X.tree
+++ b/trees/ag-000X.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-000Y.tree
+++ b/trees/ag-000Y.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{definition}{level set \citewiki{level-set}{https://en.wikipedia.org/wiki/Level_set}}{
+\card{Definition}{level set \citewiki{level-set}{https://en.wikipedia.org/wiki/Level_set}}{
 A \newvocab{level set} of a real-valued function #{f} (a.k.a. an iso-contour of a scalar field in 3D)
 
 ##{L_c(f)=\left\{\point{x} \mid \forall \point{x} \in X, f(\point{x})=c  \right\} }

--- a/trees/ag-0011.tree
+++ b/trees/ag-0011.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere
 
-\card{example}{SDFs of geometric primitives}{
+\card{Example}{SDFs of geometric primitives}{
 \p{SDFs of some geometric primitives in #{\RR^3}, can be found in \em{Appendix A: Distance to Natural Quadrics and Torus} of \citek{hart1996sphere}.}
 
 \p{Many more can be found in Inigo Quilez's article [Distance functions](https://iquilezles.org/articles/distfunctions/) (written in [GLSL](https://en.wikipedia.org/wiki/OpenGL_Shading_Language)), which also includes an example that renders them by ray-marching.

--- a/trees/ag-0012.tree
+++ b/trees/ag-0012.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{remark}{SDFs in a Euclidean space}{
+\card{Remark}{SDFs in a Euclidean space}{
 \p{If #{X} is also a normed space, i.e. for a point #{\point{p} \in X}, its [norm](https://en.wikipedia.org/wiki/Norm_(mathematics)) can be defined, e.g. in a Euclidean space #{\RR^n} where #{\point{p}} can be expressed by basis vectors as #{(p_1, \ldots, p_n)}, then its norm #{\norm{\point{p}}} can be defined as the Euclidean norm
 
 ##{

--- a/trees/ag-0013.tree
+++ b/trees/ag-0013.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{example}{SDFs of exotic implicit surfaces}{
+\card{Example}{SDFs of exotic implicit surfaces}{
 \p{SDFs of many exotic implicit surfaces can be found in:
 \ul{
   \li{\em{Appendix A: Implicit Equations} in \citek{singh2009real}}

--- a/trees/ag-0014.tree
+++ b/trees/ag-0014.tree
@@ -1,6 +1,6 @@
 \import{macros}
 % clifford hopf spin tt ag math draft tech exp
-\taxon{figure}
+\taxon{Figure}
 
 \note{test implicit surface shader 3}{
 

--- a/trees/ag-0015.tree
+++ b/trees/ag-0015.tree
@@ -1,6 +1,6 @@
 \import{macros}
 % clifford hopf spin tt ag math draft tech exp
-\taxon{figure}
+\taxon{Figure}
 
 \note{test implicit surface shader 4}{
 

--- a/trees/ag-0016.tree
+++ b/trees/ag-0016.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{example}{SDFs of implicit surfaces in exotic geometries}{
+\card{Example}{SDFs of implicit surfaces in exotic geometries}{
 
 \p{Implicit surface could be defined in geometries other than Euclidean space, for some examples of such geometries, see \citek{szirmay2022adapting} \citek{coulon2022ray} \citek{kopczynski2022real} and more.
 }

--- a/trees/ag-0017.tree
+++ b/trees/ag-0017.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt ag math draft cg
 \tag{cg}
 
-\taxon{figure}
+\taxon{Figure}
 
 \title{SDF for a sphere}
 

--- a/trees/ag-0018.tree
+++ b/trees/ag-0018.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
@@ -26,7 +26,7 @@
 \def\eps{\varepsilon}
 \def\tmax{t_{\max}}
 
-\card{algorithm}{ray marching (naïve)}{
+\card{Algorithm}{ray marching (naïve)}{
 \minialg{
 % \begin{algorithm*}{Ray marching (naive)}{}
 \alg/input{$\ro \in \RR^3$, ray origin}

--- a/trees/ag-0019.tree
+++ b/trees/ag-0019.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{example}{ray marching (naïve)}{
+\card{Example}{ray marching (naïve)}{
 
 \p{The following renders a scene with a unit sphere at the origin, the camera at #{(0,0,8)} and looking at the origin, through a screen of height 1.0, centered at 5.0 from the camera.
 }

--- a/trees/ag-001A.tree
+++ b/trees/ag-001A.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{definition}{ray}{
+\card{Definition}{ray}{
 \p{A \newvocab{ray} is a half-line that starts at a point and extends indefinitely in one direction.
 }
 

--- a/trees/ag-001B.tree
+++ b/trees/ag-001B.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{definition}{ray marching (naïve)}{
+\card{Definition}{ray marching (naïve)}{
 \p{The \newvocab{ray marching (naïve)} algorithm is to march a ray by a \em{fixed step size}, check if a \vocab{ray intersection} occurs at each step, until the ray reaches a maximum distance or step count.
 }
 

--- a/trees/ag-001C.tree
+++ b/trees/ag-001C.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{definition}{ray marching}{
+\card{Definition}{ray marching}{
 \p{To render a scene, the \newvocab{Ray marching} algorithm marches a ray from an origin towards a direction. At each step, the algorithm marches a short (possibly changing) distance and checks if a \vocab{ray intersection} occurs. This process continues until a \em{stopping condition} is met. The information obtained from the ray intersection is then used to determine the color of a pixel on the screen.
 }
 }

--- a/trees/ag-001D.tree
+++ b/trees/ag-001D.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{example}{ray-marching for different types of rays}{
+\card{Example}{ray-marching for different types of rays}{
 
 \p{A \vocab{view ray} has the origin at the camera, the direction is determined by the pixel on the screen that it passes through. It may intersect with a surface in the scene, and the information obtained from the intersection is used to determine the color of the corresponding pixel on the screen.}
 

--- a/trees/ag-001E.tree
+++ b/trees/ag-001E.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{remark}{ray-casting/ray-tracing/ray-marching}{
+\card{Remark}{ray-casting/ray-tracing/ray-marching}{
 \p{The \newvocab{ray-casting}/\newvocab{ray-tracing}/\newvocab{ray-marching} algorithms simply apply one of the multitude of root finding methods to solve the \vocab{ray intersection} equation.
 }
 

--- a/trees/ag-001F.tree
+++ b/trees/ag-001F.tree
@@ -3,9 +3,9 @@
 % clifford hopf spin tt ag math draft cg
 \tag{cg}
 
-\taxon{figure}
+\taxon{Figure}
 
-\title{ray marching}
+\title{Ray marching}
 
 \let\ball/screen{
   \patch{\ball/new}{

--- a/trees/ag-001G.tree
+++ b/trees/ag-001G.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{remark}{ }{
+\card{Remark}{ }{
 \p{By convention, the GLSL community uses two-to-three letter variable names. Here are some common abbreviations:}
 
 \ul{

--- a/trees/ag-001H.tree
+++ b/trees/ag-001H.tree
@@ -3,9 +3,9 @@
 % clifford hopf spin tt ag math draft cg
 \tag{cg}
 
-\taxon{figure}
+\taxon{Figure}
 
-\title{sphere tracing}
+\title{Sphere tracing}
 
 \let\point/camera{
   \patch{\point/new}{

--- a/trees/ag-001I.tree
+++ b/trees/ag-001I.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ag-001J.tree
+++ b/trees/ag-001J.tree
@@ -2,9 +2,9 @@
 % clifford hopf spin tt ag math draft cg
 \tag{cg}
 
-\taxon{figure}
+\taxon{Figure}
 
-\title{raymarching in raymarching (sphere tracing)}
+\title{Raymarching in raymarching (sphere tracing)}
 
 \figure{
 % iTime-8.921700000047593 debug

--- a/trees/ca-0003.tree
+++ b/trees/ca-0003.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark
 % \taxon{}
-\card{definition}{Bilinear form}{
+\card{Definition}{Bilinear form}{
     \label{BilinForm}
     \leanok
     \lean{BilinForm}

--- a/trees/ca-0005.tree
+++ b/trees/ca-0005.tree
@@ -5,6 +5,6 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark
-\taxon{remark}
+\taxon{Remark}
 
 \p{This notion generalizes to commutative semirings using the approach in \citek{izhakian2016supertropical}.}

--- a/trees/ca-0007.tree
+++ b/trees/ca-0007.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark
-\taxon{remark}
+\taxon{Remark}
 % \texnote{}{}{
 % }
 

--- a/trees/ca-0008.tree
+++ b/trees/ca-0008.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark
-\taxon{remark}
+\taxon{Remark}
 % \texnote{}{}{
 % }
 

--- a/trees/ca-0009.tree
+++ b/trees/ca-0009.tree
@@ -10,7 +10,7 @@
 % }
 
 \title{Clifford algebra over a vector space}
-\taxon{example}
+\taxon{Example}
 
 \p{Let #{V} be a vector space #{\RR^n} over #{\RR}, equipped with a quadratic form #{Q}.}
   

--- a/trees/ca-000C.tree
+++ b/trees/ca-000C.tree
@@ -8,7 +8,7 @@
 % \taxon{}
 % \texnote{}{}{
 % }
-\taxon{theorem}
+\taxon{Theorem}
 \refnote{Universal property}{wieser2022formalizing}{
 \p{
   \label{univ}

--- a/trees/ca-000D.tree
+++ b/trees/ca-000D.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark
-\taxon{remark}
+\taxon{Remark}
 
 \p{The universal property of the Clifford algebras is now proven, and should be used instead of the definition
 that is subject to change.}

--- a/trees/ca-000H.tree
+++ b/trees/ca-000H.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark
-\taxon{convention}
+\taxon{Convention}
 \refnote{ }{wieser2022formalizing}{
 \p{
 Same as the previous section, let #{M} be a module over a commutative ring #{R}, equipped with a quadratic form #{Q: M \to R}.}

--- a/trees/ca-000O.tree
+++ b/trees/ca-000O.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 %
 
-\card{convention}{definition style}{
+\card{Convention}{definition style}{
 
 \p{
 In this document, we unify the informal mathematical language for a definition to:}

--- a/trees/ca-000P.tree
+++ b/trees/ca-000P.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ca-000Q.tree
+++ b/trees/ca-000Q.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % jadczyk2019notes garling2011clifford chen2016infinitely
 % hestenes2012clifford wieser2022formalizing wieser2024formalizing wieser2024blueprint

--- a/trees/ca-000R.tree
+++ b/trees/ca-000R.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{ }{
+\card{Remark}{ }{
 
 \p{
     It then follows that #{1}, the \newvocab{identity} element, is unique, and that for each #{g \in G} the \vocab{inverse} #{g^{-1}} is unique.

--- a/trees/ca-000S.tree
+++ b/trees/ca-000S.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{notation}{product}{
+\card{Notation}{product}{
 \p{
 In literatures, the binary operation of a group is usually called a product. It's denoted by juxtaposition #{g h}, and is understood to be a mapping
 #{(g, h) \mapsto g * h} from #{G \times G} to #{G}.

--- a/trees/ca-000T.tree
+++ b/trees/ca-000T.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{monoid}{
+\card{Definition}{monoid}{
 
 \p{
     \label{Monoid}

--- a/trees/ca-000U.tree
+++ b/trees/ca-000U.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ca-000V.tree
+++ b/trees/ca-000V.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{ }{
+\card{Remark}{ }{
 \p{
 In applications to Clifford algebras #{R} will be always assumed to be \vocab{commutative}.
 }

--- a/trees/ca-000W.tree
+++ b/trees/ca-000W.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{division ring}{
+\card{Definition}{division ring}{
 
 \p{
     \label{DivisionRing}

--- a/trees/ca-000X.tree
+++ b/trees/ca-000X.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ca-000Y.tree
+++ b/trees/ca-000Y.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{ }{
+\card{Remark}{ }{
 
 \p{
     The notation of scalar multiplication is generalized as heterogeneous scalar multiplication \MathlibDoc{HMul} in \Mathlib:

--- a/trees/ca-000Z.tree
+++ b/trees/ca-000Z.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ca-0010.tree
+++ b/trees/ca-0010.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{ }{
+\card{Remark}{ }{
 \label{mk:VectorSpace}
 \p{
     For generality, \Mathlib uses \MathlibDoc{Module} throughout for vector spaces,

--- a/trees/ca-0011.tree
+++ b/trees/ca-0011.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{submodule}{
+\card{Definition}{submodule}{
 
 \p{
     \label{mk:Submodule}

--- a/trees/ca-0012.tree
+++ b/trees/ca-0012.tree
@@ -7,13 +7,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{dual module}{
+\card{Definition}{dual module}{
 \p{
     \label{Dual}
     \leanok

--- a/trees/ca-0013.tree
+++ b/trees/ca-0013.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ca-0014.tree
+++ b/trees/ca-0014.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/ca-0015.tree
+++ b/trees/ca-0015.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{isomorphism, endomorphism, automorphism}{
+\card{Definition}{isomorphism, endomorphism, automorphism}{
     \label{mk:homomorphism}
 
 \p{\newvocab{Isomorphism} #{A \cong B} is a bijective \vocab{homomorphism} #{\phi : A \to B}

--- a/trees/ca-0016.tree
+++ b/trees/ca-0016.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{algebra}{
+\card{Definition}{algebra}{
 \p{
 \label{Algebra}
 \leanok

--- a/trees/ca-0017.tree
+++ b/trees/ca-0017.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{notation}{ }{
+\card{Notation}{ }{
 \p{
 \label{mk:AlgebraNotation}
 

--- a/trees/ca-0018.tree
+++ b/trees/ca-0018.tree
@@ -6,9 +6,9 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
-\card{remark}{ }{
+\card{Remark}{ }{
 
 \p{
 \label{mk:AlgebraLiterature}

--- a/trees/ca-0019.tree
+++ b/trees/ca-0019.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{ }{
+\card{Remark}{ }{
 \p{
 \label{mk:AlgebraName}
 

--- a/trees/ca-001A.tree
+++ b/trees/ca-001A.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{algebra homomorphism}{
+\card{Definition}{algebra homomorphism}{
 
 \p{
 \label{AlgHom}

--- a/trees/ca-001B.tree
+++ b/trees/ca-001B.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{ring quotient}{
+\card{Definition}{ring quotient}{
 
 \p{
 \label{RingQuot}

--- a/trees/ca-001C.tree
+++ b/trees/ca-001C.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{ }{
+\card{Remark}{ }{
 
 \p{
 As ideals haven't been formalized for the non-commutative case, \Mathlib uses \MathlibDoc{RingQuot} in places

--- a/trees/ca-001D.tree
+++ b/trees/ca-001D.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{free algebra}{
+\card{Definition}{free algebra}{
 
 \p{
 \label{FreeAlgebra}

--- a/trees/ca-001E.tree
+++ b/trees/ca-001E.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{ }{
+\card{Remark}{ }{
 
 \p{
 \label{mk:FreeAlgebra}

--- a/trees/ca-001F.tree
+++ b/trees/ca-001F.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{linear map}{
+\card{Definition}{linear map}{
 
 \p{
 \label{LinearMap}

--- a/trees/ca-001G.tree
+++ b/trees/ca-001G.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{Lin}{
+\card{Remark}{Lin}{
 \p{
 \label{mk:linearMap}
 

--- a/trees/ca-001H.tree
+++ b/trees/ca-001H.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{definition}{tensor algebra}{
+\card{Definition}{tensor algebra}{
 \p{
 \label{TensorAlgebra}
 \leanok

--- a/trees/ca-001I.tree
+++ b/trees/ca-001I.tree
@@ -6,13 +6,13 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
 % cox1997ideals gathmann2013commutative
 
-\card{remark}{ }{
+\card{Remark}{ }{
 \label{mk:TensorAlgebra}
 \p{
 The definition above is equivalent to the following definition in literature (e.g. \citet{1.7}{jadczyk2019notes}):}

--- a/trees/ca-001J.tree
+++ b/trees/ca-001J.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % james2001representations woit2017quantum lux2010representations sims1994computation wilson2024discrete hamilton2023supergeometric hamilton2023unification
 

--- a/trees/ca-001K.tree
+++ b/trees/ca-001K.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative
 
-\title{drafts for [[ca-0001]]}
+\title{Drafts for [[ca-0001]]}
 
 \scope{
   % \put\transclude/toc{true}

--- a/trees/ca-001K.tree
+++ b/trees/ca-001K.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/hopf-0003.tree
+++ b/trees/hopf-0003.tree
@@ -1,7 +1,7 @@
 \import{macros}
 \tag{hopf}
 
-\taxon{remark}
+\taxon{Remark}
 \refnote{Peano space}{fauser2002treatise}{
 \p{Of course, this structure is much weaker as e.g. a normed space or an inner product space. It does not allow to introduce the concept of length, distance or angle. Therefore it is clear that a geometry based on this structure cannot be metric. However, the bracket can be addressed as a volume form. Volume measurements are used e.g. in the analysis of chaotic systems and strange attractors.}
 }

--- a/trees/lm-0001.tree
+++ b/trees/lm-0001.tree
@@ -15,7 +15,7 @@ This is a placeholder root note, for now, see [[lm-0006]].
 
 \subtree{
 
-\title{drafts for [[lm-0001]]}
+\title{Drafts for [[lm-0001]]}
 
 \scope{
     \put\transclude/toc{true}

--- a/trees/lm-0007.tree
+++ b/trees/lm-0007.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % spinner2024lorentz
 

--- a/trees/macros.tree
+++ b/trees/macros.tree
@@ -300,11 +300,11 @@ so the text size almost matches the size output by native forester code. This do
 
 \p{\code{refdef[name][reference][body]}: A definition with a reference.}
 
-\def\refdef[name][reference][body]{\refcard{definition}{\name}{\reference}{\body}}
+\def\refdef[name][reference][body]{\refcard{Definition}{\name}{\reference}{\body}}
 
 \p{\code{refdeft[name][tid][reference][body]}: A definition with a reference to a definition/theorem/page.}
 
-\def\refdeft[name][tid][reference][body]{\refcardt{definition}{\name}{\tid}{\reference}{\body}}
+\def\refdeft[name][tid][reference][body]{\refcardt{Definition}{\name}{\tid}{\reference}{\body}}
 
 \p{\code{texdef[name][reference][body]}: A \code{minitex} definition with a reference.}
 

--- a/trees/macros.tree
+++ b/trees/macros.tree
@@ -1,4 +1,4 @@
-\title{basic macros}
+\title{Basic macros}
 \tag{macro}
 
 \import{latex-preamble}
@@ -68,7 +68,7 @@
    \put\transclude/toc{false}
    %  \put\transclude/expanded{false}
    \subtree{
-     \taxon{proof}
+     \taxon{Proof}
      \body
    }
  }
@@ -122,71 +122,71 @@
 
 \def\make-topic-bibliography[topic]{
   \subtree{
-   \title{accepted papers}
+   \title{Accepted papers}
    \query{
     \open\query
-    \isect{\tag{\topic}}{\taxon{reference}}{\tag{accepted}}
+    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{accepted}}
    }
   }
 
   \subtree{
-   \title{refereed papers}
+   \title{Refereed papers}
    \query{
     \open\query
-    \isect{\tag{\topic}}{\taxon{reference}}{\tag{refereed}}
+    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{refereed}}
    }
   }
 
   \subtree{
-   \title{manuscripts}
+   \title{Manuscripts}
    \query{
     \open\query
-    \isect{\tag{\topic}}{\taxon{reference}}{\tag{preprint}}{\compl{\tag{accepted}}}
+    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{preprint}}{\compl{\tag{accepted}}}
    }
   }
 
   \subtree{
-   \title{dissertations}
+   \title{Dissertations}
    \query{
     \open\query
-    \isect{\tag{\topic}}{\taxon{reference}}{\tag{dissertation}}
+    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{dissertation}}
    }
   }
 
   \subtree{
-   \title{technical reports}
+   \title{Technical reports}
    \query{
     \open\query
-    \isect{\tag{\topic}}{\taxon{reference}}{\tag{techreport}}
+    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{techreport}}
    }
   }
 
   \subtree{
-   \title{presentations}
+   \title{Presentations}
    \query{
     \open\query
     \isect{\tag{\topic}}{
      \union{
-      \isect{\tag{workshop}}{\taxon{reference}}
-     }{\taxon{presentation}}
+      \isect{\tag{workshop}}{\taxon{Reference}}
+     }{\taxon{Presentation}}
     }
    }
   }
 
 
   \subtree{
-   \title{seminar talks}
+   \title{Seminar talks}
    \query{
     \open\query
-    \isect{\tag{\topic}}{\taxon{reference}}{\tag{seminar}}
+    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{seminar}}
    }
   }
 
   \subtree{
-   \title{roladex}
+   \title{Roladex}
    \query{
     \open\query
-    \isect{\taxon{person}}{\tag{\topic}}
+    \isect{\taxon{Person}}{\tag{\topic}}
    }
   }
 }
@@ -315,7 +315,7 @@ so the text size almost matches the size output by native forester code. This do
 \def\wikiref[name][citeid][pageid][year]{
   \title{\name - Wikipedia}
   \meta{external}{https://en.wikipedia.org/wiki/\pageid}
-  \taxon{reference}
+  \taxon{Reference}
   \meta{bibtex}{\startverb
 @misc{wiki\stopverb\year\citeid\startverb,
   title  = {\stopverb\name - Wikipedia\startverb},
@@ -337,7 +337,7 @@ so the text size almost matches the size output by native forester code. This do
 \def\nlabref[name][citeid][pageid][year]{
   \title{\name - nLab}
   \meta{external}{https://ncatlab.org/nlab/show/\pageid}
-  \taxon{reference}
+  \taxon{Reference}
   \meta{bibtex}{\startverb
 @misc{nlab\stopverb\year\citeid\startverb,
   title  = {\stopverb\name - nLab\startverb},
@@ -361,7 +361,7 @@ so the text size almost matches the size output by native forester code. This do
   \def\prtitle{\prname}
   \title{\prtitle}
   \meta{external}{\prurl}
-  \taxon{reference}
+  \taxon{Reference}
   \meta{bibtex}{\startverb
 @misc{pr-\stopverb\citeid\startverb,
   title  = {\stopverb\prtitle\startverb},

--- a/trees/spin-0010.tree
+++ b/trees/spin-0010.tree
@@ -10,7 +10,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/spin-0011.tree
+++ b/trees/spin-0011.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/tt-0003.tree
+++ b/trees/tt-0003.tree
@@ -6,7 +6,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{notation}{hom-set, hom-class}{1.2}{zhang2021type}{
+\refcardt{Notation}{hom-set, hom-class}{1.2}{zhang2021type}{
 
 \p{#{\Hom} in #{\Hom_{\C}(X, Y)} is short for [homomorphism](https://en.wikipedia.org/wiki/Homomorphism), since an arrow in category theory is a [morphism](https://en.wikipedia.org/wiki/Morphism) (i.e. an arrow), a generalization of homomorphism between algebraic structures.}
 

--- a/trees/tt-0004.tree
+++ b/trees/tt-0004.tree
@@ -7,7 +7,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{notation}{string diagrams: category, object and arrow}{sec. 2.1}{marsden2014category}{
+\refcardt{Notation}{string diagrams: category, object and arrow}{sec. 2.1}{marsden2014category}{
 
 \p{
   Later, when we have learned about [functor](tt-0014)s and [natural transformation](tt-001E)s, we will see that, in \vocabk{string diagram}{tt-003V} for 1-category:

--- a/trees/tt-0007.tree
+++ b/trees/tt-0007.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\taxon{notation}\refdeft{commuting diagram}{1.2}{kostecki2011introduction}{
+\taxon{Notation}\refdeft{commuting diagram}{1.2}{kostecki2011introduction}{
 
 \p{A \newvocab{diagram} in a category #{\C} is defined as a collection of objects and arrows that belong to the category #{\C} with specified operations #{\dom} and #{\cod}.
 }

--- a/trees/tt-000A.tree
+++ b/trees/tt-000A.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\taxon{definition}
+\taxon{Definition}
 
 \title{}
 

--- a/trees/tt-000E.tree
+++ b/trees/tt-000E.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{Iso}{2.4}{kostecki2011introduction}{
+\refcardt{Lemma}{Iso}{2.4}{kostecki2011introduction}{
 
 \p{An iso arrow is always monic and epic. However, not every arrow which is monic and epic is also iso.}
 

--- a/trees/tt-000F.tree
+++ b/trees/tt-000F.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{isomorphism}
+\title{Isomorphism}
 
 \transclude{tt-000B}
 

--- a/trees/tt-000G.tree
+++ b/trees/tt-000G.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{special objects and categories}
+\title{Special objects and categories}
 
 \transclude{tt-000I}
 

--- a/trees/tt-000J.tree
+++ b/trees/tt-000J.tree
@@ -5,9 +5,9 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\taxon{convention}
+\taxon{Convention}
 
-\title{uniqueness: dashed arrow}
+\title{Uniqueness: dashed arrow}
 
 \p{Uniqueness of an arrow is denoted #{\exists ! f} or simply #{!f}, and visualized as a \vocab{dashed arrow} in diagrams, and #{!} is often omitted.}
 

--- a/trees/tt-000K.tree
+++ b/trees/tt-000K.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{Uniqueness}{2.7}{kostecki2011introduction}{
+\refcardt{Lemma}{Uniqueness}{2.7}{kostecki2011introduction}{
 
 \p{All \vocab{initial object}s in a category are isomorphic.}
 

--- a/trees/tt-000L.tree
+++ b/trees/tt-000L.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt math draft
 \tag{tt}
 
-\title{drafts for [[tt-0001]]}
+\title{Drafts for [[tt-0001]]}
 
 \scope{
   % \put\transclude/toc{true}

--- a/trees/tt-000P.tree
+++ b/trees/tt-000P.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{basic types of diagrams}
+\title{Basic types of diagrams}
 
 \p{By "basic types of diagrams", we mean some basic structures \em{inside} a category.}
 

--- a/trees/tt-000S.tree
+++ b/trees/tt-000S.tree
@@ -5,8 +5,8 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\taxon{convention}
+\taxon{Convention}
 
-\title{grey arrow}
+\title{Grey arrow}
 
 \p{We use \newvocab{grey arrow}s to represent the composition arrow in a \vocab{fork}. This convention is not from literatures and is subject to change.}

--- a/trees/tt-000T.tree
+++ b/trees/tt-000T.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{notation}{inclusion}{0.8}{leinster2016basic}{
+\refcardt{Notation}{inclusion}{0.8}{leinster2016basic}{
 
 \p{
 In

--- a/trees/tt-000U.tree
+++ b/trees/tt-000U.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{remark}{equalizing set}{eq. 32}{kostecki2011introduction}{
+\refcardt{Remark}{equalizing set}{eq. 32}{kostecki2011introduction}{
 \p{
 \vocab{Equalizer} in a category is a generalisation of a subset which consists of elements of a given set such that two given functions are equal on them, formally:}
 

--- a/trees/tt-000Z.tree
+++ b/trees/tt-000Z.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt math draft
 \tag{tt}
 
-\title{category theory}
+\title{Category theory}
 
 \transclude{tt-0005}
 

--- a/trees/tt-0010.tree
+++ b/trees/tt-0010.tree
@@ -5,9 +5,9 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\taxon{convention}
+\taxon{Convention}
 
-\title{letters}
+\title{Letters}
 
 \p{The general idea is that we try to use visually distinct letters for different concepts:}
 

--- a/trees/tt-0013.tree
+++ b/trees/tt-0013.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{functors}
+\title{Functors}
 
 \transclude{tt-0014}
 

--- a/trees/tt-0016.tree
+++ b/trees/tt-0016.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{example}{other special functors}{3.1, example 10, 11, 4.6}{kostecki2011introduction}{
+\refcardt{Example}{other special functors}{3.1, example 10, 11, 4.6}{kostecki2011introduction}{
 \p{Some other special functors are introduced in later sections in context, e.g. \vocabk{hom-functor}{tt-001S}, \vocabk{Yoneda embedding functors}{tt-002T}.
 }
 }

--- a/trees/tt-0019.tree
+++ b/trees/tt-0019.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{example}{full, faithful, preserve and reflect}{3.3}{kostecki2011introduction}{
+\refcardt{Example}{full, faithful, preserve and reflect}{3.3}{kostecki2011introduction}{
 
 \p{Every inclusion functor is faithful.}
 

--- a/trees/tt-001B.tree
+++ b/trees/tt-001B.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{universal arrow via initial/terminal object of comma category}{3.6}{kostecki2011introduction}{
+\refcardt{Lemma}{universal arrow via initial/terminal object of comma category}{3.6}{kostecki2011introduction}{
 
 \p{A universal arrow from #{X \in \D} to #{\fF : \C \to \D} is an [initial object](tt-000I) in the [comma category](tt-001C) #{X \downarrow \fF}.
 }

--- a/trees/tt-001D.tree
+++ b/trees/tt-001D.tree
@@ -5,9 +5,9 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\taxon{convention}
+\taxon{Convention}
 
-\title{functors}
+\title{Functors}
 
 \p{For simplicity, when there is no confusion, we use #{\bullet} to represent corresponding objects, and omit the arrow names in the codomain of a functor, e.g.
 

--- a/trees/tt-001G.tree
+++ b/trees/tt-001G.tree
@@ -200,7 +200,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{notation}{string diagrams: functor and natural transformation}{sec. 2}{marsden2014category}{
+\refcardt{Notation}{string diagrams: functor and natural transformation}{sec. 2}{marsden2014category}{
 \p{In \vocabk{string diagram}{tt-003V}s,}
 \ol{
   \li{A \newvocab{functor} #{\fF : \C \to \D} can be represented as an edge, commonly referred to as a wire:

--- a/trees/tt-001I.tree
+++ b/trees/tt-001I.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{natural isomorphism}{1.3.10}{leinster2016basic}{
+\refcardt{Lemma}{natural isomorphism}{1.3.10}{leinster2016basic}{
 
 \p{A \vocab{natural isomorphism} between functors from categories #{\C} and #{\D} is an isomorphism in the functor category #{[\C, \D]}.}
 

--- a/trees/tt-001M.tree
+++ b/trees/tt-001M.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{natural transformation and functor category}
+\title{Natural transformation and functor category}
 
 \transclude{tt-001E}
 

--- a/trees/tt-001P.tree
+++ b/trees/tt-001P.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{remark}{indexed, labelled}{4.5}{kostecki2011introduction}{
+\refcardt{Remark}{indexed, labelled}{4.5}{kostecki2011introduction}{
 \p{One can think of a functor category #{[\C, \D]} or #{\D^{\C}} as a category of diagrams in #{D} \newvocab{indexed} (or \newvocab{labelled}) by the objects from #{\C}.}
 
 \p{This particularly makes sense in a \vocabk{diagram}{tt-0025}.

--- a/trees/tt-001R.tree
+++ b/trees/tt-001R.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{remark}{adjoint functor}{5.1}{kostecki2011introduction}{
+\refcardt{Remark}{adjoint functor}{5.1}{kostecki2011introduction}{
 \p{An [adjunction](tt-001Q) #{\fL \dashv \fR} means arrows #{\fL(X) \to Y} are essentially the same thing as arrows #{X \to \fR(Y)} for any #{X \in \C} and #{Y \in \D}.
 }
 

--- a/trees/tt-001T.tree
+++ b/trees/tt-001T.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{adjunctions}
+\title{Adjunctions}
 
 \transclude{tt-001Q}
 

--- a/trees/tt-001U.tree
+++ b/trees/tt-001U.tree
@@ -86,7 +86,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{notation}{string diagrams: adjunction}{sec. 3.1}{nakahira2023diagrammatic}{
+\refcardt{Notation}{string diagrams: adjunction}{sec. 3.1}{nakahira2023diagrammatic}{
 
 \p{Here we follow the \vocabk{string diagram}{tt-003V} style of \citek{marsden2014category} and \citek{sterling2023models}, but with additional string diagram types inspired by \citet{eq. 3.1, 4.3}{nakahira2023diagrammatic}.}
 

--- a/trees/tt-001W.tree
+++ b/trees/tt-001W.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{universality of (co)unit}{5.3}{kostecki2011introduction}{
+\refcardt{Lemma}{universality of (co)unit}{5.3}{kostecki2011introduction}{
 
 \p{The unit #{\eta} and counit #{\epsilon} of an adjunction #{\fL \dashv \fR: \C \rightleftarrows \D} are [universal](tt-001A), i.e. the diagram
 

--- a/trees/tt-001Y.tree
+++ b/trees/tt-001Y.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{(co)unit and transposes}{2.2.4}{leinster2016basic}{
+\refcardt{Lemma}{(co)unit and transposes}{2.2.4}{leinster2016basic}{
 
 \p{Given an adjunction
 

--- a/trees/tt-001Z.tree
+++ b/trees/tt-001Z.tree
@@ -27,7 +27,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{triangle identities}{5.4}{kostecki2011introduction}{
+\refcardt{Lemma}{triangle identities}{5.4}{kostecki2011introduction}{
 
 \p{Given an adjunction #{\fL \dashv \fR: \C \rightleftarrows \D}, the diagrams 
 

--- a/trees/tt-0020.tree
+++ b/trees/tt-0020.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{(co)unit and natural isomorphism}{eq. 127}{kostecki2011introduction}{
+\refcardt{Lemma}{(co)unit and natural isomorphism}{eq. 127}{kostecki2011introduction}{
 
 \p{The natural transformation #{\sigma_{XY}} and #{\tau_{XY}} that are the components of the natural isomorphism in the adjunction #{\fL \dashv \fR : \C \rightleftarrows \D} are related to the unit and counit of the adjunction:
 

--- a/trees/tt-0021.tree
+++ b/trees/tt-0021.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{uniqueness of adjoints}{5.8}{kostecki2011introduction}{
+\refcardt{Lemma}{uniqueness of adjoints}{5.8}{kostecki2011introduction}{
 
 \p{A left or right adjoint, if it exists, is unique up to natural isomorphism.}
 

--- a/trees/tt-0022.tree
+++ b/trees/tt-0022.tree
@@ -15,6 +15,6 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\taxon{lemma}\title{representable functor and adjoint}
+\taxon{Lemma}\title{Representable functor and adjoint}
 
 \todo{[Lemma 4.24.2 in The Stacks project](https://stacks.math.columbia.edu/tag/0A8B).}

--- a/trees/tt-0023.tree
+++ b/trees/tt-0023.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{limits}
+\title{Limits}
 
 \transclude{tt-0024}
 

--- a/trees/tt-0024.tree
+++ b/trees/tt-0024.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{remark}{Limits}{ch. 5}{leinster2016basic}{
+\refcardt{Remark}{Limits}{ch. 5}{leinster2016basic}{
 
 \p{[Adjointness](tt-001T) is about the relationships \em{between} categories. [Representability](tt-002K) is a property of [\em{set-valued}](tt-001L) functors. \vocab{Limit}s are about what goes on \em{inside} a category.}
 

--- a/trees/tt-0029.tree
+++ b/trees/tt-0029.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{example}{a cone on a diagram}{4.9}{kostecki2011introduction}{
+\refcardt{Example}{a cone on a diagram}{4.9}{kostecki2011introduction}{
 
 \p{The cone for a diagram
 

--- a/trees/tt-002B.tree
+++ b/trees/tt-002B.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{example}{limits}{4.11, example 1-4}{kostecki2011introduction}{
+\refcardt{Example}{limits}{4.11, example 1-4}{kostecki2011introduction}{
 
 \p{The [basic types of diagrams](tt-000P) are actually examples of \vocab{limits}:}
 

--- a/trees/tt-002E.tree
+++ b/trees/tt-002E.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{remark}{cocone, colimit}{4.10}{kostecki2011introduction}{
+\refcardt{Remark}{cocone, colimit}{4.10}{kostecki2011introduction}{
 \p{A \newvocab{cocone} and a \newvocab{colimit} are defined by dualization, that is, by reversing the arrows in [[tt-0028]] and [[tt-002A]].
 }
 

--- a/trees/tt-002I.tree
+++ b/trees/tt-002I.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\refcardt{lemma}{(co)complete functor category}{4.15}{kostecki2011introduction}{
+\refcardt{Lemma}{(co)complete functor category}{4.15}{kostecki2011introduction}{
 \p{
 If category #{\D} is complete and category #{\C} is small, then the functor category #{\D^{\C}} is complete.}
 

--- a/trees/tt-002J.tree
+++ b/trees/tt-002J.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\refcardt{lemma}{(finitely) (co)complete category}{4.14}{kostecki2011introduction}{
+\refcardt{Lemma}{(finitely) (co)complete category}{4.14}{kostecki2011introduction}{
 \p{
 A category #{\C} is (finitely) complete if it has a terminal object, equalizers and (finite) products, or if it has a terminal object and (finite) pullbacks.}
 

--- a/trees/tt-002K.tree
+++ b/trees/tt-002K.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{representables}
+\title{Representables}
 
 \transclude{tt-002L}
 

--- a/trees/tt-002L.tree
+++ b/trees/tt-002L.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{remark}{}{}{}{
+% \refcardt{Remark}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{remark}{representables}{ch. 4, 4.1.15}{leinster2016basic}{
+\refcardt{Remark}{representables}{ch. 4, 4.1.15}{leinster2016basic}{
 \p{A category is a world of objects, all looking at one another. Each sees the world from a different viewpoint.}
 
 \p{We may ask: what objects \em{see}? Fix an object, this can be described by the arrows \em{from} it, this corresponds to the \newvocab{covariantly representable functor}.

--- a/trees/tt-002M.tree
+++ b/trees/tt-002M.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{remark}{}{}{}{
+% \refcardt{Remark}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{remark}{representation}{4.1.3, 4.1.17}{leinster2016basic}{
+\refcardt{Remark}{representation}{4.1.3, 4.1.17}{leinster2016basic}{
 \p{A \vocab{representation} #{(\tau, X)} of a \vocab{representable functor} #{\fF} is a \em{choice} of an object #{X \in \C} and an isomorphism #{\tau} between the corresponding type of \vocabk{hom-functor}{tt-001S} and #{\fF}.}
 
 \p{Representable functors are sometimes just called \newvocab{representables}. Only set-valued functors can be representable.}

--- a/trees/tt-002N.tree
+++ b/trees/tt-002N.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{lemma}{Yoneda}{4.2.1}{leinster2016basic}{
+\refcardt{Lemma}{Yoneda}{4.2.1}{leinster2016basic}{
 \p{
 Let #{\C} be a \vocabk{locally small}{tt-000A} category. Then
 ##{

--- a/trees/tt-002O.tree
+++ b/trees/tt-002O.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{adjunction preserves (co)limits}{6.3.1}{leinster2016basic}{
+\refcardt{Lemma}{adjunction preserves (co)limits}{6.3.1}{leinster2016basic}{
 \p{Given an adjunction #{\fL \dashv \fR: \C \rightleftarrows \D}, #{\fL} preserves colimits, and #{\fR} preserves limits.}
 
 \p{Explictly, given #{\fD: \J \to \C}, we have

--- a/trees/tt-002P.tree
+++ b/trees/tt-002P.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\title{interactions}
+\title{Interactions}
 
 \transclude{tt-0043}
 

--- a/trees/tt-002Q.tree
+++ b/trees/tt-002Q.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-002R.tree
+++ b/trees/tt-002R.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{remark}{}{}{}{
+% \refcardt{Remark}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-002S.tree
+++ b/trees/tt-002S.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic rosiak2022sheaf
 
-\refcardt{remark}{Yoneda philosophy}{sec. 6.6}{rosiak2022sheaf}{
+\refcardt{Remark}{Yoneda philosophy}{sec. 6.6}{rosiak2022sheaf}{
 \p{
 The Yoneda lemma can be regarded as saying:
 }

--- a/trees/tt-002T.tree
+++ b/trees/tt-002T.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-002U.tree
+++ b/trees/tt-002U.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{notation}{Yoneda lemma}{4.2.1}{leinster2016basic}{
+\refcardt{Notation}{Yoneda lemma}{4.2.1}{leinster2016basic}{
 \p{Diagramatically, #{\Nat(\fH_X, \fF)} is
 \tikzfig{% \begin{equation*}
 % \left\{

--- a/trees/tt-002V.tree
+++ b/trees/tt-002V.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{remark}{presheaf and Yoneda lemma}{4.2.1}{leinster2016basic}{
+\refcardt{Remark}{presheaf and Yoneda lemma}{4.2.1}{leinster2016basic}{
 \p{
 The Yoneda lemma says that for any #{X \in \C} and \vocabk{presheaf}{tt-002Q} #{\fF} on #{\C},
 a natural transformation #{\fH_X \to \fF} is an \vocabk{element}{tt-000M} of #{\fF(X)} of shape #{\fH_X}.

--- a/trees/tt-002W.tree
+++ b/trees/tt-002W.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{remark}{element}{2.8}{kostecki2011introduction}{
+\refcardt{Remark}{element}{2.8}{kostecki2011introduction}{
 \p{In an \vocabk{element}{tt-000M} #{x : S \to X}, the object #{S} is called a \vocab{stage} in order to express the intuition that it is a "place of view" on #{X}. In the same sense, #{S} is also called a \newvocab{domain of variation}, and #{X} a \newvocab{variable element}.
 }
 

--- a/trees/tt-002X.tree
+++ b/trees/tt-002X.tree
@@ -6,10 +6,10 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{lemma}{full and faithful}{4.8}{kostecki2011introduction}{
+\refcardt{Lemma}{full and faithful}{4.8}{kostecki2011introduction}{
 \p{The \vocabk{Yoneda embedding functor}{tt-002T} #{\fH_{\bullet}: \C \to [\C^{op}, \Set]} is \vocabk{full and faithful}{tt-0017}.}
 }

--- a/trees/tt-002Z.tree
+++ b/trees/tt-002Z.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{remark}{universal property}{sec. 1}{leinster2016basic}{
+\refcardt{Remark}{universal property}{sec. 1}{leinster2016basic}{
 \p{We say \vocabk{universal arrow}{tt-001A}s satisfy some \newvocab{universal property}.}
 \p{
 The term \vocab{universal property} is used to describe some \vocab{property} (usually some equality of some compositions, or a \vocabk{commuting diagram}{tt-0007} in general) that is satisfied \em{for all} (hence \vocab{universal}) relevant objects/arrows in the "world" (i.e. in the relevant categories), by a corresponding \em{unique} object/arrow.

--- a/trees/tt-0030.tree
+++ b/trees/tt-0030.tree
@@ -31,7 +31,7 @@
   }
 }
 
-\refcardt{lemma}{snake identities}{thm. 4.8}{nakahira2023diagrammatic}{
+\refcardt{Lemma}{snake identities}{thm. 4.8}{nakahira2023diagrammatic}{
 \p{Continuing from \ref{tt-001U}, the \vocabk{triangle identities}{tt-001Z} can be represented in \vocabk{string diagram}{tt-003V}s as follows, and called the \newvocab{snake identities} (or \newvocab{zig-zag identities}):
 \tikzfig{\adj/LR#left-snake-identity#draw
 }

--- a/trees/tt-0031.tree
+++ b/trees/tt-0031.tree
@@ -8,7 +8,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
@@ -32,7 +32,7 @@
   }
 }
 
-\refcardt{notation}{string diagram: snake identities}{thm. 4.8}{nakahira2023diagrammatic}{
+\refcardt{Notation}{string diagram: snake identities}{thm. 4.8}{nakahira2023diagrammatic}{
 \p{Following \ref{tt-001G}, recall that a string diagram is composed from top to bottem, left to right, we can read the left snake
 \tikzfig{\adj/LR/halo#left-snake#draw
 }

--- a/trees/tt-0032.tree
+++ b/trees/tt-0032.tree
@@ -4,7 +4,7 @@
 % \tag{draft}
 \tag{macro}
 
-\title{basic objects in category theory}
+\title{Basic objects in category theory}
 
 \p{This is a macro-only tree, basic objects in category theory are defined here.
 }

--- a/trees/tt-0033.tree
+++ b/trees/tt-0033.tree
@@ -62,7 +62,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{notation}{string diagrams: (co)unit and transposes}{lem. 3.6}{marsden2014category}{
+\refcardt{Notation}{string diagrams: (co)unit and transposes}{lem. 3.6}{marsden2014category}{
 \p{In \vocabk{string diagram}{tt-003V}s, \ref{tt-001Y} can be represented as:
 
 \tikzfig{\cupfun/X/eta/RY#draw $=$ \joinfun/X/RY#draw

--- a/trees/tt-0034.tree
+++ b/trees/tt-0034.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-0035.tree
+++ b/trees/tt-0035.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{corollary}{a representation is a universal element}{4.3.2}{leinster2016basic}{
+\refcardt{Corollary}{a representation is a universal element}{4.3.2}{leinster2016basic}{
 \p{Let #{\C} be a locally small category and #{\fF : \C^{op} \to \Set}. Then a \vocabk{representation}{tt-001O} of #{\fF} consists of a pair #{(X, u)} such that the diagram
 \tikzfig{\begin{tikzcd}
     X &&&& {\C(X, O)} \\

--- a/trees/tt-0036.tree
+++ b/trees/tt-0036.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{remark}{universal element}{4.3.2}{leinster2016basic}{
+\refcardt{Remark}{universal element}{4.3.2}{leinster2016basic}{
 \p{Pairs #{(Y, y)} with #{Y \in \C} and #{y \in \fF(Y)} in \ref{tt-0035} are sometimes called \newvocab{element}s of the \vocabk{presheaf}{tt-002Q} #{\fF}.}
 
 \p{Indeed, \ref{tt-002N} (Yoneda) tells us that #{y} amounts to a \vocabk{generalized element}{tt-000M} of #{\fF} of shape #{\fH_Y}.}

--- a/trees/tt-0037.tree
+++ b/trees/tt-0037.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\refcardt{remark}{idempotent}{5.30}{zhang2021type}{
+\refcardt{Remark}{idempotent}{5.30}{zhang2021type}{
 \p{
 Given an adjunction #{\fL \dashv \fR: \C \rightleftarrows \D}, we may obtain two \vocab{endofunctors} #{ \fL \cp \fR : \C \to \C} and #{ \fR \cp \fL : \D \to \D} that commute the diagram
 

--- a/trees/tt-0038.tree
+++ b/trees/tt-0038.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\refcardt{theorem}{adjunction via (co)units}{2.2.5}{leinster2016basic}{
+\refcardt{Theorem}{adjunction via (co)units}{2.2.5}{leinster2016basic}{
 \p{Given categories and functors
 
 \tikzfig{\begin{tikzcd}

--- a/trees/tt-0039.tree
+++ b/trees/tt-0039.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{remark}{topologically plausible}{2.2.9}{leinster2016basic}{
+\refcardt{Remark}{topologically plausible}{2.2.9}{leinster2016basic}{
 \p{The \vocabk{string diagram}{tt-003V}s in \ref{tt-0030} and \ref{tt-0033} are \newvocab{topologically plausible} equations, i.e. the equality can be obtained by simply pulling the string straight.
 }
 }

--- a/trees/tt-003A.tree
+++ b/trees/tt-003A.tree
@@ -7,7 +7,7 @@
 % discussion remark notation
 % \taxon{}
 
-\refcardt{theorem}{adjunction via initial objects}{2.3.6}{leinster2016basic}{
+\refcardt{Theorem}{adjunction via initial objects}{2.3.6}{leinster2016basic}{
 \p{Given categories and functors
 
 \tikzfig{\begin{tikzcd}

--- a/trees/tt-003C.tree
+++ b/trees/tt-003C.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{remark}{(finitely) cocomplete, right exact}{4.10}{kostecki2011introduction}{
+\refcardt{Remark}{(finitely) cocomplete, right exact}{4.10}{kostecki2011introduction}{
 \p{Dually to \ref{tt-002F}, when every diagram #{\fD : \J \to \C}, where #{\J} is a (finite) category, has a colimit, it is said that the category #{\C} \newvocab{has (finite) colimits} or is \newvocab{(finitely) cocomplete}.}
 
 \p{A category is called \newvocab{right exact} iff it is \vocab{finitely cocomplete}.}

--- a/trees/tt-003D.tree
+++ b/trees/tt-003D.tree
@@ -7,11 +7,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{definition}{sequence}{sec. 3.1}{leinster2016basic}{
+\refcardt{Definition}{sequence}{sec. 3.1}{leinster2016basic}{
 \p{A function with domain #{\NN} is usually called a \newvocab{sequence}.}
 }
 

--- a/trees/tt-003E.tree
+++ b/trees/tt-003E.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003F.tree
+++ b/trees/tt-003F.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003G.tree
+++ b/trees/tt-003G.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003H.tree
+++ b/trees/tt-003H.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003I.tree
+++ b/trees/tt-003I.tree
@@ -6,10 +6,10 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{lemma}{adjunction and representable}{4.1.11}{leinster2016basic}{
+\refcardt{Lemma}{adjunction and representable}{4.1.11}{leinster2016basic}{
 \p{Any set-valued functor with a left adjoint is representable.}
 }

--- a/trees/tt-003J.tree
+++ b/trees/tt-003J.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{lemma}{monic and pullback}{5.1.32}{leinster2016basic}{
+\refcardt{Lemma}{monic and pullback}{5.1.32}{leinster2016basic}{
 \p{An arrow #{X \xrightarrow{f} Y} is \vocabk{monic}{tt-000B} iff the square
   \tikzfig{\begin{tikzcd}
     X && X \\

--- a/trees/tt-003K.tree
+++ b/trees/tt-003K.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003L.tree
+++ b/trees/tt-003L.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003M.tree
+++ b/trees/tt-003M.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{lemma}{epic and pushout}{sec. 5.2}{leinster2016basic}{
+\refcardt{Lemma}{epic and pushout}{sec. 5.2}{leinster2016basic}{
 \p{An arrow #{X \xrightarrow{f} Y} is \vocabk{epic}{tt-000C} iff the square
   \tikzfig{\begin{tikzcd}
     X && X \\

--- a/trees/tt-003N.tree
+++ b/trees/tt-003N.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003N.tree
+++ b/trees/tt-003N.tree
@@ -10,7 +10,7 @@
 
 % kostecki2011introduction leinster2016basic
 
-\title{special functors}
+\title{Special functors}
 
 \transclude{tt-003P}
 

--- a/trees/tt-003O.tree
+++ b/trees/tt-003O.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003O.tree
+++ b/trees/tt-003O.tree
@@ -10,7 +10,7 @@
 
 % kostecki2011introduction leinster2016basic
 
-\title{universal properties}
+\title{Universal properties}
 
 \transclude{tt-001A}
 

--- a/trees/tt-003U.tree
+++ b/trees/tt-003U.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-003X.tree
+++ b/trees/tt-003X.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{convention}{composition}{1.1}{kostecki2011introduction}{
+\refcardt{Convention}{composition}{1.1}{kostecki2011introduction}{
 \p{In literatures, \vocab{composition} of arrows in a \vocabk{category}{tt-0002} is most frequently denoted #{\circ} or just by juxtaposition, i.e. for the diagram
 
 \tikzfig{\begin{tikzcd}

--- a/trees/tt-003Y.tree
+++ b/trees/tt-003Y.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 
-\refcardt{lemma}{limit via representation}{6.1.1}{leinster2016basic}{
+\refcardt{Lemma}{limit via representation}{6.1.1}{leinster2016basic}{
 \p{
 Let #{\J} be a small category, #{\C} a category, and #{\fD: \J \to \C} a diagram. Then there is a one-to-one correspondence between
 

--- a/trees/tt-003Z.tree
+++ b/trees/tt-003Z.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-0042.tree
+++ b/trees/tt-0042.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcardt{lemma}{representables preserve limits}{6.2.2}{leinster2016basic}{
+\refcardt{Lemma}{representables preserve limits}{6.2.2}{leinster2016basic}{
 \p{Let #{\mathscr{A}} be a locally small category and #{X \in \C}. Then #{\C(X,-): \C \to \Set} preserves limits.
 }
 \proof{It follows from \ref{tt-003Y} and that \citet{6.2.1}{leinster2016basic}

--- a/trees/tt-0043.tree
+++ b/trees/tt-0043.tree
@@ -5,7 +5,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark notation
-\refcard{remark}{interactions}{leinster2016basic}{
+\refcard{Remark}{interactions}{leinster2016basic}{
 \p{In this section, we will discuss the interactions between
 
 \ul{

--- a/trees/tt-0044.tree
+++ b/trees/tt-0044.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 

--- a/trees/tt-0045.tree
+++ b/trees/tt-0045.tree
@@ -7,11 +7,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 
-\refcardt{theorem}{limits in a functor category}{6.2.5}{leinster2016basic}{
+\refcardt{Theorem}{limits in a functor category}{6.2.5}{leinster2016basic}{
 \p{Limits in a functor category are computed pointwise.}
 
 \todo{fill in details.}

--- a/trees/tt-0046.tree
+++ b/trees/tt-0046.tree
@@ -7,11 +7,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 
-\refcardt{corollary}{evaluation functor preserves limits of ...}{6.2.6}{leinster2016basic}{
+\refcardt{Corollary}{evaluation functor preserves limits of ...}{6.2.6}{leinster2016basic}{
 \p{An important corollary of \ref{tt-0045}.}
 
 \p{The Yoneda embedding preserves limits, for any small category \citet{6.2.12}{leinster2016basic}. But it does \em{not} preserve colimits in general \citet{6.2.14}{leinster2016basic}.

--- a/trees/tt-0047.tree
+++ b/trees/tt-0047.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 
-\refcardt{lemma}{limits commute with limits}{6.2.8}{leinster2016basic}{
+\refcardt{Lemma}{limits commute with limits}{6.2.8}{leinster2016basic}{
 \p{
 Let #{\I} and #{\J} be small categories. Let #{\C} be a locally small category with limits of shape #{\I} and of shape
 #{\J}.}

--- a/trees/tt-0048.tree
+++ b/trees/tt-0048.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic
 

--- a/trees/tt-0049.tree
+++ b/trees/tt-0049.tree
@@ -6,10 +6,10 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 
-\refcardt{lemma}{colimits commute with colimits}{6.2.10}{leinster2016basic}{
+\refcardt{Lemma}{colimits commute with colimits}{6.2.10}{leinster2016basic}{
 \p{Dual to \ref{tt-0047}, colimits commute with colimits.}
 }

--- a/trees/tt-004A.tree
+++ b/trees/tt-004A.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 
-\refcardt{remark}{}{6.2.10}{leinster2016basic}{
+\refcardt{Remark}{}{6.2.10}{leinster2016basic}{
 \p{Limits do \em{not} in general commute with colimits.}
 
 \p{Some special cases where they do:

--- a/trees/tt-004B.tree
+++ b/trees/tt-004B.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 

--- a/trees/tt-004B.tree
+++ b/trees/tt-004B.tree
@@ -10,7 +10,7 @@
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
-\taxon{notation}\title{presheaf}
+\taxon{Notation}\title{Presheaf}
 
 \p{We'll use #{\fF} to denote a \vocabk{presheaf}{tt-002Q} since sheaf in French is \newvocab{faisceau}.
 }

--- a/trees/tt-004C.tree
+++ b/trees/tt-004C.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 

--- a/trees/tt-004D.tree
+++ b/trees/tt-004D.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 
-\refcardt{theorem}{density}{6.2.17}{leinster2016basic}{
+\refcardt{Theorem}{density}{6.2.17}{leinster2016basic}{
 \p{
 Let #{\C} be a small category and #{\fX} a presheaf on
 #{\C}. Then #{\fX} is the colimit of the diagram

--- a/trees/tt-004E.tree
+++ b/trees/tt-004E.tree
@@ -7,11 +7,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 
-\refcardt{theorem}{general adjoint functor theorem}{6.3.10}{leinster2016basic}{
+\refcardt{Theorem}{general adjoint functor theorem}{6.3.10}{leinster2016basic}{
 \p{Limit-preservation alone does not guarantee the existence of a left adjoint. This theorem specifies the conditions under which a limit-preserving functor has a left adjoint. This theorem requires the definition of weakly initial set.
 }
 

--- a/trees/tt-004F.tree
+++ b/trees/tt-004F.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 

--- a/trees/tt-004G.tree
+++ b/trees/tt-004G.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 

--- a/trees/tt-004H.tree
+++ b/trees/tt-004H.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic 
 

--- a/trees/tt-004I.tree
+++ b/trees/tt-004I.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 

--- a/trees/tt-004K.tree
+++ b/trees/tt-004K.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
-\refcardt{lemma}{isomorphism to class of subobjects}{6.7}{kostecki2011introduction}{
+\refcardt{Lemma}{isomorphism to class of subobjects}{6.7}{kostecki2011introduction}{
 
 \p{
 In any category #{\C} with a \vocabk{subobject classifier}{tt-004I} #{\Omega},

--- a/trees/tt-004N.tree
+++ b/trees/tt-004N.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
-\refcardt{lemma}{properties of cartesian closed categories}{5.15}{kostecki2011introduction}{
+\refcardt{Lemma}{properties of cartesian closed categories}{5.15}{kostecki2011introduction}{
 For any \vocabk{cartesian closed category}{tt-004H} #{\C}, and any objects #{X, Y, Z} of #{\C}, we have
 \ol{
 \li{#{\initobj \times X \cong \initobj} if #{\initobj} exists in #{\C}}

--- a/trees/tt-004O.tree
+++ b/trees/tt-004O.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 

--- a/trees/tt-004P.tree
+++ b/trees/tt-004P.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
-\refcardt{remark}{topoi, toposes}{7.1}{kostecki2011introduction}{
+\refcardt{Remark}{topoi, toposes}{7.1}{kostecki2011introduction}{
 \p{The name "topos" originates from the Greek word "τoπoς", meaning a \em{place}, as topos could mean a place of geometry, and at the same time as a place of logic.
 }
 

--- a/trees/tt-004Q.tree
+++ b/trees/tt-004Q.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 

--- a/trees/tt-004R.tree
+++ b/trees/tt-004R.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
-\card{example}{topos}{
+\card{Example}{topos}{
 \p{Topos theory unifies, in an extraordinary way, important aspects of geometry and logic.}
 
 \p{\newvocab{Grothendieck topos} was first introduced by Grothendieck to generalize \vocab{topological space} \citet{7.2}{kostecki2011introduction}: 

--- a/trees/tt-004S.tree
+++ b/trees/tt-004S.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt math draft
 \tag{tt}
 
-\title{cartesian closed categories}
+\title{Cartesian closed categories}
 
 \transclude{tt-0044}
 

--- a/trees/tt-004T.tree
+++ b/trees/tt-004T.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt math draft
 \tag{tt}
 
-\title{subobject classifier}
+\title{Subobject classifier}
 
 \transclude{tt-004C}
 

--- a/trees/tt-004W.tree
+++ b/trees/tt-004W.tree
@@ -7,11 +7,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
-\refcardt{example}{(co)limit in Set}{5.1.22, 5.2.16}{leinster2016basic}{
+\refcardt{Example}{(co)limit in Set}{5.1.22, 5.2.16}{leinster2016basic}{
 \p{In #{\Set}, the limit is constructed as a subset of a product, the colimit is a quotient of a sum.}
 }
 

--- a/trees/tt-004X.tree
+++ b/trees/tt-004X.tree
@@ -7,11 +7,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
-\refcardt{example}{direct limit}{example 68}{rosiak2022sheaf}{
+\refcardt{Example}{direct limit}{example 68}{rosiak2022sheaf}{
 
 \p{
 Direct limits is the colimit of a diagram indexed by the ordinal category #{\omega}. In other words, for a diagram

--- a/trees/tt-004Y.tree
+++ b/trees/tt-004Y.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
@@ -18,7 +18,7 @@
   }
 }
 
-\card{remark}{directions in (co)limits}{
+\card{Remark}{directions in (co)limits}{
   \table{
     \thead{
       \tr{

--- a/trees/tt-004Z.tree
+++ b/trees/tt-004Z.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/tt-0050.tree
+++ b/trees/tt-0050.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/tt-0051.tree
+++ b/trees/tt-0051.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/tt-0052.tree
+++ b/trees/tt-0052.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\card{example}{preorder, poset, directed poset}{
+\card{Example}{preorder, poset, directed poset}{
 \p{An example of a \vocab{preorder} category which is \em{not} \vocab{poset} is:
 
 \tikzfig{\begin{tikzcd}

--- a/trees/tt-0053.tree
+++ b/trees/tt-0053.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/tt-0054.tree
+++ b/trees/tt-0054.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\refcardt{lemma}{initial and terminal objects via adjunction}{2.1.9}{leinster2016basic}{
+\refcardt{Lemma}{initial and terminal objects via adjunction}{2.1.9}{leinster2016basic}{
 
 \p{
 Initial and terminal objects can be described as adjoints. Let #{\C} be a category. There exist the \vocab{unique functor} #{\fUniq : \C \to \termcat}, and a \vocab{constant object functor} #{X : 1 \to \C} for each object #{X}.

--- a/trees/tt-0055.tree
+++ b/trees/tt-0055.tree
@@ -7,11 +7,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\card{remark}{summary}{
+\card{Remark}{summary}{
 \tikzfig{
 \begin{tikzcd}
 	\colim && \lim \\

--- a/trees/tt-0056.tree
+++ b/trees/tt-0056.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\refcardt{lemma}{pasting pullbacks}{2.5.1.17}{spivak2013category}{
+\refcardt{Lemma}{pasting pullbacks}{2.5.1.17}{spivak2013category}{
 \p{Pullbacks can be pasted together, i.e. for diagram
 
 \tikzfig{

--- a/trees/tt-0057.tree
+++ b/trees/tt-0057.tree
@@ -6,11 +6,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\refcardt{lemma}{limits via products and equalizers}{002N, 002P}{stacks2017stacks}{
+\refcardt{Lemma}{limits via products and equalizers}{002N, 002P}{stacks2017stacks}{
 \p{If all products and equalizers exist, all limits exist.}
 
 \p{Dually, if all coproducts and coequalizers exist, all colimits exist.}

--- a/trees/tt-0058.tree
+++ b/trees/tt-0058.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/tt-0059.tree
+++ b/trees/tt-0059.tree
@@ -7,11 +7,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\refcardt{lemma}{preserves if creates}{5.3.6}{leinster2016basic}{
+\refcardt{Lemma}{preserves if creates}{5.3.6}{leinster2016basic}{
 \p{Let #{\fF: \C \rightarrow \D} be a functor and #{\J} a small category. Suppose that #{\D} has, and #{\fF} creates, limits of shape #{\J}. Then #{\C} has, and #{\fF} preserves, limits of shape #{\J}.
 }
 }

--- a/trees/tt-005A.tree
+++ b/trees/tt-005A.tree
@@ -5,11 +5,11 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\refcardt{lemma}{(co)limits via adjunction}{example 200}{rosiak2022sheaf}{
+\refcardt{Lemma}{(co)limits via adjunction}{example 200}{rosiak2022sheaf}{
 \p{(Co)limits can be phrased entirely in terms of adjunctions:
 
 \tikzfig{

--- a/trees/tt-005B.tree
+++ b/trees/tt-005B.tree
@@ -11,4 +11,4 @@
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\title{shaef theory}
+\title{Shaef theory}

--- a/trees/tt-005B.tree
+++ b/trees/tt-005B.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/tt-005C.tree
+++ b/trees/tt-005C.tree
@@ -7,10 +7,10 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\refcardt{remark}{local, global}{p. 1}{rosiak2022sheaf}{
+\refcardt{Remark}{local, global}{p. 1}{rosiak2022sheaf}{
 In a very general and rough way, by \newvocab{local} we typically understand that something is being compared to what is around or nearby it; this is as opposed to the \newvocab{global}, generally understood to mean compared to everything or across an entire domain of interest. Satisfying a property at a local level does not necessarily entail that the same will obtain at the global level.
 }

--- a/trees/uts-0001.tree
+++ b/trees/uts-0001.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin math
 \tag{root}
 
-\title{draft notes}
+\title{Draft notes}
 
 \block{draft notes captured by topic}{
 

--- a/trees/uts-0002.tree
+++ b/trees/uts-0002.tree
@@ -6,7 +6,7 @@
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof
 % discussion remark
-\taxon{definition}
+\taxon{Definition}
 \refnote{Kronecker delta}{wiki2024dirac}{
 \p{
 Kronecker delta

--- a/trees/uts-0008.tree
+++ b/trees/uts-0008.tree
@@ -1,6 +1,6 @@
 \import{tt-macros}
 % clifford hopf spin tt ag math draft tech exp
-\title{drawing string diagrams}
+\title{Drawing string diagrams}
 
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof

--- a/trees/uts-0009.tree
+++ b/trees/uts-0009.tree
@@ -11,7 +11,7 @@
 % \texdef{scratchpad}{none}{
 % }
 
-\title{tools for diagrams}
+\title{Tools for diagrams}
 
 \md{
 - [Pikchr](https://pikchr.org/): an open-source text-to-diagram tool, the language is [simple](https://pikchr.org/home/doc/trunk/doc/grammar.md) yet has great support for [relative positioning](https://pikchr.org/home/doc/trunk/doc/position.md) and [flexible path guiding](https://pikchr.org/home/doc/trunk/doc/locattr.md).

--- a/trees/uts-000B.tree
+++ b/trees/uts-000B.tree
@@ -17,7 +17,7 @@
   \put\transclude/numbered{false}
   \put\transclude/expanded{true} % not working yet
   \subtree[eqid]{
-    \taxon{eq}
+    \taxon{Eq}
     ##{\body \verb~|\tag{~\eqno\verb~|}~}
   }
 }
@@ -26,7 +26,7 @@
   \let\eqid{\get\current-refid\eqno}
   \put\transclude/numbered{false}
   \subtree[eqid2]{
-    \taxon{eq}
+    \taxon{Eq}
     ##{\body \verb~|\tag{~\eqno\verb~|}~}
   }
 }
@@ -36,7 +36,7 @@
 \p{The following is an equation:
 
 \subtree[math-eq-1.1]{
-  \taxon{eq}
+  \taxon{Eq}
   ##{E = m c^2 \verb*|\tag{*math-eq-1.1\verb*|}*}
 }
 
@@ -45,7 +45,7 @@
 \eqtag2{1.3}{E = m c^2}
 
 \subtree[math-eq-1.4]{
-  \taxon{eq}
+  \taxon{Eq}
   ##{E = m c^2 \verb*|\tag{*math-eq-1.4\verb*|}*}
 }
 

--- a/trees/uts-000C.tree
+++ b/trees/uts-000C.tree
@@ -11,7 +11,7 @@
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 
-\title{translation of Bourbaki on Clifford algebras}
+\title{Translation of Bourbaki on Clifford algebras}
 \author{utensil}
 \date{2020-09-02}
 \meta{pdf}{true}

--- a/trees/uts-000C.tree
+++ b/trees/uts-000C.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000D.tree
+++ b/trees/uts-000D.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000E.tree
+++ b/trees/uts-000E.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000F.tree
+++ b/trees/uts-000F.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000I.tree
+++ b/trees/uts-000I.tree
@@ -5,7 +5,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000J.tree
+++ b/trees/uts-000J.tree
@@ -1,6 +1,6 @@
 \import{macros}
 % clifford hopf spin tt ag math draft tech exp
-\taxon{figure}
+\taxon{Figure}
 
 % definition theorem lemma construction observation
 % convention corollary axiom example exercise proof

--- a/trees/uts-000J.tree
+++ b/trees/uts-000J.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000K.tree
+++ b/trees/uts-000K.tree
@@ -5,7 +5,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000L.tree
+++ b/trees/uts-000L.tree
@@ -5,7 +5,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000M.tree
+++ b/trees/uts-000M.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000N.tree
+++ b/trees/uts-000N.tree
@@ -5,7 +5,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000O.tree
+++ b/trees/uts-000O.tree
@@ -5,7 +5,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000P.tree
+++ b/trees/uts-000P.tree
@@ -5,7 +5,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000Q.tree
+++ b/trees/uts-000Q.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000R.tree
+++ b/trees/uts-000R.tree
@@ -7,7 +7,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic rosiak2022sheaf
 

--- a/trees/uts-000T.tree
+++ b/trees/uts-000T.tree
@@ -2,7 +2,7 @@
 
 \tag{root}
 
-\title{some tips about Forester}
+\title{Some tips about Forester}
 
 \block{Browsing}{
     \p{To search, use the magnifying glass icon on the top right corner, or press \code{Ctrl+K}(Windows/Linux) or \code{Cmd+K}(Mac).}

--- a/trees/uts-0010.tree
+++ b/trees/uts-0010.tree
@@ -1,7 +1,7 @@
 \import{macros}
 \tag{root}
 
-\title{technical experiments}
+\title{Technical experiments}
 
 \p{The following are technical experiments on what kind of rich content I can include in my forester notes. See [my post on this](uts-000X) for more background. Some of my [[uts-0012]] might have additional information.
 }

--- a/trees/uts-0012.tree
+++ b/trees/uts-0012.tree
@@ -1,7 +1,7 @@
 \import{macros}
 \tag{root}
 
-\title{technical notes (draft)}
+\title{Technical notes (draft)}
 
 \scope{
     \query\datalog{

--- a/trees/uts-0014.tree
+++ b/trees/uts-0014.tree
@@ -10,7 +10,7 @@
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 
-\title{lost notes}
+\title{Lost notes}
 
 \p{The following are normal leaf notes that are not transcluded by any note, and are not captured by [[uts-001O]] or [[uts-0001]], thus might be lost.
 }
@@ -60,7 +60,7 @@
 %   }
 %   \def\query/normal{
 %     \compl{
-%       \union{\query/root}{\tag{draft}}{\tag{macro}}{\tag{exp}}{\taxon{person}}{\taxon{reference}}{\taxon{eq}}{\tag{mwe}}{\tag{post}}
+%       \union{\query/root}{\tag{draft}}{\tag{macro}}{\tag{exp}}{\taxon{Person}}{\taxon{reference}}{\taxon{eq}}{\tag{mwe}}{\tag{post}}
 %     }
 %   }
 

--- a/trees/uts-0014.tree
+++ b/trees/uts-0014.tree
@@ -6,7 +6,7 @@
 % convention corollary axiom example exercise proof
 % discussion remark notation
 % \taxon{}
-% \refcardt{lemma}{}{}{}{
+% \refcardt{Lemma}{}{}{}{
 
 % kostecki2011introduction leinster2016basic nakahira2023diagrammatic
 


### PR DESCRIPTION
## Summary
- Capitalize all titles that didn't start with a capital letter (47 files)
- Capitalize all taxon values in both direct `\taxon{}` usage and macro arguments (`\card{}`, `\refcard{}`, `\refcardt{}`) — 203 files
- Remove the "upgraded to Forester 5.x" warning banner from layout
- Fix `<title>` element to use `fr:title/@text` for proper plain-text extraction
- Remove dead commented-out code from `uts-layout.xsl` and `uts-overrides.xsl`

## Review URLs
After deploying, verify these pages:
- https://utensil.github.io/forest/ — Home page (no warning banner)
- https://utensil.github.io/forest/tt-0001/ — Taxons show as "Definition 1.1.1.", "Convention 1.1.2." etc.
- https://utensil.github.io/forest/uts-000M/ — Markdown rendering with headings, lists, sublists
- https://utensil.github.io/forest/ag-001F/ — Title now "Ray marching" (capitalized)

## Items deferred (blocked or out-of-scope)
- Meta buttons for custom functions (blocked on upstream forester#187)
- Markdown sublist with mixed markers creates separate `<ul>` per marker (standard markdown-it behavior, not a bug)
- `/forest/` prefix in `\loadjs`/`\loadvjs` macros (deployment constant, can't be made dynamic at tree-compile time)

## Test plan
- [x] Full `./build.sh` passes (1191 XML files converted)
- [x] Headless Chrome verification of index, tt-0001, uts-000M pages
- [x] Taxons render capitalized in output XML and HTML
- [x] Warning banner removed from all pages
- [x] `xsltproc` transformation succeeds with cleaned-up XSL files

Closes partially: #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)