### PR TITLE
fix: port PDF generation to forester 5.x

### DIFF
--- a/assets/article.xsl
+++ b/assets/article.xsl
@@ -2,7 +2,8 @@
 <!-- SPDX-License-Identifier: CC0-1.0 -->
 <xsl:stylesheet version="1.0"
   xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
-  xmlns:f="http://www.jonmsterling.com/jms-005P.xml">
+  xmlns:f="http://www.forester-notes.org"
+  xmlns:html="http://www.w3.org/1999/xhtml">
 
   <xsl:output method="text" encoding="utf-8" indent="yes" doctype-public="" doctype-system="" />
 

--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -3,7 +3,7 @@
 <xsl:stylesheet version="1.0"
                 xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:html="http://www.w3.org/1999/xhtml"
-                xmlns:f="http://www.jonmsterling.com/jms-005P.xml">
+                xmlns:f="http://www.forester-notes.org">
   
   <xsl:template match="/f:tree/f:backmatter//f:tree[f:frontmatter/f:taxon[text()='Reference']]">
     <xsl:apply-templates select="f:frontmatter/f:meta[@name='bibtex']" />
@@ -25,9 +25,9 @@
   
   <xsl:template match="f:tree[not(f:frontmatter/f:taxon)]">
     <xsl:apply-templates select="f:frontmatter/f:title" />
-    <xsl:if test="f:frontmatter/f:addr[not(contains(text(), '#'))]">
+    <xsl:if test="f:frontmatter/f:display-uri[not(contains(text(), '#'))]">
       <xsl:text>\label{</xsl:text>
-      <xsl:value-of select="f:frontmatter/f:addr" />
+      <xsl:value-of select="f:frontmatter/f:display-uri" />
       <xsl:text>}</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="f:mainmatter" />
@@ -97,9 +97,9 @@
       <xsl:apply-templates select="f:frontmatter/f:title" />
       <xsl:text>}]</xsl:text>
     </xsl:if>
-    <xsl:if test="f:frontmatter/f:addr[not(contains(text(), '#'))]">
+    <xsl:if test="f:frontmatter/f:display-uri[not(contains(text(), '#'))]">
       <xsl:text>\label{</xsl:text>
-      <xsl:value-of select="f:frontmatter/f:addr" />
+      <xsl:value-of select="f:frontmatter/f:display-uri" />
       <xsl:text>}</xsl:text>
     </xsl:if>
     <xsl:apply-templates select="f:mainmatter" />
@@ -120,8 +120,8 @@
       <xsl:text>}}</xsl:text>
     </xsl:if>
     <xsl:text>{</xsl:text>
-    <xsl:if test="f:frontmatter/f:addr[not(contains(text(), '#'))]">
-      <xsl:value-of select="f:frontmatter/f:addr" />
+    <xsl:if test="f:frontmatter/f:display-uri[not(contains(text(), '#'))]">
+      <xsl:value-of select="f:frontmatter/f:display-uri" />
     </xsl:if>
     <xsl:text>}{</xsl:text>
     <xsl:apply-templates select="f:mainmatter" />
@@ -135,20 +135,20 @@
     <xsl:apply-templates />
   </xsl:template>
   
-  <xsl:template match="f:p">
+  <xsl:template match="html:p">
     <xsl:text>\par{}</xsl:text>
     <!-- <xsl:text>\paragraph{</xsl:text> -->
     <xsl:apply-templates />
     <!-- <xsl:text>}</xsl:text> -->
   </xsl:template>
   
-  <xsl:template match="f:strong">
+  <xsl:template match="html:strong">
     <xsl:text>\textbf{</xsl:text>
     <xsl:apply-templates />
     <xsl:text>}</xsl:text>
   </xsl:template>
   
-  <xsl:template match="f:em">
+  <xsl:template match="html:em">
     <xsl:text>\emph{</xsl:text>
     <xsl:apply-templates />
     <xsl:text>}</xsl:text>
@@ -169,22 +169,22 @@
     <xsl:text>\end{equation}</xsl:text>
   </xsl:template>
   
-  <xsl:template match="f:ol">
+  <xsl:template match="html:ol">
     <xsl:text>\begin{enumerate}</xsl:text>
     <xsl:apply-templates />
     <xsl:text>\end{enumerate}</xsl:text>
   </xsl:template>
   
-  <xsl:template match="f:ul">
+  <xsl:template match="html:ul">
     <xsl:text>\begin{itemize}</xsl:text>
     <xsl:apply-templates />
     <xsl:text>\end{itemize}</xsl:text>
   </xsl:template>
   
-  <xsl:template match="f:li">
+  <xsl:template match="html:li">
     <xsl:text>\item{}</xsl:text>
     <xsl:apply-templates />
-    <xsl:if test="(parent::f:ol/parent::f:mainmatter/parent::f:tree/f:frontmatter/f:taxon[text()='Proof'] or parent::f:ul/parent::f:mainmatter/parent::f:tree/f:frontmatter/f:taxon[text()='Proof']) and position()=last()">
+    <xsl:if test="(parent::html:ol/parent::f:mainmatter/parent::f:tree/f:frontmatter/f:taxon[text()='Proof'] or parent::html:ul/parent::f:mainmatter/parent::f:tree/f:frontmatter/f:taxon[text()='Proof']) and position()=last()">
       <xsl:text>\qedhere</xsl:text>
     </xsl:if>
   </xsl:template>
@@ -193,21 +193,21 @@
     <xsl:value-of select="@taxon" />
     <xsl:text>\unskip~</xsl:text>
     <xsl:text>\ref{</xsl:text>
-    <xsl:value-of select="@addr" />
+    <xsl:value-of select="@display-uri" />
     <xsl:text>}</xsl:text>
   </xsl:template>
   
   <xsl:template match="f:ref[not(@taxon)]">
     <xsl:text>\S~\ref{</xsl:text>
-    <xsl:value-of select="@addr" />
+    <xsl:value-of select="@display-uri" />
     <xsl:text>}</xsl:text>
   </xsl:template> -->
 
   <xsl:template match="f:ref">
     <xsl:choose>
-      <xsl:when test="//f:tree/f:frontmatter[f:addr/text()=current()/@addr and not(ancestor::f:backmatter)]">
+      <xsl:when test="//f:tree/f:frontmatter[f:display-uri/text()=current()/@display-uri and not(ancestor::f:backmatter)]">
         <xsl:text>\Cref{</xsl:text>
-        <xsl:value-of select="@addr" />
+        <xsl:value-of select="@display-uri" />
         <xsl:text>}</xsl:text>
       </xsl:when>
       <xsl:otherwise>
@@ -220,10 +220,10 @@
             <xsl:text>\S~</xsl:text>
           </xsl:otherwise>
         </xsl:choose>
-        <xsl:text>\href{https://utensil.github.io/forest/</xsl:text>
-        <xsl:value-of select="@href" />
+        <xsl:text>\href{</xsl:text>
+        <xsl:value-of select="@uri" />
         <xsl:text>}{[</xsl:text>
-        <xsl:value-of select="@addr" />
+        <xsl:value-of select="@display-uri" />
         <xsl:text>]}</xsl:text>
       </xsl:otherwise>
     </xsl:choose>
@@ -231,14 +231,14 @@
   
   <xsl:template match="f:link[@type='local']">
     <xsl:choose>
-      <xsl:when test="//f:tree/f:frontmatter[f:addr/text()=current()/@addr and not(ancestor::f:backmatter)]">
+      <xsl:when test="//f:tree/f:frontmatter[f:display-uri/text()=current()/@display-uri and not(ancestor::f:backmatter)]">
         <xsl:text>\hyperref[</xsl:text>
-        <xsl:value-of select="@addr" />
+        <xsl:value-of select="@display-uri" />
         <xsl:text>]{</xsl:text>
         <xsl:apply-templates />
         <xsl:text>}</xsl:text>
       </xsl:when>
-      <xsl:when test="/f:tree/f:backmatter//f:tree/f:frontmatter[f:taxon/text()='Reference' and f:addr/text()=current()/@addr]">
+      <xsl:when test="/f:tree/f:backmatter//f:tree/f:frontmatter[f:taxon/text()='Reference' and f:display-uri/text()=current()/@display-uri]">
         <xsl:text>{\sloppy\cite</xsl:text>
         <xsl:if test="../@tid">
           <xsl:text>[</xsl:text>
@@ -246,12 +246,12 @@
           <xsl:text>]</xsl:text>
         </xsl:if>
         <xsl:text>{</xsl:text>
-        <xsl:value-of select="@addr" />
+        <xsl:value-of select="@display-uri" />
         <xsl:text>}}</xsl:text>
       </xsl:when>
       <xsl:otherwise>
-        <xsl:text>\href{https://utensil.github.io/forest/</xsl:text>
-        <xsl:value-of select="@href" />
+        <xsl:text>\href{</xsl:text>
+        <xsl:value-of select="@uri" />
         <xsl:text>}{</xsl:text>
         <xsl:apply-templates />
         <xsl:text>}</xsl:text>
@@ -267,6 +267,7 @@
     <xsl:text>}</xsl:text>
   </xsl:template>
   
+  <xsl:template match="f:contextual-number" />
   <xsl:template match="f:headline" />
   
   <xsl:template match="f:resource">
@@ -299,7 +300,7 @@
     </xsl:choose>
   </xsl:template>
 
-  <xsl:template match="f:code">
+  <xsl:template match="html:code">
     <xsl:text>\lstinline|</xsl:text>
     <xsl:apply-templates />
     <xsl:text>|</xsl:text>

--- a/assets/uts-overrides.xsl
+++ b/assets/uts-overrides.xsl
@@ -105,7 +105,7 @@
                 </xsl:choose>
             </xsl:if>
             <xsl:if test="../fr:meta[@name='pdf']">
-                <a target="_blank" title="PDF" class="link-button link-pdf" href="{../fr:display-uri}.pdf">
+                <a target="_blank" title="PDF" class="link-button link-pdf" href="{/fr:tree/@base-url}{../fr:display-uri}.pdf">
                     📄<span>PDF</span></a>
             </xsl:if>
             <xsl:if test="../fr:meta[@name='lean']">

--- a/lize.sh
+++ b/lize.sh
@@ -21,7 +21,8 @@ PDF_FILE="$1.pdf"
 
 rm "build/$1".* >/dev/null 2>&1 || echo no files to clean
 
-cp "output/$XML_FILE" "build/$XML_FILE"
+# Forester 5.x outputs XML at output/forest/TREE_ID/index.xml
+cp "output/forest/$1/index.xml" "build/$XML_FILE"
 
 # brew install saxon
 # bun add xslt3
@@ -50,10 +51,10 @@ fi
 
 cd ..
 
-cp "build/$PDF_FILE" "output/$PDF_FILE"
+cp "build/$PDF_FILE" "output/forest/$PDF_FILE"
 
 echo "lize.sh| Open build/$1.log to see the log."
 echo "lize.sh| Open build/$TEX_FILE to see the LaTeX source."
-echo "lize.sh| Open output/$PDF_FILE to see the result."
+echo "lize.sh| Open output/forest/$PDF_FILE to see the result."
 
 # use ./lize.sh uts-0001 2>&1|grep lize to see a short output


### PR DESCRIPTION
## Summary
- Update XSL namespace from old `jonmsterling.com/jms-005P.xml` to new `forester-notes.org`
- Map renamed elements: `f:p` → `html:p`, `f:em` → `html:em`, `f:ol` → `html:ol`, etc.
- Fix `f:addr` → `f:display-uri` for LaTeX labels
- Fix link URL generation (use `@uri` instead of hardcoded base + `@href`)
- Update `lize.sh` for new output path structure (`output/forest/TREE/index.xml`)

## Test plan
- [x] `./lize.sh tt-0001` generates PDF (493KB) successfully
- [x] `./lize.sh spin-0001` generates PDF (250KB) successfully
- [x] XSL transformation produces correct LaTeX: sections, definitions, theorems, tikz diagrams, citations, cross-references
- [x] No double-slash in generated URLs

## Review URLs
After deploy, verify PDF links work:
- https://utensil.github.io/forest/tt-0001.pdf
- https://utensil.github.io/forest/spin-0001.pdf

🤖 Generated with [Claude Code](https://claude.com/claude-code)