### PR TITLE
fix: migrate legacy queries to datalog syntax (issue #9)

### DIFF
--- a/trees/macros.tree
+++ b/trees/macros.tree
@@ -121,72 +121,64 @@
 \p{\code{make-topic-bibliography[topic]}: A bibliography of papers, presentations, and people related to a topic.}
 
 \def\make-topic-bibliography[topic]{
+  % Helper relation for presentations: workshop references OR presentation taxon
+  \def\rel/is-presentation-like{utensil.query.is-presentation-like}
+  \execute\datalog{\rel/is-presentation-like ?X -: {\rel/has-tag ?X '{workshop}}{\rel/has-taxon ?X '{Reference}}}
+  \execute\datalog{\rel/is-presentation-like ?X -: {\rel/has-taxon ?X '{Presentation}}}
+
   \subtree{
    \title{Accepted papers}
-   \query{
-    \open\query
-    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{accepted}}
+   \query\datalog{
+    ?X -: {\rel/has-tag ?X '{\topic}}{\rel/has-taxon ?X '{Reference}}{\rel/has-tag ?X '{accepted}}
    }
   }
 
   \subtree{
    \title{Refereed papers}
-   \query{
-    \open\query
-    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{refereed}}
+   \query\datalog{
+    ?X -: {\rel/has-tag ?X '{\topic}}{\rel/has-taxon ?X '{Reference}}{\rel/has-tag ?X '{refereed}}
    }
   }
 
   \subtree{
    \title{Manuscripts}
-   \query{
-    \open\query
-    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{preprint}}{\compl{\tag{accepted}}}
+   \query\datalog{
+    ?X -: {\rel/has-tag ?X '{\topic}}{\rel/has-taxon ?X '{Reference}}{\rel/has-tag ?X '{preprint}} # {\rel/has-tag ?X '{accepted}}
    }
   }
 
   \subtree{
    \title{Dissertations}
-   \query{
-    \open\query
-    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{dissertation}}
+   \query\datalog{
+    ?X -: {\rel/has-tag ?X '{\topic}}{\rel/has-taxon ?X '{Reference}}{\rel/has-tag ?X '{dissertation}}
    }
   }
 
   \subtree{
    \title{Technical reports}
-   \query{
-    \open\query
-    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{techreport}}
+   \query\datalog{
+    ?X -: {\rel/has-tag ?X '{\topic}}{\rel/has-taxon ?X '{Reference}}{\rel/has-tag ?X '{techreport}}
    }
   }
 
   \subtree{
    \title{Presentations}
-   \query{
-    \open\query
-    \isect{\tag{\topic}}{
-     \union{
-      \isect{\tag{workshop}}{\taxon{Reference}}
-     }{\taxon{Presentation}}
-    }
+   \query\datalog{
+    ?X -: {\rel/has-tag ?X '{\topic}}{\rel/is-presentation-like ?X}
    }
   }
 
-
   \subtree{
    \title{Seminar talks}
-   \query{
-    \open\query
-    \isect{\tag{\topic}}{\taxon{Reference}}{\tag{seminar}}
+   \query\datalog{
+    ?X -: {\rel/has-tag ?X '{\topic}}{\rel/has-taxon ?X '{Reference}}{\rel/has-tag ?X '{seminar}}
    }
   }
 
   \subtree{
    \title{Roladex}
-   \query{
-    \open\query
-    \isect{\taxon{Person}}{\tag{\topic}}
+   \query\datalog{
+    ?X -: {\rel/has-taxon ?X '{Person}}{\rel/has-tag ?X '{\topic}}
    }
   }
 }

--- a/trees/people/ericwieser.tree
+++ b/trees/people/ericwieser.tree
@@ -1,4 +1,4 @@
 \title{Eric Wieser}
-\taxon{person}
+\taxon{Person}
 \meta{external}{https://github.com/eric-wieser}
 \meta{orcid}{0000-0003-0412-4978}

--- a/trees/people/jonmsterling.tree
+++ b/trees/people/jonmsterling.tree
@@ -1,5 +1,5 @@
 \title{Jon Sterling}
-\taxon{person}
+\taxon{Person}
 
 \p{Jon Sterling is an \em{Associate Professor in Logical Foundations and Formal Methods} at the [University of Cambridge](https://www.cst.cam.ac.uk/people/js2878/). Jon Sterling studies programming languages and semantics using type theory, category theory, domain theory, and topos theory as a guide. Jon Sterling's other interests include Near Eastern, Classical, and Germanic philology.}
 

--- a/trees/people/utensil.tree
+++ b/trees/people/utensil.tree
@@ -1,5 +1,5 @@
 \title{Utensil Song}
-\taxon{person}
+\taxon{Person}
 \meta{external}{https://github.com/utensil}
 \meta{orcid}{0000-0003-3994-4466}
 \meta{position}{Independent researcher}

--- a/trees/refs/abbott2024flashattention.tree
+++ b/trees/refs/abbott2024flashattention.tree
@@ -2,7 +2,7 @@
 \title{FlashAttention on a napkin: A diagrammatic approach to deep learning IO-awareness}
 \date{2024}
 \author/literal{Vincent Abbott}\author/literal{Gioele Zardini}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{abbott2024flashattention,

--- a/trees/refs/ablamowicz2004lectures.tree
+++ b/trees/refs/ablamowicz2004lectures.tree
@@ -2,7 +2,7 @@
 \title{Lectures on clifford (geometric) algebras and applications}
 \date{2004}
 \author/literal{Rafal Ablamowicz}\author/literal{Garret Sobczyk}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{ablamowicz2004lectures,

--- a/trees/refs/ablamowicz2016clifford.tree
+++ b/trees/refs/ablamowicz2016clifford.tree
@@ -2,7 +2,7 @@
 \title{On clifford algebras and related finite groups and group algebras}
 \date{2016}
 \author/literal{Rafal Ablamowicz}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{ablamowicz2016clifford,

--- a/trees/refs/ablamowicz2016structure.tree
+++ b/trees/refs/ablamowicz2016structure.tree
@@ -2,7 +2,7 @@
 \title{On the structure theorem of clifford algebras}
 \date{2016}
 \author/literal{Rafal Ablamowicz}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{ablamowicz2016structure,

--- a/trees/refs/achourioti2011formalization.tree
+++ b/trees/refs/achourioti2011formalization.tree
@@ -2,7 +2,7 @@
 \title{A formalization of kant’s transcendental logic}
 \date{2011}
 \author/literal{Theodora Achourioti}\author/literal{Michiel Van Lambalgen}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{achourioti2011formalization,

--- a/trees/refs/ahle2024tensor.tree
+++ b/trees/refs/ahle2024tensor.tree
@@ -2,7 +2,7 @@
 \title{The tensor cookbook}
 \date{2024}
 \author/literal{Thomas Dybdahl Ahle}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://github.com/thomasahle/tensorgrad/blob/main/paper/cookbook.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/albantakis2023integrated.tree
+++ b/trees/refs/albantakis2023integrated.tree
@@ -2,7 +2,7 @@
 \title{Integrated information theory (IIT) 4.0: Formulating the properties of phenomenal existence in physical terms}
 \date{2023}
 \author/literal{Larissa Albantakis}\author/literal{Leonardo Barbosa}\author/literal{Graham Findlay}\author/literal{Matteo Grasso}\author/literal{Andrew M Haun}\author/literal{William Marshall}\author/literal{William GP Mayner}\author/literal{Alireza Zaeemzadeh}\author/literal{Melanie Boly}\author/literal{Bjørn E Juel}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{albantakis2023integrated,

--- a/trees/refs/albuquerque2002clifford.tree
+++ b/trees/refs/albuquerque2002clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras obtained by twisting of group algebras}
 \date{2002}
 \author/literal{Helena Albuquerque}\author/literal{Shahn Majid}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/math/0011040}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/aragon2009reflections.tree
+++ b/trees/refs/aragon2009reflections.tree
@@ -2,7 +2,7 @@
 \title{Reflections, rotations, and pythagorean numbers}
 \date{2009}
 \author/literal{G Aragón-González}\author/literal{JL Aragón}\author/literal{Marco Antonio Rodriguez-Andrade}\author/literal{L Verde-Star}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{aragon2009reflections,

--- a/trees/refs/armstrong2003making.tree
+++ b/trees/refs/armstrong2003making.tree
@@ -2,7 +2,7 @@
 \title{Making reliable distributed systems in the presence of software errors}
 \date{2003}
 \author/literal{Joe Armstrong}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @phdthesis{armstrong2003making,

--- a/trees/refs/atiyah1964clifford.tree
+++ b/trees/refs/atiyah1964clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford modules}
 \date{1964}
 \author/literal{Michael F Atiyah}\author/literal{Raoul Bott}\author/literal{Arnold Shapiro}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{atiyah1964clifford,

--- a/trees/refs/ba2016layer.tree
+++ b/trees/refs/ba2016layer.tree
@@ -2,7 +2,7 @@
 \title{Layer normalization}
 \date{2016}
 \author/literal{Jimmy Lei Ba}\author/literal{Jamie Ryan Kiros}\author/literal{Geoffrey E Hinton}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/1607.06450}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/bach2024learning.tree
+++ b/trees/refs/bach2024learning.tree
@@ -2,7 +2,7 @@
 \title{Learning theory from first principles}
 \date{2024}
 \author/literal{Francis Bach}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{bach2024learning,

--- a/trees/refs/baez2002octonions.tree
+++ b/trees/refs/baez2002octonions.tree
@@ -2,7 +2,7 @@
 \title{The octonions}
 \date{2002}
 \author/literal{John Baez}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/math/0105155.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/baez2010algebra.tree
+++ b/trees/refs/baez2010algebra.tree
@@ -2,7 +2,7 @@
 \title{The algebra of grand unified theories}
 \date{2010}
 \author/literal{John Baez}\author/literal{John Huerta}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{baez2010algebra,

--- a/trees/refs/bahdanau2014neural.tree
+++ b/trees/refs/bahdanau2014neural.tree
@@ -2,7 +2,7 @@
 \title{Neural machine translation by jointly learning to align and translate}
 \date{2014}
 \author/literal{Dzmitry Bahdanau}\author/literal{Kyunghyun Cho}\author/literal{Yoshua Bengio}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/1409.0473}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/bao2023all.tree
+++ b/trees/refs/bao2023all.tree
@@ -2,7 +2,7 @@
 \title{All are worth words: A ViT backbone for diffusion models}
 \date{2023}
 \author/literal{Fan Bao}\author/literal{Shen Nie}\author/literal{Kaiwen Xue}\author/literal{Yue Cao}\author/literal{Chongxuan Li}\author/literal{Hang Su}\author/literal{Jun Zhu}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{bao2023all,

--- a/trees/refs/bar2011spin.tree
+++ b/trees/refs/bar2011spin.tree
@@ -2,7 +2,7 @@
 \title{Lecture notes in spin geometry}
 \date{2018}
 \author/literal{Christian Bär}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.math.uni-potsdam.de/en/professuren/geometry/teaching/lecture-notes}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/bayliss2019geometric.tree
+++ b/trees/refs/bayliss2019geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric algebra workbook}
 \date{2019}
 \author/literal{William Bayliss}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://web4.uwindsor.ca/users/b/baylis/main.nsf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/bennett2024anything.tree
+++ b/trees/refs/bennett2024anything.tree
@@ -2,7 +2,7 @@
 \title{Why is anything conscious?}
 \date{2024}
 \author/literal{Michael Timothy Bennett}\author/literal{Sean Welsh}\author/literal{Anna Ciaunica}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{bennett2024anything,

--- a/trees/refs/bentkamp2023verified.tree
+++ b/trees/refs/bentkamp2023verified.tree
@@ -2,7 +2,7 @@
 \title{Verified reductions for optimization}
 \date{2023}
 \author/literal{Alexander Bentkamp}\author/literal{Ramon Fernández Mir}\author/literal{Jeremy Avigad}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{bentkamp2023verified,

--- a/trees/refs/berzins2024geometry.tree
+++ b/trees/refs/berzins2024geometry.tree
@@ -2,7 +2,7 @@
 \title{Geometry-informed neural networks}
 \date{2024}
 \author/literal{Arturs Berzins}\author/literal{Andreas Radler}\author/literal{Sebastian Sanokowski}\author/literal{Sepp Hochreiter}\author/literal{Johannes Brandstetter}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{berzins2024geometry,

--- a/trees/refs/bielas2023applications.tree
+++ b/trees/refs/bielas2023applications.tree
@@ -2,7 +2,7 @@
 \title{Applications of topos theory to quantum physics}
 \date{2023}
 \author/literal{Krzysztof BIELAS}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @phdthesis{bielas2023applications,

--- a/trees/refs/bonzio2018nxnxn.tree
+++ b/trees/refs/bonzio2018nxnxn.tree
@@ -2,7 +2,7 @@
 \title{On the nxnxn rubik’s cube}
 \date{2018}
 \author/literal{Stefano Bonzio}\author/literal{Andrea Loi}\author/literal{Luisa Peruzzi}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{bonzio2018nxnxn,

--- a/trees/refs/bordg2022simple.tree
+++ b/trees/refs/bordg2022simple.tree
@@ -2,7 +2,7 @@
 \title{Simple type theory is not too simple: Grothendieck’s schemes without dependent types}
 \date{2022}
 \author/literal{Anthony Bordg}\author/literal{Lawrence Paulson}\author/literal{Wenda Li}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{bordg2022simple,

--- a/trees/refs/borisov2024adventures.tree
+++ b/trees/refs/borisov2024adventures.tree
@@ -2,7 +2,7 @@
 \title{Adventures in algebraic geometry}
 \date{2024}
 \author/literal{Lev Borisov}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{borisov2024adventures,

--- a/trees/refs/bosch2013algebraic.tree
+++ b/trees/refs/bosch2013algebraic.tree
@@ -2,7 +2,7 @@
 \title{Algebraic geometry and commutative algebra}
 \date{2013}
 \author/literal{Siegfried Bosch}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{bosch2013algebraic,

--- a/trees/refs/bourbaki2007algebra.tree
+++ b/trees/refs/bourbaki2007algebra.tree
@@ -2,7 +2,7 @@
 \title{Éléments de mathématique. Algèbre. Chapitre 9}
 \date{2007}
 \author/literal{Nicolas Bourbaki}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{bourbaki2007algebra,

--- a/trees/refs/brehmer2023geometric.tree
+++ b/trees/refs/brehmer2023geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric algebra transformers}
 \date{2023}
 \author/literal{Johann Brehmer}\author/literal{Pim De Haan}\author/literal{Sönke Behrends}\author/literal{Taco Cohen}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{brehmer2023geometric,

--- a/trees/refs/broadbent2022categorical.tree
+++ b/trees/refs/broadbent2022categorical.tree
@@ -2,7 +2,7 @@
 \title{Categorical composable cryptography}
 \date{2022}
 \author/literal{Anne Broadbent}\author/literal{Martti Karvonen}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{broadbent2022categorical,

--- a/trees/refs/broden2024knots.tree
+++ b/trees/refs/broden2024knots.tree
@@ -2,7 +2,7 @@
 \title{Knots inside fractals}
 \date{2024}
 \author/literal{Joshua Broden}\author/literal{Malors Espinosa}\author/literal{Noah Nazareth}\author/literal{Niko Voth}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2409.03639}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/brody2023expressivity.tree
+++ b/trees/refs/brody2023expressivity.tree
@@ -2,7 +2,7 @@
 \title{On the expressivity role of LayerNorm in transformers’ attention}
 \date{2023}
 \author/literal{Shaked Brody}\author/literal{Uri Alon}\author/literal{Eran Yahav}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{brody2023expressivity,

--- a/trees/refs/bromborsky2014introduction.tree
+++ b/trees/refs/bromborsky2014introduction.tree
@@ -2,7 +2,7 @@
 \title{An introduction to geometric algebra and calculus}
 \date{2014}
 \author/literal{Alan Bromborsky}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{bromborsky2014introduction,

--- a/trees/refs/broue2024rings.tree
+++ b/trees/refs/broue2024rings.tree
@@ -2,7 +2,7 @@
 \title{From rings and modules to hopf algebras: One flew over the algebraist’s nest}
 \date{2024}
 \author/literal{Michel Broué}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{broue2024rings,

--- a/trees/refs/browne2012grassmann.tree
+++ b/trees/refs/browne2012grassmann.tree
@@ -2,7 +2,7 @@
 \title{Grassmann algebra-volume 1: foundations}
 \date{2012}
 \author/literal{John Browne}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @misc{browne2012grassmann,

--- a/trees/refs/bruneton2020real.tree
+++ b/trees/refs/bruneton2020real.tree
@@ -2,7 +2,7 @@
 \title{Real-time high-quality rendering of non-rotating black holes}
 \date{2020}
 \author/literal{Eric Bruneton}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{bruneton2020real,

--- a/trees/refs/bulacu2011clifford.tree
+++ b/trees/refs/bulacu2011clifford.tree
@@ -2,7 +2,7 @@
 \title{A clifford algebra is a weak hopf algebra in a suitable symmetric monoidal category}
 \date{2011}
 \author/literal{Daniel Bulacu}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{bulacu2011clifford,

--- a/trees/refs/buzzard2022schemes.tree
+++ b/trees/refs/buzzard2022schemes.tree
@@ -2,7 +2,7 @@
 \title{Schemes in lean}
 \date{2022}
 \author/literal{Kevin Buzzard}\author/literal{Chris Hughes}\author/literal{Kenny Lau}\author/literal{Amelia Livingston}\author/literal{Ramon Fernández Mir}\author/literal{Scott Morrison}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{buzzard2022schemes,

--- a/trees/refs/carneiro2019type.tree
+++ b/trees/refs/carneiro2019type.tree
@@ -2,7 +2,7 @@
 \title{The type theory of lean}
 \date{2019}
 \author/literal{Mario Carneiro}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{carneiro2019type,

--- a/trees/refs/carosso2018geometric.tree
+++ b/trees/refs/carosso2018geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric quantization}
 \date{2018}
 \author/literal{Andrea Carosso}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{carosso2018geometric,

--- a/trees/refs/cassiday2015representations.tree
+++ b/trees/refs/cassiday2015representations.tree
@@ -2,7 +2,7 @@
 \title{On representations of semigroups having hypercube-like cayley graphs}
 \date{2015}
 \author/literal{Cody Cassiday}\author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{cassiday2015representations,

--- a/trees/refs/chen2016infinitely.tree
+++ b/trees/refs/chen2016infinitely.tree
@@ -2,7 +2,7 @@
 \title{An infinitely large napkin}
 \date{2016}
 \author/literal{Evan Chen}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @misc{chen2016infinitely,

--- a/trees/refs/cheng2016long.tree
+++ b/trees/refs/cheng2016long.tree
@@ -2,7 +2,7 @@
 \title{Long short-term memory-networks for machine reading}
 \date{2016}
 \author/literal{Jianpeng Cheng}\author/literal{Li Dong}\author/literal{Mirella Lapata}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/1601.06733}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/cheng2019new.tree
+++ b/trees/refs/cheng2019new.tree
@@ -2,7 +2,7 @@
 \title{A new view of generalized clifford algebras}
 \date{2019}
 \author/literal{Tao Cheng}\author/literal{Huilan Li}\author/literal{Yuping Yang}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{cheng2019new,

--- a/trees/refs/chiang2021named.tree
+++ b/trees/refs/chiang2021named.tree
@@ -2,7 +2,7 @@
 \title{Named tensor notation}
 \date{2021}
 \author/literal{David Chiang}\author/literal{Alexander M Rush}\author/literal{Boaz Barak}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2102.13196}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/chisolm2012geometric.tree
+++ b/trees/refs/chisolm2012geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric algebra}
 \date{2012}
 \author/literal{Eric Chisolm}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://arxiv.org/abs/1205.5935}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/chrisman2023geometric.tree
+++ b/trees/refs/chrisman2023geometric.tree
@@ -2,7 +2,7 @@
 \title{A geometric foundation of virtual knot theory}
 \date{2023}
 \author/literal{Micah Chrisman}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{chrisman2023geometric,

--- a/trees/refs/clifford1961algebraic.tree
+++ b/trees/refs/clifford1961algebraic.tree
@@ -2,7 +2,7 @@
 \title{The algebraic theory of semigroups, vol. 1}
 \date{1961}
 \author/literal{Alfred H Clifford}\author/literal{Gordon B Preston}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{clifford1961algebraic,

--- a/trees/refs/cohen1978basic.tree
+++ b/trees/refs/cohen1978basic.tree
@@ -2,7 +2,7 @@
 \title{Basic techniques of combinatorial theory}
 \date{1978}
 \author/literal{Daniel IA Cohen}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{cohen1978basic,

--- a/trees/refs/collas2018dirac.tree
+++ b/trees/refs/collas2018dirac.tree
@@ -2,7 +2,7 @@
 \title{The dirac equation in general relativity, a guide for calculations}
 \date{2018}
 \author/literal{Peter Collas}\author/literal{David Klein}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/1809.02764}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/conlon1964twisted.tree
+++ b/trees/refs/conlon1964twisted.tree
@@ -2,7 +2,7 @@
 \title{Twisted group algebras and their representations}
 \date{1964}
 \author/literal{Samuel B Conlon}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{conlon1964twisted,

--- a/trees/refs/coulon2022ray.tree
+++ b/trees/refs/coulon2022ray.tree
@@ -2,7 +2,7 @@
 \title{Ray-marching thurston geometries}
 \date{2022}
 \author/literal{Rémi Coulon}\author/literal{Elisabetta A Matsumoto}\author/literal{Henry Segerman}\author/literal{Steve J Trettel}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{coulon2022ray,

--- a/trees/refs/cox1997ideals.tree
+++ b/trees/refs/cox1997ideals.tree
@@ -2,7 +2,7 @@
 \title{Ideals, varieties, and algorithms}
 \date{1997}
 \author/literal{David Cox}\author/literal{John Little}\author/literal{Donal O’shea}\author/literal{Moss Sweedler}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{cox1997ideals,

--- a/trees/refs/cutkosky2018introduction.tree
+++ b/trees/refs/cutkosky2018introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to algebraic geometry}
 \date{2018}
 \author/literal{Steven Dale Cutkosky}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{cutkosky2018introduction,

--- a/trees/refs/davis2019zeon.tree
+++ b/trees/refs/davis2019zeon.tree
@@ -2,7 +2,7 @@
 \title{Zeon and idem-clifford formulations of boolean satisfiability}
 \date{2019}
 \author/literal{Amanda Davis}\author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{davis2019zeon,

--- a/trees/refs/de2005role.tree
+++ b/trees/refs/de2005role.tree
@@ -2,7 +2,7 @@
 \title{The role of the rigged hilbert space in quantum mechanics}
 \date{2005}
 \author/literal{Rafael De la Madrid}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{de2005role,

--- a/trees/refs/de2019geometric.tree
+++ b/trees/refs/de2019geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric algebra levenberg-marquardt}
 \date{2019}
 \author/literal{Steven De Keninck}\author/literal{Leo Dorst}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{de2019geometric,

--- a/trees/refs/depies2024octonions.tree
+++ b/trees/refs/depies2024octonions.tree
@@ -2,7 +2,7 @@
 \title{Octonions as clifford-like algebras}
 \date{2024}
 \author/literal{Connor M Depies}\author/literal{Jonathan DH Smith}\author/literal{Mitchell D Ashburn}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/2310.09972}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/dereli2010degenerate.tree
+++ b/trees/refs/dereli2010degenerate.tree
@@ -2,7 +2,7 @@
 \title{Degenerate spin groups as semi-direct products}
 \date{2010}
 \author/literal{Tekin Dereli}\author/literal{Şahin Koçak}\author/literal{Murat Limoncu}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{dereli2010degenerate,

--- a/trees/refs/dolgachev2013introduction.tree
+++ b/trees/refs/dolgachev2013introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to algebraic geometry}
 \date{2013}
 \author/literal{I Dolgachev}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{dolgachev2013introduction,

--- a/trees/refs/dong2025beyond.tree
+++ b/trees/refs/dong2025beyond.tree
@@ -2,7 +2,7 @@
 \title{Beyond limited data: Self-play LLM theorem provers with iterative conjecturing and proving}
 \date{2025}
 \author/literal{Kefan Dong}\author/literal{Tengyu Ma}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2502.00212}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/doran1993lie.tree
+++ b/trees/refs/doran1993lie.tree
@@ -2,7 +2,7 @@
 \title{Lie groups as spin groups}
 \date{1993}
 \author/literal{Chris Doran}\author/literal{David Hestenes}\author/literal{Frank Sommen}\author/literal{Nadine Van Acker}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{doran1993lie,

--- a/trees/refs/doran1994geometric.tree
+++ b/trees/refs/doran1994geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric algebra and its application to mathematical physics}
 \date{1994}
 \author/literal{Christopher John Leslie Doran}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @phdthesis{doran1994geometric,

--- a/trees/refs/doran2003geometric.tree
+++ b/trees/refs/doran2003geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric algebra for physicists}
 \date{2003}
 \author/literal{Chris Doran}\author/literal{Anthony Lasenby}\author/literal{Joan Lasenby}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://geometry.mrao.cam.ac.uk/2007/01/geometric-algebra-for-physicists/}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/dutailly2018clifford.tree
+++ b/trees/refs/dutailly2018clifford.tree
@@ -2,7 +2,7 @@
 \title{CLIFFORD ALGEBRAS-NEW RESULTS}
 \date{2018}
 \author/literal{Jean Claude Dutailly}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{dutailly2018clifford,

--- a/trees/refs/edwards1969twisted.tree
+++ b/trees/refs/edwards1969twisted.tree
@@ -2,7 +2,7 @@
 \title{Twisted group algebras i}
 \date{1969}
 \author/literal{Christopher M Edwards}\author/literal{John T Lewis}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{edwards1969twisted,

--- a/trees/refs/edwards1969twisted2.tree
+++ b/trees/refs/edwards1969twisted2.tree
@@ -2,7 +2,7 @@
 \title{Twisted group algebras II}
 \date{1969}
 \author/literal{CM Edwards}\author/literal{JT Lewis}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{edwards1969twisted2,

--- a/trees/refs/eid2024developing.tree
+++ b/trees/refs/eid2024developing.tree
@@ -2,7 +2,7 @@
 \title{Developing GA-FuL: A generic wide-purpose library for computing with geometric algebra}
 \date{2024}
 \author/literal{Ahmad Hosny Eid}\author/literal{Francisco G Montoya}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{eid2024developing,

--- a/trees/refs/eisenbud2013commutative.tree
+++ b/trees/refs/eisenbud2013commutative.tree
@@ -2,7 +2,7 @@
 \title{Commutative algebra: With a view toward algebraic geometry}
 \date{2013}
 \author/literal{David Eisenbud}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{eisenbud2013commutative,

--- a/trees/refs/estep2024rose.tree
+++ b/trees/refs/estep2024rose.tree
@@ -2,7 +2,7 @@
 \title{Rose: Composable autodiff for the interactive web}
 \date{2024}
 \author/literal{Sam Estep}\author/literal{Wode Ni}\author/literal{Raven Rothkopf}\author/literal{Joshua Sunshine}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{estep2024rose,

--- a/trees/refs/etingof2024introduction.tree
+++ b/trees/refs/etingof2024introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to representation theory}
 \date{2024}
 \author/literal{Pavel et al. Etingof}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{etingof2024introduction,

--- a/trees/refs/etingof2024mathematical.tree
+++ b/trees/refs/etingof2024mathematical.tree
@@ -2,7 +2,7 @@
 \title{Mathematical ideas and notions of quantum field theory}
 \date{2024}
 \author/literal{Pavel Etingof}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2409.03117}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/ewing2022zeon.tree
+++ b/trees/refs/ewing2022zeon.tree
@@ -2,7 +2,7 @@
 \title{Zeon and idem-clifford formulations of hypergraph problems}
 \date{2022}
 \author/literal{Samuel Ewing}\author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/2201.05895.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/faddeev2009lectures.tree
+++ b/trees/refs/faddeev2009lectures.tree
@@ -2,7 +2,7 @@
 \title{Lectures on quantum mechanics for mathematics students}
 \date{2009}
 \author/literal{Ljudvig D Faddeev}\author/literal{Oleg Aleksandrovich I︠A︡kubovskiı̆}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{faddeev2009lectures,

--- a/trees/refs/fang2024identifying.tree
+++ b/trees/refs/fang2024identifying.tree
@@ -2,7 +2,7 @@
 \title{Identifying black holes through space telescopes and deep learning}
 \date{2024}
 \author/literal{Yeqi Fang}\author/literal{Wei Hong}\author/literal{Jun Tao}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{fang2024identifying,

--- a/trees/refs/fantechi2001stacks.tree
+++ b/trees/refs/fantechi2001stacks.tree
@@ -2,7 +2,7 @@
 \title{Stacks for everybody}
 \date{2001}
 \author/literal{Barbara Fantechi}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{fantechi2001stacks,

--- a/trees/refs/fantechi2006fundamental.tree
+++ b/trees/refs/fantechi2006fundamental.tree
@@ -2,7 +2,7 @@
 \title{Fundamental algebraic geometry: Grothendieck’s FGA explained}
 \date{2006}
 \author/literal{B Fantechi}\author/literal{L Göttsche}\author/literal{L Illusie}\author/literal{S Kleiman}\author/literal{N Nitsure}\author/literal{Angelo Vistoli}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{fantechi2006fundamental,

--- a/trees/refs/fauser2002treatise.tree
+++ b/trees/refs/fauser2002treatise.tree
@@ -2,7 +2,7 @@
 \title{A treatise on quantum clifford algebras}
 \date{2002}
 \author/literal{Bertfried Fauser}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{fauser2002treatise,

--- a/trees/refs/fauser2004grade.tree
+++ b/trees/refs/fauser2004grade.tree
@@ -2,7 +2,7 @@
 \title{Grade free product formulae from graßmann-hopf gebras}
 \date{2004}
 \author/literal{Bertfried Fauser}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/math-ph/0208018}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/feinsilver2007zeon.tree
+++ b/trees/refs/feinsilver2007zeon.tree
@@ -2,7 +2,7 @@
 \title{Zeon algebra, fock space, and markov chains}
 \date{2007}
 \author/literal{Philip Feinsilver}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{feinsilver2007zeon,

--- a/trees/refs/feng2023winding.tree
+++ b/trees/refs/feng2023winding.tree
@@ -2,7 +2,7 @@
 \title{Winding numbers on discrete surfaces}
 \date{2023-07}
 \author/literal{Nicole Feng}\author/literal{Mark Gillespie}\author/literal{Keenan Crane}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1145/3592401}
 \meta{external}{https://doi.org/10.1145/3592401}
 

--- a/trees/refs/feng2024heat.tree
+++ b/trees/refs/feng2024heat.tree
@@ -2,7 +2,7 @@
 \title{A heat method for generalized signed distance}
 \date{2024-07}
 \author/literal{Nicole Feng}\author/literal{Keenan Crane}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1145/3658220}
 \meta{external}{https://doi.org/10.1145/3658220}
 

--- a/trees/refs/fernandes2022clifford.tree
+++ b/trees/refs/fernandes2022clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford Algebraic Approach to the De Donder-Weyl Hamiltonian Theory}
 \date{2022}
 \author/literal{Marco Cezar Barbosa Fernandes}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/2112.08483}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/ferrando2024primer.tree
+++ b/trees/refs/ferrando2024primer.tree
@@ -2,7 +2,7 @@
 \title{A primer on the inner workings of transformer-based language models}
 \date{2024}
 \author/literal{Javier Ferrando}\author/literal{Gabriele Sarti}\author/literal{Arianna Bisazza}\author/literal{Marta R Costa-jussà}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{ferrando2024primer,

--- a/trees/refs/figueroa2010spin.tree
+++ b/trees/refs/figueroa2010spin.tree
@@ -2,7 +2,7 @@
 \title{Spin geometry}
 \date{2010}
 \author/literal{José Figueroa-O’Farrill}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://mat.uab.cat/~rubio/csa2017/SpinNotes.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/filimoshina2023some.tree
+++ b/trees/refs/filimoshina2023some.tree
@@ -2,7 +2,7 @@
 \title{On some lie groups in degenerate clifford geometric algebras}
 \date{2023}
 \author/literal{Ekaterina Filimoshina}\author/literal{Dmitry Shirokov}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{filimoshina2023some,

--- a/trees/refs/filimoshina2024note.tree
+++ b/trees/refs/filimoshina2024note.tree
@@ -2,7 +2,7 @@
 \title{A note on centralizers and twisted centralizers in clifford algebras}
 \date{2024}
 \author/literal{Ekaterina Filimoshina}\author/literal{Dmitry Shirokov}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{filimoshina2024note,

--- a/trees/refs/flori2012topos.tree
+++ b/trees/refs/flori2012topos.tree
@@ -2,7 +2,7 @@
 \title{Lectures on topos quantum theory}
 \date{2012}
 \author/literal{Cecilia Flori}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/1207.1744}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/flori2013first.tree
+++ b/trees/refs/flori2013first.tree
@@ -2,7 +2,7 @@
 \title{A first course in topos quantum theory}
 \date{2013}
 \author/literal{Cecilia Flori}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{flori2013first,

--- a/trees/refs/fong2018seven.tree
+++ b/trees/refs/fong2018seven.tree
@@ -2,7 +2,7 @@
 \title{Seven sketches in compositionality: An invitation to applied category theory}
 \date{2018}
 \author/literal{Brendan Fong}\author/literal{David I Spivak}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/1803.05316}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/francis1987topological.tree
+++ b/trees/refs/francis1987topological.tree
@@ -2,7 +2,7 @@
 \title{A topological picturebook}
 \date{1987}
 \author/literal{George K Francis}\author/literal{GK Francis}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{francis1987topological,

--- a/trees/refs/freyd1976properties.tree
+++ b/trees/refs/freyd1976properties.tree
@@ -2,7 +2,7 @@
 \title{Properties invariant within equivalence types of categories}
 \date{1976}
 \author/literal{Peter Freyd}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://angg.twu.net/Freyd76.html}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/fritz2024differential.tree
+++ b/trees/refs/fritz2024differential.tree
@@ -2,7 +2,7 @@
 \title{Differential geometry and general relativity with algebraifolds}
 \date{2024}
 \author/literal{Tobias Fritz}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{fritz2024differential,

--- a/trees/refs/fulton2004representation.tree
+++ b/trees/refs/fulton2004representation.tree
@@ -2,7 +2,7 @@
 \title{Representation theory: A first course}
 \date{2004}
 \author/literal{William Fulton}\author/literal{Joe Harris}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{fulton2004representation,

--- a/trees/refs/fulton2013representation.tree
+++ b/trees/refs/fulton2013representation.tree
@@ -2,7 +2,7 @@
 \title{Representation theory: A first course}
 \date{2013}
 \author/literal{William Fulton}\author/literal{Joe Harris}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{fulton2013representation,

--- a/trees/refs/fushida2020knot.tree
+++ b/trees/refs/fushida2020knot.tree
@@ -2,7 +2,7 @@
 \title{Knot theory}
 \date{2020}
 \author/literal{Shintaro Fushida-Hardy}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{stanford.edu/~sfh/knot.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/gallier2008clifford.tree
+++ b/trees/refs/gallier2008clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras, clifford groups, and a generalization of the quaternions}
 \date{2008}
 \author/literal{Jean Gallier}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{gallier2008clifford,

--- a/trees/refs/gallier2014clifford.tree
+++ b/trees/refs/gallier2014clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras, clifford groups, and a generalization of the quaternions}
 \date{2014}
 \author/literal{Jean Gallier}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{gallier2014clifford,

--- a/trees/refs/garling2011clifford.tree
+++ b/trees/refs/garling2011clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras: An introduction}
 \date{2011}
 \author/literal{David JH Garling}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{garling2011clifford,

--- a/trees/refs/garrity2013algebraic.tree
+++ b/trees/refs/garrity2013algebraic.tree
@@ -2,7 +2,7 @@
 \title{Algebraic geometry: A problem solving approach}
 \date{2013}
 \author/literal{Thomas A Garrity}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{garrity2013algebraic,

--- a/trees/refs/gathmann2013commutative.tree
+++ b/trees/refs/gathmann2013commutative.tree
@@ -2,7 +2,7 @@
 \title{Commutative algebra}
 \date{2013}
 \author/literal{Andreas Gathmann}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://agag-gathmann.math.rptu.de/class/commalg-2013/commalg-2013.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/gathmann2022algebraic.tree
+++ b/trees/refs/gathmann2022algebraic.tree
@@ -2,7 +2,7 @@
 \title{Algebraic geometry}
 \date{2022}
 \author/literal{Andreas Gathmann}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://agag-gathmann.math.rptu.de/class/alggeom-2021/alggeom-2021.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/gathmann2023plane.tree
+++ b/trees/refs/gathmann2023plane.tree
@@ -2,7 +2,7 @@
 \title{Plane algebraic curves}
 \date{2023}
 \author/literal{Andreas Gathmann}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://agag-gathmann.math.rptu.de/class/curves-2023/curves-2023.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/gebhart2023sheaf.tree
+++ b/trees/refs/gebhart2023sheaf.tree
@@ -2,7 +2,7 @@
 \title{Sheaf representation learning}
 \date{2023}
 \author/literal{Thomas Gebhart}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @phdthesis{gebhart2023sheaf,

--- a/trees/refs/gillespie2024ray.tree
+++ b/trees/refs/gillespie2024ray.tree
@@ -2,7 +2,7 @@
 \title{Ray tracing harmonic functions}
 \date{2024}
 \author/literal{Mark Gillespie}\author/literal{Denise Yang}\author/literal{Mario Botsch}\author/literal{Keenan Crane}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{gillespie2024ray,

--- a/trees/refs/glassner1989introduction.tree
+++ b/trees/refs/glassner1989introduction.tree
@@ -2,7 +2,7 @@
 \title{An introduction to ray tracing}
 \date{1989}
 \author/literal{Andrew S Glassner}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{glassner1989introduction,

--- a/trees/refs/grassmann2000extension.tree
+++ b/trees/refs/grassmann2000extension.tree
@@ -2,7 +2,7 @@
 \title{Extension theory}
 \date{2000}
 \author/literal{Hermann Grassmann}\author/literal{Lloyd C Kannenberg}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{grassmann2000extension,

--- a/trees/refs/grinberg2016clifford.tree
+++ b/trees/refs/grinberg2016clifford.tree
@@ -2,7 +2,7 @@
 \title{The clifford algebra and the chevalley map - a computational approach}
 \date{2016}
 \author/literal{Darij Grinberg}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.cip.ifi.lmu.de/~grinberg/algebra/chevalley.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/grothendieck1964elements.tree
+++ b/trees/refs/grothendieck1964elements.tree
@@ -2,7 +2,7 @@
 \title{Éléments de géométrie algébrique}
 \date{1964}
 \author/literal{Alexandre Grothendieck}\author/literal{Jean Dieudonné}\author/literal{Jean Dieudonné}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{grothendieck1964elements,

--- a/trees/refs/gundry2013tutorial.tree
+++ b/trees/refs/gundry2013tutorial.tree
@@ -2,7 +2,7 @@
 \title{A tutorial implementation of dynamic pattern unification}
 \date{2013}
 \author/literal{Adam Gundry}\author/literal{Conor McBride}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{gundry2013tutorial,

--- a/trees/refs/guo2025deepseek.tree
+++ b/trees/refs/guo2025deepseek.tree
@@ -2,7 +2,7 @@
 \title{Deepseek-r1: Incentivizing reasoning capability in llms via reinforcement learning}
 \date{2025}
 \author/literal{Daya Guo}\author/literal{Dejian Yang}\author/literal{Haowei Zhang}\author/literal{Junxiao Song}\author/literal{Ruoyu Zhang}\author/literal{Runxin Xu}\author/literal{Qihao Zhu}\author/literal{Shirong Ma}\author/literal{Peiyi Wang}\author/literal{Xiao Bi}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{guo2025deepseek,

--- a/trees/refs/hadfield2021exploring.tree
+++ b/trees/refs/hadfield2021exploring.tree
@@ -2,7 +2,7 @@
 \title{Exploring novel surface representations via an experimental ray-tracer in cga}
 \date{2021}
 \author/literal{Hugo Hadfield}\author/literal{Sushant Achawal}\author/literal{Joan Lasenby}\author/literal{Anthony Lasenby}\author/literal{Benjamin Young}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{hadfield2021exploring,

--- a/trees/refs/haftmann2013haskell.tree
+++ b/trees/refs/haftmann2013haskell.tree
@@ -2,7 +2,7 @@
 \title{Haskell-style type classes with isabelle/isar}
 \date{2013}
 \author/literal{Florian Haftmann}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @misc{haftmann2013haskell,

--- a/trees/refs/hahn2004clifford.tree
+++ b/trees/refs/hahn2004clifford.tree
@@ -2,7 +2,7 @@
 \title{The clifford algebra in the theory of algebras, quadratic forms, and classical groups}
 \date{2004}
 \author/literal{Alexander J Hahn}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{hahn2004clifford,

--- a/trees/refs/hamilton2023supergeometric.tree
+++ b/trees/refs/hamilton2023supergeometric.tree
@@ -2,7 +2,7 @@
 \title{The supergeometric algebra}
 \date{2023}
 \author/literal{Andrew JS Hamilton}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2212.11998}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/hamilton2023unification.tree
+++ b/trees/refs/hamilton2023unification.tree
@@ -2,7 +2,7 @@
 \title{Unification of the four forces in the spin (11, 1) geometric algebra}
 \date{2023}
 \author/literal{Andrew JS Hamilton}\author/literal{Tyler McMaken}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2307.01243}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/hart1996sphere.tree
+++ b/trees/refs/hart1996sphere.tree
@@ -2,7 +2,7 @@
 \title{Sphere tracing: A geometric method for the antialiased ray tracing of implicit surfaces}
 \date{1996}
 \author/literal{John C Hart}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{hart1996sphere,

--- a/trees/refs/hartshorne1977graduate.tree
+++ b/trees/refs/hartshorne1977graduate.tree
@@ -2,7 +2,7 @@
 \title{Algebraic geometry}
 \date{1977}
 \author/literal{Robin Hartshorne}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{hartshorne1977graduate,

--- a/trees/refs/haydys2024introduction.tree
+++ b/trees/refs/haydys2024introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to gauge theory}
 \date{2024}
 \author/literal{Andriy Haydys}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://haydys.net/misc/IntroGaugeTheory_LectNotes.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/hayman2024lean.tree
+++ b/trees/refs/hayman2024lean.tree
@@ -2,7 +2,7 @@
 \title{A lean and mean introduction to modern general relativity}
 \date{2024}
 \author/literal{Peter Hayman}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{hayman2024lean,

--- a/trees/refs/helmstetter2013minimal.tree
+++ b/trees/refs/helmstetter2013minimal.tree
@@ -2,7 +2,7 @@
 \title{Minimal algorithms for lipschitz monoids and vahlen monoids}
 \date{2013}
 \author/literal{Jacques Helmstetter}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://ccsenet.org/journal/index.php/jmr/article/view/31523}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/henry2024geometry.tree
+++ b/trees/refs/henry2024geometry.tree
@@ -2,7 +2,7 @@
 \title{Geometry of lightning self-attention: Identifiability and dimension}
 \date{2024}
 \author/literal{Nathan W. Henry}\author/literal{Giovanni Luca Marchetti}\author/literal{Kathlén Kohn}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2408.17221}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/hestenes2012clifford.tree
+++ b/trees/refs/hestenes2012clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebra to geometric calculus: A unified language for mathematics and physics}
 \date{1984}
 \author/literal{David Hestenes}\author/literal{Garret Sobczyk}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.springer.com/gp/book/9789027716736}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/himmel2020diagram.tree
+++ b/trees/refs/himmel2020diagram.tree
@@ -2,7 +2,7 @@
 \title{Diagram chasing in interactive theorem proving}
 \date{2020}
 \author/literal{Markus Himmel}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{himmel2020diagram,

--- a/trees/refs/hitzer2012introduction.tree
+++ b/trees/refs/hitzer2012introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to clifford’s geometric algebra}
 \date{2012}
 \author/literal{Eckhard Hitzer}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{hitzer2012introduction,

--- a/trees/refs/hofmann2024koda.tree
+++ b/trees/refs/hofmann2024koda.tree
@@ -2,7 +2,7 @@
 \title{KODA: Knit-program optimization by dependency analysis}
 \date{2024}
 \author/literal{Megan Hofmann}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{hofmann2024koda,

--- a/trees/refs/huang1992quarks.tree
+++ b/trees/refs/huang1992quarks.tree
@@ -2,7 +2,7 @@
 \title{Quarks, leptons & gauge fields}
 \date{1992}
 \author/literal{Kerson Huang}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{huang1992quarks,

--- a/trees/refs/hull2020origametry.tree
+++ b/trees/refs/hull2020origametry.tree
@@ -2,7 +2,7 @@
 \title{Origametry: Mathematical methods in paper folding}
 \date{2020}
 \author/literal{Thomas C Hull}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{hull2020origametry,

--- a/trees/refs/hull2023flat.tree
+++ b/trees/refs/hull2023flat.tree
@@ -2,7 +2,7 @@
 \title{Flat origami is turing complete}
 \date{2023}
 \author/literal{Thomas C Hull}\author/literal{Inna Zakharevich}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2309.07932}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/hutter2024introduction.tree
+++ b/trees/refs/hutter2024introduction.tree
@@ -2,7 +2,7 @@
 \title{An introduction to universal artificial intelligence}
 \date{2024}
 \author/literal{Marcus Hutter}\author/literal{David Quarel}\author/literal{Elliot Catt}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://www.hutter1.net/publ/uaibook2.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/izhakian2016supertropical.tree
+++ b/trees/refs/izhakian2016supertropical.tree
@@ -2,7 +2,7 @@
 \title{Supertropical quadratic forms i}
 \date{2016}
 \author/literal{Zur Izhakian}\author/literal{Manfred Knebusch}\author/literal{Louis Rowen}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1016/j.jpaa.2015.05.043}
 \meta{external}{https://www.sciencedirect.com/science/article/pii/S0022404915001589}
 

--- a/trees/refs/izhikevich2007dynamical.tree
+++ b/trees/refs/izhikevich2007dynamical.tree
@@ -2,7 +2,7 @@
 \title{Dynamical systems in neuroscience}
 \date{2007}
 \author/literal{Eugene M Izhikevich}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.izhikevich.org/publications/dsn/}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/jadczyk2019notes.tree
+++ b/trees/refs/jadczyk2019notes.tree
@@ -2,7 +2,7 @@
 \title{Notes on clifford algebras}
 \date{2019}
 \author/literal{Arkadiusz Jadczyk}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{jadczyk2019notes,

--- a/trees/refs/jadczyk2023bundle.tree
+++ b/trees/refs/jadczyk2023bundle.tree
@@ -2,7 +2,7 @@
 \title{On the bundle of clifford algebras over the space of quadratic forms}
 \date{2023}
 \author/literal{Arkadiusz Jadczyk}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{jadczyk2023bundle,

--- a/trees/refs/james2001representations.tree
+++ b/trees/refs/james2001representations.tree
@@ -2,7 +2,7 @@
 \title{Representations and characters of groups}
 \date{2001}
 \author/literal{Gordon Douglas James}\author/literal{Martin W Liebeck}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{james2001representations,

--- a/trees/refs/james2015gravitational.tree
+++ b/trees/refs/james2015gravitational.tree
@@ -2,7 +2,7 @@
 \title{Gravitational lensing by spinning black holes in astrophysics, and in the movie interstellar}
 \date{2015}
 \author/literal{Oliver James}\author/literal{Eugénie von Tunzelmann}\author/literal{Paul Franklin}\author/literal{Kip S Thorne}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{james2015gravitational,

--- a/trees/refs/james2015visualizing.tree
+++ b/trees/refs/james2015visualizing.tree
@@ -2,7 +2,7 @@
 \title{Visualizing interstellar’s wormhole}
 \date{2015}
 \author/literal{Oliver James}\author/literal{Eugénie von Tunzelmann}\author/literal{Paul Franklin}\author/literal{Kip S Thorne}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{james2015visualizing,

--- a/trees/refs/joot2016exploring2.tree
+++ b/trees/refs/joot2016exploring2.tree
@@ -2,7 +2,7 @@
 \title{Exploring physics with geometric algebra, book II}
 \date{2016}
 \author/literal{Peeter Joot}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://peeterjoot.com/archives/math2015/gabookII.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/karpavicius2013real.tree
+++ b/trees/refs/karpavicius2013real.tree
@@ -2,7 +2,7 @@
 \title{Real-time visualization of moebius transformations in space using quaternionic-bezier approach}
 \date{2013}
 \author/literal{Vytautas Karpavicius}\author/literal{Rimvydas Krasauskas}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{karpavicius2013real,

--- a/trees/refs/kashiwara2006categories.tree
+++ b/trees/refs/kashiwara2006categories.tree
@@ -2,7 +2,7 @@
 \title{Categories and sheaves}
 \date{2006-01}
 \author/literal{Masaki Kashiwara}\author/literal{Pierre Schapira}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1007/3-540-27950-4}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/keeter2020massively.tree
+++ b/trees/refs/keeter2020massively.tree
@@ -2,7 +2,7 @@
 \title{Massively parallel rendering of complex closed-form implicit surfaces}
 \date{2020}
 \author/literal{Matthew J Keeter}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{keeter2020massively,

--- a/trees/refs/keninck2019non.tree
+++ b/trees/refs/keninck2019non.tree
@@ -2,7 +2,7 @@
 \title{Non-parametric realtime rendering of subspace objects in arbitrary geometric algebras}
 \date{2019}
 \author/literal{Steven De Keninck}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{keninck2019non,

--- a/trees/refs/khan2023lectures.tree
+++ b/trees/refs/khan2023lectures.tree
@@ -2,7 +2,7 @@
 \title{Lectures on algebraic stacks}
 \date{2023}
 \author/literal{Adeel A Khan}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{khan2023lectures,

--- a/trees/refs/knapp2006basic.tree
+++ b/trees/refs/knapp2006basic.tree
@@ -2,7 +2,7 @@
 \title{Basic algebra}
 \date{2006}
 \author/literal{Anthony W Knapp}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{knapp2006basic,

--- a/trees/refs/knapp2007advanced.tree
+++ b/trees/refs/knapp2007advanced.tree
@@ -2,7 +2,7 @@
 \title{Advanced algebra}
 \date{2007}
 \author/literal{Anthony W Knapp}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{knapp2007advanced,

--- a/trees/refs/kock2006synthetic.tree
+++ b/trees/refs/kock2006synthetic.tree
@@ -2,7 +2,7 @@
 \title{Synthetic differential geometry}
 \date{2006}
 \author/literal{Anders Kock}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://users-math.au.dk/kock/sdg99.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/komech2019lectures.tree
+++ b/trees/refs/komech2019lectures.tree
@@ -2,7 +2,7 @@
 \title{Lectures on quantum mechanics for mathematicians}
 \date{2019}
 \author/literal{Alexander Komech}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{komech2019lectures,

--- a/trees/refs/kopczynski2022real.tree
+++ b/trees/refs/kopczynski2022real.tree
@@ -2,7 +2,7 @@
 \title{Real-time visualization in anisotropic geometries}
 \date{2022}
 \author/literal{Eryk Kopczyński}\author/literal{Dorota Celińska-Kopczyńska}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{kopczynski2022real,

--- a/trees/refs/kostecki2009differential.tree
+++ b/trees/refs/kostecki2009differential.tree
@@ -2,7 +2,7 @@
 \title{Differential geometry in toposes}
 \date{2009}
 \author/literal{Ryszard Paweł Kostecki}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.fuw.edu.pl/~kostecki/sdg.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/kostecki2011introduction.tree
+++ b/trees/refs/kostecki2011introduction.tree
@@ -2,7 +2,7 @@
 \title{An introduction to topos theory}
 \date{2011}
 \author/literal{Ryszard Paweł Kostecki}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.fuw.edu.pl/~kostecki/ittt.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/krakauer2020information.tree
+++ b/trees/refs/krakauer2020information.tree
@@ -2,7 +2,7 @@
 \title{The information theory of individuality}
 \date{2020}
 \author/literal{David Krakauer}\author/literal{Nils Bertschinger}\author/literal{Eckehard Olbrich}\author/literal{Jessica C Flack}\author/literal{Nihat Ay}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{krakauer2020information,

--- a/trees/refs/kriz2021introduction.tree
+++ b/trees/refs/kriz2021introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to algebraic geometry}
 \date{2021}
 \author/literal{Igor Kriz}\author/literal{Sophie Kriz}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{kriz2021introduction,

--- a/trees/refs/lasenby2024some.tree
+++ b/trees/refs/lasenby2024some.tree
@@ -2,7 +2,7 @@
 \title{Some recent results for su (3) and octonions within the geometric algebra approach to the fundamental forces of nature}
 \date{2024}
 \author/literal{Anthony Lasenby}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/2202.06733}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/lawson2016spin.tree
+++ b/trees/refs/lawson2016spin.tree
@@ -2,7 +2,7 @@
 \title{Spin geometry (pms-38)}
 \date{2016}
 \author/literal{H. Blaine Lawson}\author/literal{Marie-Louise Michelsohn}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{lawson2016spin,

--- a/trees/refs/leinster2016basic.tree
+++ b/trees/refs/leinster2016basic.tree
@@ -2,7 +2,7 @@
 \title{Basic category theory}
 \date{2016}
 \author/literal{Tom Leinster}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/1612.09375}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/leissa2018anydsl.tree
+++ b/trees/refs/leissa2018anydsl.tree
@@ -2,7 +2,7 @@
 \title{AnyDSL: A partial evaluation framework for programming high-performance libraries}
 \date{2018}
 \author/literal{Roland Leißa}\author/literal{Klaas Boesche}\author/literal{Sebastian Hack}\author/literal{Arsène Pérard-Gayot}\author/literal{Richard Membarth}\author/literal{Philipp Slusallek}\author/literal{André Müller}\author/literal{Bertil Schmidt}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{leissa2018anydsl,

--- a/trees/refs/lengyel2001real.tree
+++ b/trees/refs/lengyel2001real.tree
@@ -2,7 +2,7 @@
 \title{Real-time fur over arbitrary surfaces}
 \date{2001}
 \author/literal{Jerome Lengyel}\author/literal{Emil Praun}\author/literal{Adam Finkelstein}\author/literal{Hugues Hoppe}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{lengyel2001real,

--- a/trees/refs/lengyel2024foundations.tree
+++ b/trees/refs/lengyel2024foundations.tree
@@ -2,7 +2,7 @@
 \title{Projective geometric algebra illuminated}
 \date{2024}
 \author/literal{Eric Lengyel}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{lengyel2024foundations,

--- a/trees/refs/li2008invariant.tree
+++ b/trees/refs/li2008invariant.tree
@@ -2,7 +2,7 @@
 \title{Invariant algebras and geometric reasoning}
 \date{2008}
 \author/literal{Hongbo Li}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{li2008invariant,

--- a/trees/refs/li2023camel.tree
+++ b/trees/refs/li2023camel.tree
@@ -2,7 +2,7 @@
 \title{Camel: Communicative agents for" mind" exploration of large language model society}
 \date{2023}
 \author/literal{Guohao Li}\author/literal{Hasan Hammoud}\author/literal{Hani Itani}\author/literal{Dmitrii Khizbullin}\author/literal{Bernard Ghanem}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2303.17760}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/lin2023semantics.tree
+++ b/trees/refs/lin2023semantics.tree
@@ -2,7 +2,7 @@
 \title{Semantics and scheduling for machine knitting compilers}
 \date{2023}
 \author/literal{Jenny Lin}\author/literal{Vidya Narayanan}\author/literal{Yuka Ikarashi}\author/literal{Jonathan Ragan-Kelley}\author/literal{Gilbert Bernstein}\author/literal{James McCann}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{lin2023semantics,

--- a/trees/refs/lipman2024flow.tree
+++ b/trees/refs/lipman2024flow.tree
@@ -2,7 +2,7 @@
 \title{Flow matching guide and code}
 \date{2024}
 \author/literal{Yaron Lipman}\author/literal{Marton Havasi}\author/literal{Peter Holderrieth}\author/literal{Neta Shaul}\author/literal{Matt Le}\author/literal{Brian Karrer}\author/literal{Ricky TQ Chen}\author/literal{David Lopez-Paz}\author/literal{Heli Ben-Hamu}\author/literal{Itai Gat}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{lipman2024flow,

--- a/trees/refs/liu2016lie.tree
+++ b/trees/refs/liu2016lie.tree
@@ -2,7 +2,7 @@
 \title{Notes for lie groups and representations}
 \date{2016}
 \author/literal{Henry Liu}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://member.ipmu.jp/henry.liu/notes/f16-lie-groups.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/liu2018generating.tree
+++ b/trees/refs/liu2018generating.tree
@@ -2,7 +2,7 @@
 \title{Generating wikipedia by summarizing long sequences}
 \date{2018}
 \author/literal{Peter J Liu}\author/literal{Mohammad Saleh}\author/literal{Etienne Pot}\author/literal{Ben Goodrich}\author/literal{Ryan Sepassi}\author/literal{Lukasz Kaiser}\author/literal{Noam Shazeer}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/1801.10198}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/liu2025understanding.tree
+++ b/trees/refs/liu2025understanding.tree
@@ -2,7 +2,7 @@
 \title{Understanding r1-zero-like training: A critical perspective}
 \date{2025}
 \author/literal{Zichen Liu}\author/literal{Changyu Chen}\author/literal{Wenjun Li}\author/literal{Penghui Qi}\author/literal{Tianyu Pang}\author/literal{Chao Du}\author/literal{Wee Sun Lee}\author/literal{Min Lin}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{liu2025understanding,

--- a/trees/refs/lobo2021categories.tree
+++ b/trees/refs/lobo2021categories.tree
@@ -2,7 +2,7 @@
 \title{Categories in symbols}
 \date{2021}
 \author/literal{Matheus Pereira Lobo}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://osf.io/k9fbc/download}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/loret2024universe.tree
+++ b/trees/refs/loret2024universe.tree
@@ -2,7 +2,7 @@
 \title{The universe is not a lie, but actually an hopf, algebra}
 \date{2024}
 \author/literal{Niccoló Loret}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2408.16970}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/lounesto2001clifford.tree
+++ b/trees/refs/lounesto2001clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras and spinors}
 \date{2001}
 \author/literal{Pertti Lounesto}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{lounesto2001clifford,

--- a/trees/refs/love2024role.tree
+++ b/trees/refs/love2024role.tree
@@ -2,7 +2,7 @@
 \title{The role of symmetry in the development of the standard model}
 \date{2024}
 \author/literal{Sherwin T Love}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{love2024role,

--- a/trees/refs/low2023gafro.tree
+++ b/trees/refs/low2023gafro.tree
@@ -2,7 +2,7 @@
 \title{Gafro: Geometric algebra for robotics}
 \date{2023}
 \author/literal{Tobias Löw}\author/literal{Philip Abbet}\author/literal{Sylvain Calinon}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{low2023gafro,

--- a/trees/refs/lundholm2009clifford.tree
+++ b/trees/refs/lundholm2009clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebra, geometric algebra, and applications}
 \date{2009}
 \author/literal{Douglas Lundholm}\author/literal{Lars Svensson}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{lundholm2009clifford,

--- a/trees/refs/lux2010representations.tree
+++ b/trees/refs/lux2010representations.tree
@@ -2,7 +2,7 @@
 \title{Representations of groups: A computational approach}
 \date{2010}
 \author/literal{Klaus Lux}\author/literal{Herbert Pahlings}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{lux2010representations,

--- a/trees/refs/ma2025bitnet.tree
+++ b/trees/refs/ma2025bitnet.tree
@@ -2,7 +2,7 @@
 \title{BitNet b1. 58 2B4T technical report}
 \date{2025}
 \author/literal{Shuming Ma}\author/literal{Hongyu Wang}\author/literal{Shaohan Huang}\author/literal{Xingxing Zhang}\author/literal{Ying Hu}\author/literal{Ting Song}\author/literal{Yan Xia}\author/literal{Furu Wei}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{ma2025bitnet,

--- a/trees/refs/macdonald2017survey.tree
+++ b/trees/refs/macdonald2017survey.tree
@@ -2,7 +2,7 @@
 \title{A survey of geometric algebra and geometric calculus}
 \date{2017}
 \author/literal{Alan Macdonald}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{macdonald2017survey,

--- a/trees/refs/madrid2005role.tree
+++ b/trees/refs/madrid2005role.tree
@@ -2,7 +2,7 @@
 \title{The role of the rigged hilbert space in quantum mechanics}
 \date{2005}
 \author/literal{Rafael De la Madrid}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{madrid2005role,

--- a/trees/refs/mallios2015differential.tree
+++ b/trees/refs/mallios2015differential.tree
@@ -2,7 +2,7 @@
 \title{Differential sheaves and connections: A natural approach to physical geometry}
 \date{2015}
 \author/literal{Anastasios Mallios}\author/literal{Elias Zafiris}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{mallios2015differential,

--- a/trees/refs/mandolesi2022compendium.tree
+++ b/trees/refs/mandolesi2022compendium.tree
@@ -2,7 +2,7 @@
 \title{Compendium on multivector contractions}
 \date{2022}
 \author/literal{André LG Mandolesi}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{mandolesi2022compendium,

--- a/trees/refs/manturov2018knot.tree
+++ b/trees/refs/manturov2018knot.tree
@@ -2,7 +2,7 @@
 \title{Knot theory}
 \date{2018}
 \author/literal{Vassily Olegovich Manturov}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{manturov2018knot,

--- a/trees/refs/marsden2014category.tree
+++ b/trees/refs/marsden2014category.tree
@@ -2,7 +2,7 @@
 \title{Category theory using string diagrams}
 \date{2014}
 \author/literal{Daniel Marsden}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{marsden2014category,

--- a/trees/refs/massot2024teaching.tree
+++ b/trees/refs/massot2024teaching.tree
@@ -2,7 +2,7 @@
 \title{Teaching mathematics using lean and controlled natural language}
 \date{2024}
 \author/literal{Patrick Massot}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{massot2024teaching,

--- a/trees/refs/mathlib2020lean.tree
+++ b/trees/refs/mathlib2020lean.tree
@@ -2,7 +2,7 @@
 \title{The lean mathematical library}
 \date{2020-01-20}
 \author/literal{The mathlib Community}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1145/3372885.3373824}
 \meta{external}{https://doi.org/10.1145/3372885.3373824}
 

--- a/trees/refs/mehrle2015commutative.tree
+++ b/trees/refs/mehrle2015commutative.tree
@@ -2,7 +2,7 @@
 \title{Notes on commutative algebra}
 \date{2015}
 \author/literal{David Mehrle}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{mehrle2015commutative,

--- a/trees/refs/mehrle2017algebraic.tree
+++ b/trees/refs/mehrle2017algebraic.tree
@@ -2,7 +2,7 @@
 \title{Notes on math 6670: Algebraic geometry}
 \date{2017}
 \author/literal{David Mehrle}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{mehrle2017algebraic,

--- a/trees/refs/meinrenken2009lie.tree
+++ b/trees/refs/meinrenken2009lie.tree
@@ -2,7 +2,7 @@
 \title{Lecture notes in MAT 1120HF lie groups and clifford algebras}
 \date{2009}
 \author/literal{Eckhard Meinrenken}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.math.utoronto.ca/mein/teaching/LieClifford/clifford.html}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/meinrenken2013clifford.tree
+++ b/trees/refs/meinrenken2013clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras and lie theory}
 \date{2013}
 \author/literal{Eckhard Meinrenken}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{meinrenken2013clifford,

--- a/trees/refs/meseguer2023custom.tree
+++ b/trees/refs/meseguer2023custom.tree
@@ -2,7 +2,7 @@
 \title{Custom vulkan engine to render black holes in real time using ray-marching}
 \date{2023}
 \author/literal{Roger Meseguer Orrit}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{meseguer2023custom,

--- a/trees/refs/michalek2021invitation.tree
+++ b/trees/refs/michalek2021invitation.tree
@@ -2,7 +2,7 @@
 \title{Invitation to nonlinear algebra}
 \date{2021}
 \author/literal{Mateusz Michałek}\author/literal{Bernd Sturmfels}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{michalek2021invitation,

--- a/trees/refs/michor2008topics.tree
+++ b/trees/refs/michor2008topics.tree
@@ -2,7 +2,7 @@
 \title{Topics in differential geometry}
 \date{2008}
 \author/literal{Peter W Michor}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{michor2008topics,

--- a/trees/refs/mikula2023magnushammer.tree
+++ b/trees/refs/mikula2023magnushammer.tree
@@ -2,7 +2,7 @@
 \title{Magnushammer: A transformer-based approach to premise selection}
 \date{2023}
 \author/literal{Maciej Mikuła}\author/literal{Szymon Antoniak}\author/literal{Szymon Tworkowski}\author/literal{Albert Qiaochu Jiang}\author/literal{Jin Peng Zhou}\author/literal{Christian Szegedy}\author/literal{Łukasz Kuciński}\author/literal{Piotr Miłoś}\author/literal{Yuhuai Wu}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{mikula2023magnushammer,

--- a/trees/refs/milne2012algebraic.tree
+++ b/trees/refs/milne2012algebraic.tree
@@ -2,7 +2,7 @@
 \title{Algebraic geometry}
 \date{2012}
 \author/literal{James S Milne}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{milne2012algebraic,

--- a/trees/refs/mosto2024templex.tree
+++ b/trees/refs/mosto2024templex.tree
@@ -2,7 +2,7 @@
 \title{Templex-based dynamical units for a taxonomy of chaos}
 \date{2024}
 \author/literal{Caterina Mosto}\author/literal{Gisela D Charó}\author/literal{Christophe Letellier}\author/literal{Denisse Sciamarella}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{mosto2024templex,

--- a/trees/refs/moura2015lean.tree
+++ b/trees/refs/moura2015lean.tree
@@ -2,7 +2,7 @@
 \title{The Lean Theorem Prover (System Description)}
 \date{2015}
 \author/literal{Leonardo de Moura}\author/literal{Soonho Kong}\author/literal{Jeremy Avigad}\author/literal{Floris van Doorn}\author/literal{Jakob von Raumer}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1007/978-3-319-21401-6_26}
 \meta{external}{http://link.springer.com/10.1007/978-3-319-21401-6_26}
 

--- a/trees/refs/moura2021lean.tree
+++ b/trees/refs/moura2021lean.tree
@@ -2,7 +2,7 @@
 \title{The lean 4 theorem prover and programming language}
 \date{2021}
 \author/literal{Leonardo de Moura}\author/literal{Sebastian Ullrich}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{moura2021lean,

--- a/trees/refs/mumford1976algebraic.tree
+++ b/trees/refs/mumford1976algebraic.tree
@@ -2,7 +2,7 @@
 \title{Algebraic geometry i: Complex projective varieties}
 \date{1976}
 \author/literal{David Mumford}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{mumford1976algebraic,

--- a/trees/refs/mumford1976algebraic2.tree
+++ b/trees/refs/mumford1976algebraic2.tree
@@ -2,7 +2,7 @@
 \title{Algebraic geometry II (a penultimate draft)}
 \date{1976}
 \author/literal{David Mumford}\author/literal{Tadao Oda}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.dam.brown.edu/people/mumford/alg_geom/papers/AGII.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/murphy2024reinforcement.tree
+++ b/trees/refs/murphy2024reinforcement.tree
@@ -2,7 +2,7 @@
 \title{Reinforcement learning: An overview}
 \date{2024}
 \author/literal{Kevin Murphy}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2412.05265}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/nakahira2023diagrammatic.tree
+++ b/trees/refs/nakahira2023diagrammatic.tree
@@ -2,7 +2,7 @@
 \title{Diagrammatic category theory}
 \date{2023}
 \author/literal{Kenji Nakahira}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{nakahira2023diagrammatic,

--- a/trees/refs/naumann2024matrix.tree
+++ b/trees/refs/naumann2024matrix.tree
@@ -2,7 +2,7 @@
 \title{A matrix-free exact newton method}
 \date{2024}
 \author/literal{Uwe Naumann}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{naumann2024matrix,

--- a/trees/refs/nelson2017visualizing.tree
+++ b/trees/refs/nelson2017visualizing.tree
@@ -2,7 +2,7 @@
 \title{Visualizing hyperbolic honeycombs}
 \date{2017}
 \author/literal{Roice Nelson}\author/literal{Henry Segerman}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{nelson2017visualizing,

--- a/trees/refs/ochs2022missing.tree
+++ b/trees/refs/ochs2022missing.tree
@@ -2,7 +2,7 @@
 \title{On the the missing diagrams in category theory (first-person version)}
 \date{2022}
 \author/literal{Eduardo Ochs}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2204.10630}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/paszke2021getting.tree
+++ b/trees/refs/paszke2021getting.tree
@@ -2,7 +2,7 @@
 \title{Getting to the point: Index sets and parallelism-preserving autodiff for pointful array programming}
 \date{2021}
 \author/literal{Adam Paszke}\author/literal{Daniel D Johnson}\author/literal{David Duvenaud}\author/literal{Dimitrios Vytiniotis}\author/literal{Alexey Radul}\author/literal{Matthew J Johnson}\author/literal{Jonathan Ragan-Kelley}\author/literal{Dougal Maclaurin}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{paszke2021getting,

--- a/trees/refs/peng2024eagle.tree
+++ b/trees/refs/peng2024eagle.tree
@@ -2,7 +2,7 @@
 \title{Eagle and finch: RWKV with matrix-valued states and dynamic recurrence}
 \date{2024}
 \author/literal{Bo Peng}\author/literal{Daniel Goldstein}\author/literal{Quentin Anthony}\author/literal{Alon Albalak}\author/literal{Eric Alcaide}\author/literal{Stella Biderman}\author/literal{Eugene Cheah}\author/literal{Teddy Ferdinan}\author/literal{Haowen Hou}\author/literal{Przemysław Kazienko}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{peng2024eagle,

--- a/trees/refs/peng2025rwkv.tree
+++ b/trees/refs/peng2025rwkv.tree
@@ -2,7 +2,7 @@
 \title{Rwkv-7 "goose" with expressive dynamic state evolution}
 \date{2025}
 \author/literal{Bo Peng}\author/literal{Ruichong Zhang}\author/literal{Daniel Goldstein}\author/literal{Eric Alcaide}\author/literal{Haowen Hou}\author/literal{Janna Lu}\author/literal{William Merrill}\author/literal{Guangyu Song}\author/literal{Kaifeng Tan}\author/literal{Saiteja Utpala}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{peng2025rwkv,

--- a/trees/refs/pepe2024staresnet.tree
+++ b/trees/refs/pepe2024staresnet.tree
@@ -2,7 +2,7 @@
 \title{STAResNet: A network in spacetime algebra to solve maxwell’s PDEs}
 \date{2024}
 \author/literal{Alberto Pepe}\author/literal{Sven Buchholz}\author/literal{Joan Lasenby}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{pepe2024staresnet,

--- a/trees/refs/perard2017ratrace.tree
+++ b/trees/refs/perard2017ratrace.tree
@@ -2,7 +2,7 @@
 \title{RaTrace: Simple and efficient abstractions for BVH ray traversal algorithms}
 \date{2017}
 \author/literal{Arsène Pérard-Gayot}\author/literal{Martin Weier}\author/literal{Richard Membarth}\author/literal{Philipp Slusallek}\author/literal{Roland Leißa}\author/literal{Sebastian Hack}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{perard2017ratrace,

--- a/trees/refs/perwass2009geometric.tree
+++ b/trees/refs/perwass2009geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric algebra with applications in engineering}
 \date{2009}
 \author/literal{Christian Perwass}\author/literal{Herbert Edelsbrunner}\author/literal{Leif Kobbelt}\author/literal{Konrad Polthier}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{perwass2009geometric,

--- a/trees/refs/petersen2008matrix.tree
+++ b/trees/refs/petersen2008matrix.tree
@@ -2,7 +2,7 @@
 \title{The matrix cookbook}
 \date{2008}
 \author/literal{Kaare Brandt Petersen}\author/literal{Michael Syskind Pedersen}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.math.uwaterloo.ca/~hwolkowi/matrixcookbook.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/petersen2024mathematical.tree
+++ b/trees/refs/petersen2024mathematical.tree
@@ -2,7 +2,7 @@
 \title{Mathematical theory of deep learning}
 \date{2024}
 \author/literal{Philipp Petersen}\author/literal{Jakob Zech}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2407.18384}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/petrisan2023introduction.tree
+++ b/trees/refs/petrisan2023introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to category theory OPLSS 2023}
 \date{2023}
 \author/literal{Daniela Petrisan}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.cs.uoregon.edu/research/summerschool/summer23/_lectures/Introduction_to_Category_Theory_notes.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/pharr2023physically.tree
+++ b/trees/refs/pharr2023physically.tree
@@ -2,7 +2,7 @@
 \title{Physically based rendering: From theory to implementation}
 \date{2023}
 \author/literal{Matt Pharr}\author/literal{Wenzel Jakob}\author/literal{Greg Humphreys}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{pharr2023physically,

--- a/trees/refs/phuong2022formal.tree
+++ b/trees/refs/phuong2022formal.tree
@@ -2,7 +2,7 @@
 \title{Formal algorithms for transformers}
 \date{2022}
 \author/literal{Mary Phuong}\author/literal{Marcus Hutter}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://arxiv.org/abs/2207.09238}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/pinkall2024differential.tree
+++ b/trees/refs/pinkall2024differential.tree
@@ -2,7 +2,7 @@
 \title{Differential geometry: From elastic curves to willmore surfaces}
 \date{2024}
 \author/literal{Ulrich Pinkall}\author/literal{Oliver Gross}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://olligross.github.io/projects/DGCS/DGCS_project.html}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/pitts2001categorical.tree
+++ b/trees/refs/pitts2001categorical.tree
@@ -2,7 +2,7 @@
 \title{Categorical logic}
 \date{2001}
 \author/literal{Andrew M Pitts}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{pitts2001categorical,

--- a/trees/refs/popescu2025exploiting.tree
+++ b/trees/refs/popescu2025exploiting.tree
@@ -2,7 +2,7 @@
 \title{Exploiting undefined behavior in c/c++ programs for optimization: A study on the performance impact}
 \date{2025}
 \author/literal{Lucian Popescu}\author/literal{Nuno P. Lopes}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1145/3729260}
 \meta{external}{https://web.ist.utl.pt/nuno.lopes/pubs/ub-pldi25.pdf}
 

--- a/trees/refs/porteous1995clifford.tree
+++ b/trees/refs/porteous1995clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras and the classical groups}
 \date{1995}
 \author/literal{Ian R Porteous}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{porteous1995clifford,

--- a/trees/refs/prahauser2022hegel.tree
+++ b/trees/refs/prahauser2022hegel.tree
@@ -2,7 +2,7 @@
 \title{Hegel in mathematics}
 \date{2022}
 \author/literal{Alexander Prähauser}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{prahauser2022hegel,

--- a/trees/refs/prasolov1995intuitive.tree
+++ b/trees/refs/prasolov1995intuitive.tree
@@ -2,7 +2,7 @@
 \title{Intuitive topology}
 \date{1995}
 \author/literal{Viktor Vasilʹevich Prasolov}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{prasolov1995intuitive,

--- a/trees/refs/press2021train.tree
+++ b/trees/refs/press2021train.tree
@@ -2,7 +2,7 @@
 \title{Train short, test long: Attention with linear biases enables input length extrapolation}
 \date{2021}
 \author/literal{Ofir Press}\author/literal{Noah A Smith}\author/literal{Mike Lewis}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2108.12409}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/quevedo2024cambridge.tree
+++ b/trees/refs/quevedo2024cambridge.tree
@@ -2,7 +2,7 @@
 \title{Cambridge lectures on the standard model}
 \date{2024}
 \author/literal{Fernando Quevedo}\author/literal{Andreas Schachner}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2409.09211}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/raissi2019physics.tree
+++ b/trees/refs/raissi2019physics.tree
@@ -2,7 +2,7 @@
 \title{Physics-informed neural networks: A deep learning framework for solving forward and inverse problems involving nonlinear partial differential equations}
 \date{2019}
 \author/literal{Maziar Raissi}\author/literal{Paris Perdikaris}\author/literal{George E Karniadakis}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{raissi2019physics,

--- a/trees/refs/randy2023matrix.tree
+++ b/trees/refs/randy2023matrix.tree
@@ -2,7 +2,7 @@
 \title{Matrix representations of clifford algebras}
 \date{2023}
 \author/literal{Randy S}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.cphysics.org/article/86175.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/raptis2024functoriality.tree
+++ b/trees/refs/raptis2024functoriality.tree
@@ -2,7 +2,7 @@
 \title{Functoriality in finitary vacuum einstein gravity and free yang-mills theories from an abstract differential geometric perspective}
 \date{2024}
 \author/literal{Ioannis Raptis}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{raptis2024functoriality,

--- a/trees/refs/ren2025deepseekproverv2.tree
+++ b/trees/refs/ren2025deepseekproverv2.tree
@@ -2,7 +2,7 @@
 \title{DeepSeek-prover-V2: Advancing formal mathematical reasoning via reinforcement learning for subgoal decomposition}
 \date{2025}
 \author/literal{Z. Z. Ren}\author/literal{Zhihong Shao}\author/literal{Junxiao Song}\author/literal{Huajian Xin}\author/literal{Haocheng Wang}\author/literal{Wanjia Zhao}\author/literal{Liyue Zhang}\author/literal{Zhe Fu}\author/literal{Qihao Zhu}\author/literal{Dejian Yang}\author/literal{Z. F. Wu}\author/literal{Zhibin Gou}\author/literal{Shirong Ma}\author/literal{Hongxuan Tang}\author/literal{Yuxuan Liu}\author/literal{Wenjun Gao}\author/literal{Daya Guo}\author/literal{Chong Ruan}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2504.21801}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/renaud2020clifford.tree
+++ b/trees/refs/renaud2020clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras lecture notes on applications in physics}
 \date{2020}
 \author/literal{Pierre Renaud}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @misc{renaud2020clifford,

--- a/trees/refs/reynoso2023probing.tree
+++ b/trees/refs/reynoso2023probing.tree
@@ -2,7 +2,7 @@
 \title{Probing clifford algebras through spin groups: A standard model perspective}
 \date{2023}
 \author/literal{Armando Reynoso}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/2312.10071}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/rhodes1991elementary.tree
+++ b/trees/refs/rhodes1991elementary.tree
@@ -2,7 +2,7 @@
 \title{Elementary representation and character theory of finite semigroups and its application}
 \date{1991}
 \author/literal{John Rhodes}\author/literal{Yechezkel Zalcstein}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{rhodes1991elementary,

--- a/trees/refs/riccardo2024towards.tree
+++ b/trees/refs/riccardo2024towards.tree
@@ -2,7 +2,7 @@
 \title{Towards a categorical foundation of deep learning: A survey}
 \date{2024}
 \author/literal{Francesco Riccardo Crescenzi}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2410.05353}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/riehl2017category.tree
+++ b/trees/refs/riehl2017category.tree
@@ -2,7 +2,7 @@
 \title{Category theory in context}
 \date{2017}
 \author/literal{Emily Riehl}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{riehl2017category,

--- a/trees/refs/rodriguez1996clifford.tree
+++ b/trees/refs/rodriguez1996clifford.tree
@@ -2,7 +2,7 @@
 \title{On clifford representation of hopf algebras and fierz identities}
 \date{1996}
 \author/literal{Suemi Rodrı́guez-Romo}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{rodriguez1996clifford,

--- a/trees/refs/roelfs2023graded.tree
+++ b/trees/refs/roelfs2023graded.tree
@@ -2,7 +2,7 @@
 \title{Graded symmetry groups: Plane and simple}
 \date{2023}
 \author/literal{Martin Roelfs}\author/literal{Steven De Keninck}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{roelfs2023graded,

--- a/trees/refs/roelfs2025willing.tree
+++ b/trees/refs/roelfs2025willing.tree
@@ -2,7 +2,7 @@
 \title{The willing kingdon clifford algebra library}
 \date{2025}
 \author/literal{Martin Roelfs}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2503.10451}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/rogozhnikov2021einops.tree
+++ b/trees/refs/rogozhnikov2021einops.tree
@@ -2,7 +2,7 @@
 \title{Einops: Clear and reliable tensor manipulations with einstein-like notation}
 \date{2021}
 \author/literal{Alex Rogozhnikov}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://openreview.net/forum?id=oapKSVM2bcj}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/rosen2019geometric.tree
+++ b/trees/refs/rosen2019geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric multivector analysis}
 \date{2019}
 \author/literal{Andreas Rosén}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{rosen2019geometric,

--- a/trees/refs/rosiak2022sheaf.tree
+++ b/trees/refs/rosiak2022sheaf.tree
@@ -2,7 +2,7 @@
 \title{Sheaf theory through examples}
 \date{2022}
 \author/literal{Daniel Rosiak}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{rosiak2022sheaf,

--- a/trees/refs/rossel2024bridging.tree
+++ b/trees/refs/rossel2024bridging.tree
@@ -2,7 +2,7 @@
 \title{Bridging syntax and semantics of lean expressions in e-graphs}
 \date{2024}
 \author/literal{Marcus Rossel}\author/literal{Andrés Goens}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{rossel2024bridging,

--- a/trees/refs/rossel2024equality.tree
+++ b/trees/refs/rossel2024equality.tree
@@ -2,7 +2,7 @@
 \title{An equality saturation tactic for lean}
 \date{2024}
 \author/literal{Marcus Rossel}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{rossel2024equality,

--- a/trees/refs/ruhe2023clifford.tree
+++ b/trees/refs/ruhe2023clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford group equivariant neural networks}
 \date{2023}
 \author/literal{David Ruhe}\author/literal{Johannes Brandstetter}\author/literal{Patrick Forré}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{ruhe2023clifford,

--- a/trees/refs/ruhe2024clifford.tree
+++ b/trees/refs/ruhe2024clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford group equivariant neural networks}
 \date{2024}
 \author/literal{David Ruhe}\author/literal{Johannes Brandstetter}\author/literal{Patrick Forré}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{ruhe2024clifford,

--- a/trees/refs/salkinder2021nxnxn.tree
+++ b/trees/refs/salkinder2021nxnxn.tree
@@ -2,7 +2,7 @@
 \title{Nxnxn rubik’s cubes and god’s number}
 \date{2021}
 \author/literal{Daniel Salkinder}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2112.08602}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/schapira2023introduction.tree
+++ b/trees/refs/schapira2023introduction.tree
@@ -2,7 +2,7 @@
 \title{An introduction to categories and sheaves}
 \date{2023}
 \author/literal{Pierre Schapira}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://webusers.imj-prg.fr/~pierre.schapira/LectNotes/CatShv.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/schellingerhout2023circles.tree
+++ b/trees/refs/schellingerhout2023circles.tree
@@ -2,7 +2,7 @@
 \title{Circles in synthetic differential geometry}
 \date{2023}
 \author/literal{Rob Schellingerhout}\author/literal{JW Portegies}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://pure.tue.nl/ws/portalfiles/portal/308028780/Thesis_BTW_Rob_Schellingerhout_Report_002_.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/schleich2023optimizing.tree
+++ b/trees/refs/schleich2023optimizing.tree
@@ -2,7 +2,7 @@
 \title{Optimizing tensor programs on flexible storage}
 \date{2023}
 \author/literal{Maximilian Schleich}\author/literal{Amir Shaikhha}\author/literal{Dan Suciu}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1145/3588717}
 \meta{external}{https://doi.org/10.1145/3588717}
 

--- a/trees/refs/schmid2025gentle.tree
+++ b/trees/refs/schmid2025gentle.tree
@@ -2,7 +2,7 @@
 \title{A gentle introduction to categorical logic and type theory}
 \date{2025}
 \author/literal{Eric Schmid}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://ericschmid-uchicago.github.io/notes/cl_and_tt_v2.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/schmoetten2024construction.tree
+++ b/trees/refs/schmoetten2024construction.tree
@@ -2,7 +2,7 @@
 \title{A construction of the lie algebra of a lie group in isabelle/HOL}
 \date{2024}
 \author/literal{Richard Schmoetten}\author/literal{Jacques D Fleuriot}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{schmoetten2024construction,

--- a/trees/refs/schott2008random.tree
+++ b/trees/refs/schott2008random.tree
@@ -2,7 +2,7 @@
 \title{Random walks on clifford algebras as directed hypercubes}
 \date{2008}
 \author/literal{René Schott}\author/literal{Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{schott2008random,

--- a/trees/refs/schott2011nilpotent.tree
+++ b/trees/refs/schott2011nilpotent.tree
@@ -2,7 +2,7 @@
 \title{Nilpotent adjacency matrices and random graphs}
 \date{2011}
 \author/literal{René Schott}\author/literal{George Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{schott2011nilpotent,

--- a/trees/refs/schott2012operator.tree
+++ b/trees/refs/schott2012operator.tree
@@ -2,7 +2,7 @@
 \title{Operator calculus on graphs: Theory and applications in computer science}
 \date{2012}
 \author/literal{René Schott}\author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{schott2012operator,

--- a/trees/refs/schott2017generalized.tree
+++ b/trees/refs/schott2017generalized.tree
@@ -2,7 +2,7 @@
 \title{Generalized zeon algebras: Theory and application to multi-constrained path problems}
 \date{2017}
 \author/literal{René Schott}\author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{schott2017generalized,

--- a/trees/refs/sen2024string.tree
+++ b/trees/refs/sen2024string.tree
@@ -2,7 +2,7 @@
 \title{String field theory: A review}
 \date{2024}
 \author/literal{Ashoke Sen}\author/literal{Barton Zwiebach}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{sen2024string,

--- a/trees/refs/sengupta2011representing.tree
+++ b/trees/refs/sengupta2011representing.tree
@@ -2,7 +2,7 @@
 \title{Representing finite groups: A semisimple introduction}
 \date{2011}
 \author/literal{Ambar N Sengupta}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{sengupta2011representing,

--- a/trees/refs/serre1955faisceaux.tree
+++ b/trees/refs/serre1955faisceaux.tree
@@ -2,7 +2,7 @@
 \title{Faisceaux algébriques cohérents}
 \date{1955}
 \author/literal{Jean-Pierre Serre}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{serre1955faisceaux,

--- a/trees/refs/serre1956geometrie.tree
+++ b/trees/refs/serre1956geometrie.tree
@@ -2,7 +2,7 @@
 \title{Géométrie algébrique et géométrie analytique}
 \date{1956}
 \author/literal{Jean-Pierre Serre}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{serre1956geometrie,

--- a/trees/refs/serre1977linear.tree
+++ b/trees/refs/serre1977linear.tree
@@ -2,7 +2,7 @@
 \title{Linear representations of finite groups}
 \date{1977}
 \author/literal{Jean-Pierre Serre}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{serre1977linear,

--- a/trees/refs/shaikhha2023nabla.tree
+++ b/trees/refs/shaikhha2023nabla.tree
@@ -2,7 +2,7 @@
 \title{∇SD: Differentiable programming for sparse tensors}
 \date{2023}
 \author/literal{Amir Shaikhha}\author/literal{Mathieu Huot}\author/literal{Shideh Hashemian}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{shaikhha2023nabla,

--- a/trees/refs/shaikhha2024tensor.tree
+++ b/trees/refs/shaikhha2024tensor.tree
@@ -2,7 +2,7 @@
 \title{A tensor algebra compiler for sparse differentiation}
 \date{2024}
 \author/literal{Amir Shaikhha}\author/literal{Mathieu Huot}\author/literal{Shideh Hashemian}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{shaikhha2024tensor,

--- a/trees/refs/shaikhha2O22functional.tree
+++ b/trees/refs/shaikhha2O22functional.tree
@@ -2,7 +2,7 @@
 \title{Functional collection programming with semi-ring dictionaries}
 \date{2022}
 \author/literal{Amir Shaikhha}\author/literal{Mathieu Huot}\author/literal{Jaclyn Smith}\author/literal{Dan Olteanu}
-\taxon{reference}
+\taxon{Reference}
 \meta{doi}{10.1145/3527333}
 \meta{external}{https://doi.org/10.1145/3527333}
 

--- a/trees/refs/sharma2024comprehensive.tree
+++ b/trees/refs/sharma2024comprehensive.tree
@@ -2,7 +2,7 @@
 \title{A comprehensive overview of GPU accelerated databases}
 \date{2024}
 \author/literal{Harshit Sharma}\author/literal{Anmol Sharma}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{sharma2024comprehensive,

--- a/trees/refs/shirley2024ray1.tree
+++ b/trees/refs/shirley2024ray1.tree
@@ -2,7 +2,7 @@
 \title{Ray tracing in one weekend}
 \date{2024}
 \author/literal{Peter Shirley}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://raytracing.github.io/books/RayTracingInOneWeekend.html}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/shirley2024ray2.tree
+++ b/trees/refs/shirley2024ray2.tree
@@ -2,7 +2,7 @@
 \title{Ray tracing: The next week}
 \date{2024}
 \author/literal{Peter Shirley}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://raytracing.github.io/books/RayTracingTheNextWeek.html}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/shirley2024ray3.tree
+++ b/trees/refs/shirley2024ray3.tree
@@ -2,7 +2,7 @@
 \title{Ray tracing: The rest of your life}
 \date{2024}
 \author/literal{Peter Shirley}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://raytracing.github.io/books/RayTracingTheRestOfYourLife.html}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/shirokov2021computing.tree
+++ b/trees/refs/shirokov2021computing.tree
@@ -2,7 +2,7 @@
 \title{On computing the determinant, other characteristic polynomial coefficients, and inverse in clifford algebras of arbitrary dimension}
 \date{2021}
 \author/literal{DS Shirokov}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{shirokov2021computing,

--- a/trees/refs/sims1994computation.tree
+++ b/trees/refs/sims1994computation.tree
@@ -2,7 +2,7 @@
 \title{Computation with finitely presented groups}
 \date{1994}
 \author/literal{Charles C Sims}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{sims1994computation,

--- a/trees/refs/singh2009real.tree
+++ b/trees/refs/singh2009real.tree
@@ -2,7 +2,7 @@
 \title{Real-time ray tracing of implicit surfaces on the GPU}
 \date{2009}
 \author/literal{Jag Mohan Singh}\author/literal{PJ Narayanan}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{singh2009real,

--- a/trees/refs/siskind2019automatic.tree
+++ b/trees/refs/siskind2019automatic.tree
@@ -2,7 +2,7 @@
 \title{Automatic differentiation: Inverse accumulation mode}
 \date{2019}
 \author/literal{Jeffrey Mark Siskind}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{siskind2019automatic,

--- a/trees/refs/smith2004invitation.tree
+++ b/trees/refs/smith2004invitation.tree
@@ -2,7 +2,7 @@
 \title{An invitation to algebraic geometry}
 \date{2004}
 \author/literal{Karen Smith}\author/literal{Lauri Kahanpää}\author/literal{Pekka Kekäläinen}\author/literal{William Traves}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{smith2004invitation,

--- a/trees/refs/smith2024introducing.tree
+++ b/trees/refs/smith2024introducing.tree
@@ -2,7 +2,7 @@
 \title{Introducing category theory}
 \date{2024}
 \author/literal{Peter Smith}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{smith2024introducing,

--- a/trees/refs/sommer2013geometric.tree
+++ b/trees/refs/sommer2013geometric.tree
@@ -2,7 +2,7 @@
 \title{Geometric computing with clifford algebras: Theoretical foundations and applications in computer vision and robotics}
 \date{2013}
 \author/literal{Gerald Sommer}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{sommer2013geometric,

--- a/trees/refs/spinner2024lorentz.tree
+++ b/trees/refs/spinner2024lorentz.tree
@@ -2,7 +2,7 @@
 \title{Lorentz-equivariant geometric algebra transformers for high-energy physics}
 \date{2024}
 \author/literal{Jonas Spinner}\author/literal{Victor Bresó}\author/literal{Pim de Haan}\author/literal{Tilman Plehn}\author/literal{Jesse Thaler}\author/literal{Johann Brehmer}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{spinner2024lorentz,

--- a/trees/refs/spivak2013category.tree
+++ b/trees/refs/spivak2013category.tree
@@ -2,7 +2,7 @@
 \title{Category theory for scientists}
 \date{2013}
 \author/literal{David I Spivak}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{spivak2013category,

--- a/trees/refs/stacks2017stacks.tree
+++ b/trees/refs/stacks2017stacks.tree
@@ -2,7 +2,7 @@
 \title{Stacks Project}
 \date{2017}
 \author/literal{The Stacks Project Authors}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://stacks.math.columbia.edu}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/staples2005clifford.tree
+++ b/trees/refs/staples2005clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford-algebraic random walks on the hypercube}
 \date{2005}
 \author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{staples2005clifford,

--- a/trees/refs/staples2008new.tree
+++ b/trees/refs/staples2008new.tree
@@ -2,7 +2,7 @@
 \title{A new adjacency matrix for finite graphs}
 \date{2008}
 \author/literal{George Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{staples2008new,

--- a/trees/refs/staples2015kravchuk.tree
+++ b/trees/refs/staples2015kravchuk.tree
@@ -2,7 +2,7 @@
 \title{Kravchuk polynomials and induced/reduced operators on clifford algebras}
 \date{2015}
 \author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{staples2015kravchuk,

--- a/trees/refs/staples2017hamiltonian.tree
+++ b/trees/refs/staples2017hamiltonian.tree
@@ -2,7 +2,7 @@
 \title{Hamiltonian cycle enumeration via fermion-zeon convolution}
 \date{2017}
 \author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{staples2017hamiltonian,

--- a/trees/refs/staples2017zeons.tree
+++ b/trees/refs/staples2017zeons.tree
@@ -2,7 +2,7 @@
 \title{Zeons, orthozeons, and graph colorings}
 \date{2017}
 \author/literal{G Stacey Staples}\author/literal{Tiffany Stellhorn}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{staples2017zeons,

--- a/trees/refs/staples2019differential.tree
+++ b/trees/refs/staples2019differential.tree
@@ -2,7 +2,7 @@
 \title{Differential calculus of zeon functions}
 \date{2019}
 \author/literal{G Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{staples2019differential,

--- a/trees/refs/staples2020clifford.tree
+++ b/trees/refs/staples2020clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras and zeons: Geometry to combinatorics and beyond}
 \date{2020}
 \author/literal{George Stacey Staples}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{staples2020clifford,

--- a/trees/refs/sterling2023models.tree
+++ b/trees/refs/sterling2023models.tree
@@ -2,7 +2,7 @@
 \title{Notes on models of type theory}
 \date{2023}
 \author/literal{Jon Sterling}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.jonmsterling.com/jms-00DJ.xml}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/sterling2023monads.tree
+++ b/trees/refs/sterling2023monads.tree
@@ -2,7 +2,7 @@
 \title{Notes on monads and algebras with successor}
 \date{2023}
 \author/literal{Jon Sterling}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.jonmsterling.com/jms-00CB.xml}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/suarez2019expository.tree
+++ b/trees/refs/suarez2019expository.tree
@@ -2,7 +2,7 @@
 \title{Expository paper on clifford algebras, representations, and the octonion algebra}
 \date{2019}
 \author/literal{Ricardo Suarez}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/1906.11460}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/sudbery1986quantum.tree
+++ b/trees/refs/sudbery1986quantum.tree
@@ -2,7 +2,7 @@
 \title{Quantum mechanics and the particles of nature. An outline for mathematicians}
 \date{1986}
 \author/literal{Anthony Sudbery}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{sudbery1986quantum,

--- a/trees/refs/szegedy2017inception.tree
+++ b/trees/refs/szegedy2017inception.tree
@@ -2,7 +2,7 @@
 \title{Inception-v4, inception-resnet and the impact of residual connections on learning}
 \date{2017}
 \author/literal{Christian Szegedy}\author/literal{Sergey Ioffe}\author/literal{Vincent Vanhoucke}\author/literal{Alexander Alemi}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/1602.07261}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/szirmay2022adapting.tree
+++ b/trees/refs/szirmay2022adapting.tree
@@ -2,7 +2,7 @@
 \title{Adapting game engines to curved spaces}
 \date{2022}
 \author/literal{László Szirmay-Kalos}\author/literal{Milán Magdics}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{szirmay2022adapting,

--- a/trees/refs/takhtajan2008quantum.tree
+++ b/trees/refs/takhtajan2008quantum.tree
@@ -2,7 +2,7 @@
 \title{Quantum mechanics for mathematicians graduate studies in mathematics vol 95 (providence, RI: American mathematical society)}
 \date{2008}
 \author/literal{LA Takhtajan}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{takhtajan2008quantum,

--- a/trees/refs/taylor2024introduction.tree
+++ b/trees/refs/taylor2024introduction.tree
@@ -2,7 +2,7 @@
 \title{An introduction to graphical tensor notation for mechanistic interpretability}
 \date{2024}
 \author/literal{Jordan K Taylor}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{taylor2024introduction,

--- a/trees/refs/tie2025survey.tree
+++ b/trees/refs/tie2025survey.tree
@@ -2,7 +2,7 @@
 \title{A survey on post-training of large language models}
 \date{2025}
 \author/literal{Guiyao Tie}\author/literal{Zeli Zhao}\author/literal{Dingjie Song}\author/literal{Fuyang Wei}\author/literal{Rong Zhou}\author/literal{Yurou Dai}\author/literal{Wen Yin}\author/literal{Zhejian Yang}\author/literal{Jiangyue Yan}\author/literal{Yao Su}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{tie2025survey,

--- a/trees/refs/trautman1997clifford.tree
+++ b/trees/refs/trautman1997clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford and the ’square root’ ideas}
 \date{1997}
 \author/literal{Andrzej Trautman}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{trautman1997clifford,

--- a/trees/refs/tricard2024interval.tree
+++ b/trees/refs/tricard2024interval.tree
@@ -2,7 +2,7 @@
 \title{Interval shading: Using mesh shaders to generate shading intervals for volume rendering}
 \date{2024}
 \author/literal{Thibault Tricard}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{tricard2024interval,

--- a/trees/refs/trindade2019clifford.tree
+++ b/trees/refs/trindade2019clifford.tree
@@ -2,7 +2,7 @@
 \title{Clifford algebras, multipartite systems and gauge theory gravity}
 \date{2019}
 \author/literal{Marco AS Trindade}\author/literal{Eric Pinto}\author/literal{Sergio Floquet}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{trindade2019clifford,

--- a/trees/refs/tucker1994applied.tree
+++ b/trees/refs/tucker1994applied.tree
@@ -2,7 +2,7 @@
 \title{Applied combinatorics}
 \date{1994}
 \author/literal{Alan Tucker}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{tucker1994applied,

--- a/trees/refs/turner2023introduction.tree
+++ b/trees/refs/turner2023introduction.tree
@@ -2,7 +2,7 @@
 \title{An introduction to transformers}
 \date{2023}
 \author/literal{Richard E Turner}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://arxiv.org/abs/2304.10557}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/ullrich2023extensible.tree
+++ b/trees/refs/ullrich2023extensible.tree
@@ -2,7 +2,7 @@
 \title{An extensible theorem proving frontend}
 \date{2023}
 \author/literal{Sebastian Andreas Ullrich}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @phdthesis{ullrich2023extensible,

--- a/trees/refs/vakil2024rising.tree
+++ b/trees/refs/vakil2024rising.tree
@@ -2,7 +2,7 @@
 \title{The rising sea: Foundations of algebraic geometry}
 \date{2024}
 \author/literal{Ravi Vakil}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://math.stanford.edu/~vakil/216blog/}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/van2023yoneda.tree
+++ b/trees/refs/van2023yoneda.tree
@@ -2,7 +2,7 @@
 \title{The yoneda lemma}
 \date{2023}
 \author/literal{Q van der Velden}\author/literal{B Kiezebrink}\author/literal{J Grube}\author/literal{W Price}\author/literal{Rashiqa Dawood}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{van2023yoneda,

--- a/trees/refs/van2025comparing.tree
+++ b/trees/refs/van2025comparing.tree
@@ -2,7 +2,7 @@
 \title{Comparing parallel functional array languages: Programming and performance}
 \date{2025}
 \author/literal{David van Balen}\author/literal{Tiziano De Matteis}\author/literal{Clemens Grelck}\author/literal{Troels Henriksen}\author/literal{Aaron W Hsu}\author/literal{Gabriele K Keller}\author/literal{Thomas Koopman}\author/literal{Trevor L McDonell}\author/literal{Cosmin Oancea}\author/literal{Sven-Bodo Scholz}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{van2025comparing,

--- a/trees/refs/vaswani2017attention.tree
+++ b/trees/refs/vaswani2017attention.tree
@@ -2,7 +2,7 @@
 \title{Attention is all you need}
 \date{2017}
 \author/literal{Ashish Vaswani}\author/literal{Noam Shazeer}\author/literal{Niki Parmar}\author/literal{Jakob Uszkoreit}\author/literal{Llion Jones}\author/literal{Aidan N Gomez}\author/literal{Łukasz Kaiser}\author/literal{Illia Polosukhin}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{http://papers.nips.cc/paper/7181-attention-is-all-you-need.pdf}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/villani2024topos.tree
+++ b/trees/refs/villani2024topos.tree
@@ -2,7 +2,7 @@
 \title{The topos of transformer networks}
 \date{2024}
 \author/literal{Mattia Jacopo Villani}\author/literal{Peter McBurney}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2403.18415}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/vistoli2007notes.tree
+++ b/trees/refs/vistoli2007notes.tree
@@ -2,7 +2,7 @@
 \title{Notes on clifford algebras, spin groups and triality}
 \date{2007}
 \author/literal{Angelo Vistoli}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{vistoli2007notes,

--- a/trees/refs/vivo2024book.tree
+++ b/trees/refs/vivo2024book.tree
@@ -2,7 +2,7 @@
 \title{The book of shaders}
 \date{2024}
 \author/literal{Patricio Gonzalez Vivo}\author/literal{Jen Lowe}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://thebookofshaders.com/}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/wang2020spores.tree
+++ b/trees/refs/wang2020spores.tree
@@ -2,7 +2,7 @@
 \title{SPORES: Sum-product optimization via relational equality saturation for large scale linear algebra}
 \date{2020}
 \author/literal{Yisu Remy Wang}\author/literal{Shana Hutchison}\author/literal{Jonathan Leang}\author/literal{Bill Howe}\author/literal{Dan Suciu}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wang2020spores,

--- a/trees/refs/wang2023grammar.tree
+++ b/trees/refs/wang2023grammar.tree
@@ -2,7 +2,7 @@
 \title{Grammar prompting for domain-specific language generation with large language models}
 \date{2023}
 \author/literal{Bailin Wang}\author/literal{Zi Wang}\author/literal{Xuezhi Wang}\author/literal{Yuan Cao}\author/literal{Rif A Saurous}\author/literal{Yoon Kim}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wang2023grammar,

--- a/trees/refs/wang2024agents.tree
+++ b/trees/refs/wang2024agents.tree
@@ -2,7 +2,7 @@
 \title{Agents in software engineering: Survey, landscape, and vision}
 \date{2024}
 \author/literal{Yanlin Wang}\author/literal{Wanjun Zhong}\author/literal{Yanxian Huang}\author/literal{Ensheng Shi}\author/literal{Min Yang}\author/literal{Jiachi Chen}\author/literal{Hui Li}\author/literal{Yuchi Ma}\author/literal{Qianxiang Wang}\author/literal{Zibin Zheng}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wang2024agents,

--- a/trees/refs/wang2024simple.tree
+++ b/trees/refs/wang2024simple.tree
@@ -2,7 +2,7 @@
 \title{A simple approach to differentiable rendering of SDFs}
 \date{2024}
 \author/literal{Zichen Wang}\author/literal{Xi Deng}\author/literal{Ziyi Zhang}\author/literal{Wenzel Jakob}\author/literal{Steve Marschner}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wang2024simple,

--- a/trees/refs/wang2025kimina.tree
+++ b/trees/refs/wang2025kimina.tree
@@ -2,7 +2,7 @@
 \title{Kimina-prover preview: Towards large formal reasoning models with reinforcement learning}
 \date{2025}
 \author/literal{Haiming Wang}\author/literal{Mert Unsal}\author/literal{Xiaohan Lin}\author/literal{Mantas Baksys}\author/literal{Junqi Liu}\author/literal{Marco Dos Santos}\author/literal{Flood Sung}\author/literal{Marina Vinyes}\author/literal{Zhenzhe Ying}\author/literal{Zekai Zhu}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wang2025kimina,

--- a/trees/refs/wang2025m1.tree
+++ b/trees/refs/wang2025m1.tree
@@ -2,7 +2,7 @@
 \title{M1: Towards scalable test-time compute with mamba reasoning models}
 \date{2025}
 \author/literal{Junxiong Wang}\author/literal{Wen-Ding Li}\author/literal{Daniele Paliotta}\author/literal{Daniel Ritter}\author/literal{Alexander M Rush}\author/literal{Tri Dao}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wang2025m1,

--- a/trees/refs/warner2024smarter.tree
+++ b/trees/refs/warner2024smarter.tree
@@ -2,7 +2,7 @@
 \title{Smarter, better, faster, longer: A modern bidirectional encoder for fast, memory efficient, and long context finetuning and inference}
 \date{2024}
 \author/literal{Benjamin Warner}\author/literal{Antoine Chaffin}\author/literal{Benjamin Clavié}\author/literal{Orion Weller}\author/literal{Oskar Hallström}\author/literal{Said Taghadouini}\author/literal{Alexis Gallagher}\author/literal{Raja Biswas}\author/literal{Faisal Ladhak}\author/literal{Tom Aarsen}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{warner2024smarter,

--- a/trees/refs/weber2013lie.tree
+++ b/trees/refs/weber2013lie.tree
@@ -2,7 +2,7 @@
 \title{Lecture notes in MATH 651: Lie algebras}
 \date{2013}
 \author/literal{Brian Weber}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www2.math.upenn.edu/~brweber/Courses/2013/Math651/Math651.html}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/wene1989clifford.tree
+++ b/trees/refs/wene1989clifford.tree
@@ -2,7 +2,7 @@
 \title{The Clifford algebra of an infinite-dimensional space}
 \date{1989}
 \author/literal{G. P. Wene}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wene1989clifford,

--- a/trees/refs/weng2023transformer.tree
+++ b/trees/refs/weng2023transformer.tree
@@ -2,7 +2,7 @@
 \title{The transformer family version 2.0}
 \date{2023}
 \author/literal{Lilian Weng}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://lilianweng.github.io/posts/2023-01-27-the-transformer-family-v2/}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/west2001introduction.tree
+++ b/trees/refs/west2001introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to graph theory}
 \date{2001}
 \author/literal{Douglas Brent West}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{west2001introduction,

--- a/trees/refs/wieser2021scalar.tree
+++ b/trees/refs/wieser2021scalar.tree
@@ -2,7 +2,7 @@
 \title{Scalar actions in lean’s mathlib}
 \date{2021}
 \author/literal{Eric Wieser}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wieser2021scalar,

--- a/trees/refs/wieser2022computing.tree
+++ b/trees/refs/wieser2022computing.tree
@@ -2,7 +2,7 @@
 \title{Computing with the universal properties of the clifford algebra and the even subalgebra}
 \date{2022}
 \author/literal{Eric Wieser}\author/literal{Joan Lasenby}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{wieser2022computing,

--- a/trees/refs/wieser2022even.tree
+++ b/trees/refs/wieser2022even.tree
@@ -2,7 +2,7 @@
 \title{Computing with the universal properties of the clifford algebra and the even subalgebra}
 \date{2022}
 \author/literal{Eric Wieser}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://eric-wieser.github.io/icacga-2022}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/wieser2022formalizing.tree
+++ b/trees/refs/wieser2022formalizing.tree
@@ -2,7 +2,7 @@
 \title{Formalizing geometric algebra in lean}
 \date{2022}
 \author/literal{Eric Wieser}\author/literal{Utensil Song}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wieser2022formalizing,

--- a/trees/refs/wieser2022graded.tree
+++ b/trees/refs/wieser2022graded.tree
@@ -2,7 +2,7 @@
 \title{Graded rings in lean’s dependent type theory}
 \date{2022}
 \author/literal{Eric Wieser}\author/literal{Jujian Zhang}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://eric-wieser.github.io/cicm-2022}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/wieser2022noncommutative.tree
+++ b/trees/refs/wieser2022noncommutative.tree
@@ -2,7 +2,7 @@
 \title{Noncommutative algebras, computer algebra systems, and theorem provers}
 \date{2022}
 \author/literal{Eric Wieser}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://eric-wieser.github.io/divf-2022}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/wieser2023multiple.tree
+++ b/trees/refs/wieser2023multiple.tree
@@ -2,7 +2,7 @@
 \title{Multiple inheritance hazards in algebraic typeclass hierarchies}
 \date{2023}
 \author/literal{Eric Wieser}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wieser2023multiple,

--- a/trees/refs/wieser2024blueprint.tree
+++ b/trees/refs/wieser2024blueprint.tree
@@ -2,7 +2,7 @@
 \title{The blueprint for formalizing geometric algebra in lean}
 \date{2024}
 \author/literal{Eric Wieser}\author/literal{Utensil Song}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://utensil.github.io/lean-ga/blueprint/}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/wieser2024formalizing.tree
+++ b/trees/refs/wieser2024formalizing.tree
@@ -2,7 +2,7 @@
 \title{Formalizing clifford algebras and related constructions in the lean theorem prover}
 \date{2024}
 \author/literal{Eric Wieser}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @phdthesis{wieser2024formalizing,

--- a/trees/refs/williams2025simulating.tree
+++ b/trees/refs/williams2025simulating.tree
@@ -2,7 +2,7 @@
 \title{Simulating time with square-root space}
 \date{2025}
 \author/literal{R Ryan Williams}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{williams2025simulating,

--- a/trees/refs/wilson1979introduction.tree
+++ b/trees/refs/wilson1979introduction.tree
@@ -2,7 +2,7 @@
 \title{Introduction to graph theory}
 \date{1979}
 \author/literal{Robin J Wilson}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{wilson1979introduction,

--- a/trees/refs/wilson2024discrete.tree
+++ b/trees/refs/wilson2024discrete.tree
@@ -2,7 +2,7 @@
 \title{A discrete model for gell-mann matrices}
 \date{2024}
 \author/literal{Robert A Wilson}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/pdf/2401.13000}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/winchenbach2024lipschitz.tree
+++ b/trees/refs/winchenbach2024lipschitz.tree
@@ -2,7 +2,7 @@
 \title{Lipschitz-agnostic, efficient and accurate rendering of implicit surfaces}
 \date{2024}
 \author/literal{Rene Winchenbach}\author/literal{Michael Möller}\author/literal{Andreas Kolb}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{winchenbach2024lipschitz,

--- a/trees/refs/woit2012lie.tree
+++ b/trees/refs/woit2012lie.tree
@@ -2,7 +2,7 @@
 \title{Lecture notes in lie groups and representations: Mathematics G4344}
 \date{2012}
 \author/literal{Peter Woit}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://www.math.columbia.edu/~woit/LieGroups-2012/}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/woit2017quantum.tree
+++ b/trees/refs/woit2017quantum.tree
@@ -2,7 +2,7 @@
 \title{Quantum theory, groups and representations}
 \date{2017}
 \author/literal{Peter Woit}\author{}\author{}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{woit2017quantum,

--- a/trees/refs/wu2024multi.tree
+++ b/trees/refs/wu2024multi.tree
@@ -2,7 +2,7 @@
 \title{A multi-level superoptimizer for tensor programs}
 \date{2024}
 \author/literal{Mengdi Wu}\author/literal{Xinhao Cheng}\author/literal{Oded Padon}\author/literal{Zhihao Jia}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{wu2024multi,

--- a/trees/refs/yang2022delta.tree
+++ b/trees/refs/yang2022delta.tree
@@ -2,7 +2,7 @@
 \title{Aδ: Autodiff for discontinuous programs-applied to shaders}
 \date{2022}
 \author/literal{Yuting Yang}\author/literal{Connelly Barnes}\author/literal{Andrew Adams}\author/literal{Adam Finkelstein}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{yang2022delta,

--- a/trees/refs/yariv2020multiview.tree
+++ b/trees/refs/yariv2020multiview.tree
@@ -2,7 +2,7 @@
 \title{Multiview neural surface reconstruction by disentangling geometry and appearance}
 \date{2020}
 \author/literal{Lior Yariv}\author/literal{Yoni Kasten}\author/literal{Dror Moran}\author/literal{Meirav Galun}\author/literal{Matan Atzmon}\author/literal{Basri Ronen}\author/literal{Yaron Lipman}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{yariv2020multiview,

--- a/trees/refs/yeasin2011initial.tree
+++ b/trees/refs/yeasin2011initial.tree
@@ -2,7 +2,7 @@
 \title{Initial algebra, final coalgebra and datatype}
 \date{2011}
 \author/literal{Masuka Yeasin}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{yeasin2011initial,

--- a/trees/refs/yizengaw2015clifford.tree
+++ b/trees/refs/yizengaw2015clifford.tree
@@ -2,7 +2,7 @@
 \title{On clifford a-algebras and a framework for localization of a-modules}
 \date{2015}
 \author/literal{Belayneh Yibeltal Yizengaw}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @book{yizengaw2015clifford,

--- a/trees/refs/yu2025dapo.tree
+++ b/trees/refs/yu2025dapo.tree
@@ -2,7 +2,7 @@
 \title{Dapo: An open-source llm reinforcement learning system at scale}
 \date{2025}
 \author/literal{Qiying Yu}\author/literal{Zheng Zhang}\author/literal{Ruofei Zhu}\author/literal{Yufeng Yuan}\author/literal{Xiaochen Zuo}\author/literal{Yu Yue}\author/literal{Tiantian Fan}\author/literal{Gaohong Liu}\author/literal{Lingjun Liu}\author/literal{Xin Liu}\author/literal{others}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2503.14476}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/yue2025does.tree
+++ b/trees/refs/yue2025does.tree
@@ -2,7 +2,7 @@
 \title{Does reinforcement learning really incentivize reasoning capacity in LLMs beyond the base model?}
 \date{2025}
 \author/literal{Yang Yue}\author/literal{Zhiqi Chen}\author/literal{Rui Lu}\author/literal{Andrew Zhao}\author/literal{Zhaokai Wang}\author/literal{Shiji Song}\author/literal{Gao Huang}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{yue2025does,

--- a/trees/refs/zhang2021type.tree
+++ b/trees/refs/zhang2021type.tree
@@ -2,7 +2,7 @@
 \title{Type theories in category theory}
 \date{2021}
 \author/literal{Tesla Zhang}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{zhang2021type,

--- a/trees/refs/zhang2024transformers.tree
+++ b/trees/refs/zhang2024transformers.tree
@@ -2,7 +2,7 @@
 \title{Why transformers need adam: A hessian perspective}
 \date{2024}
 \author/literal{Yushun Zhang}\author/literal{Congliang Chen}\author/literal{Tian Ding}\author/literal{Ziniu Li}\author/literal{Ruoyu Sun}\author/literal{Zhiquan Luo}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{zhang2024transformers,

--- a/trees/refs/zhang2025days.tree
+++ b/trees/refs/zhang2025days.tree
@@ -2,7 +2,7 @@
 \title{100 days after DeepSeek-R1: A survey on replication studies and more directions for reasoning language models}
 \date{2025}
 \author/literal{Chong Zhang}\author/literal{Yue Deng}\author/literal{Xiang Lin}\author/literal{Bin Wang}\author/literal{Dianwen Ng}\author/literal{Hai Ye}\author/literal{Xingxuan Li}\author/literal{Yao Xiao}\author/literal{Zhanfeng Mo}\author/literal{Qi Zhang}\author/literal{Lidong Bing}
-\taxon{reference}
+\taxon{Reference}
 \meta{external}{https://arxiv.org/abs/2505.00551}
 
 \meta{bibtex}{\startverb

--- a/trees/refs/zhang2025leanabell.tree
+++ b/trees/refs/zhang2025leanabell.tree
@@ -2,7 +2,7 @@
 \title{Leanabell-prover: Posttraining scaling in formal reasoning}
 \date{2025}
 \author/literal{Jingyuan Zhang}\author/literal{Qi Wang}\author/literal{Xingguang Ji}\author/literal{Yahui Liu}\author/literal{Yang Yue}\author/literal{Fuzheng Zhang}\author/literal{Di Zhang}\author/literal{Guorui Zhou}\author/literal{Kun Gai}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{zhang2025leanabell,

--- a/trees/refs/zhao2024felix.tree
+++ b/trees/refs/zhao2024felix.tree
@@ -2,7 +2,7 @@
 \title{Felix: Optimizing tensor programs with gradient descent}
 \date{2024}
 \author/literal{Yifan Zhao}\author/literal{Hashim Sharif}\author/literal{Vikram Adve}\author/literal{Sasa Misailovic}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @inproceedings{zhao2024felix,

--- a/trees/refs/zhao2025d1.tree
+++ b/trees/refs/zhao2025d1.tree
@@ -2,7 +2,7 @@
 \title{d1: Scaling reasoning in diffusion large language models via reinforcement learning}
 \date{2025}
 \author/literal{Siyan Zhao}\author/literal{Devaansh Gupta}\author/literal{Qinqing Zheng}\author/literal{Aditya Grover}
-\taxon{reference}
+\taxon{Reference}
 
 \meta{bibtex}{\startverb
 @article{zhao2025d1,

--- a/trees/uts-0014.tree
+++ b/trees/uts-0014.tree
@@ -45,9 +45,16 @@
 
     \execute\datalog{\rel/root/transcluded ?X -: {\rel/is-root ?Y}{\rel/transcludes/reflexive-transitive-closure ?Y ?X}}
 
+    \def\rel/links-to/tc{utensil.rel.links-to.transitive-closure}
+    \def\rel/links-to/rtc{utensil.rel.links-to.reflexive-transitive-closure}
+    \execute\datalog{\rel/links-to/tc ?X ?Y -: {\rel/links-to ?X ?Y}}
+    \execute\datalog{\rel/links-to/tc ?X ?Z -: {\rel/links-to/tc ?X ?Y}{\rel/links-to ?Y ?Z}}
+    \execute\datalog{\rel/links-to/rtc ?X ?X -: {\rel/is-node ?X}}
+    \execute\datalog{\rel/links-to/rtc ?X ?Y -: {\rel/links-to/tc ?X ?Y}}
+
     \def\rel/index/links-to{utensil.query.index.links-to}
 
-    \execute\datalog{\rel/index/links-to ?X -: {\rel/is-index ?Y}{\rel/links-to/reflexive-transitive-closure ?Y ?X}}
+    \execute\datalog{\rel/index/links-to ?X -: {\rel/is-index ?Y}{\rel/links-to/rtc ?Y ?X}}
 
 %   \def\query/index{
 %     \tag{interest}
@@ -69,9 +76,9 @@
     \execute\datalog{ \rel/is-special ?X -: {\rel/has-tag ?X '{draft}} }
     \execute\datalog{ \rel/is-special ?X -: {\rel/has-tag ?X '{macro}} }
     \execute\datalog{ \rel/is-special ?X -: {\rel/has-tag ?X '{exp}} }
-    \execute\datalog{ \rel/is-special ?X -: {\rel/has-taxon ?X '{person}} }
-    \execute\datalog{ \rel/is-special ?X -: {\rel/has-taxon ?X '{reference}} }
-    \execute\datalog{ \rel/is-special ?X -: {\rel/has-taxon ?X '{eq}} }
+    \execute\datalog{ \rel/is-special ?X -: {\rel/has-taxon ?X '{Person}} }
+    \execute\datalog{ \rel/is-special ?X -: {\rel/has-taxon ?X '{Reference}} }
+    \execute\datalog{ \rel/is-special ?X -: {\rel/has-taxon ?X '{Eq}} }
     \execute\datalog{ \rel/is-special ?X -: {\rel/has-tag ?X '{mwe}} }
     \execute\datalog{ \rel/is-special ?X -: {\rel/has-tag ?X '{post}} }
 


### PR DESCRIPTION
## Summary
- Define `\rel/links-to/rtc` (reflexive-transitive closure of links-to) as custom datalog rules in `uts-0014.tree` — this was the "last missing piece" for the query port
- Rewrite `\make-topic-bibliography` macro from legacy `\open\query`/`\isect`/`\union`/`\compl` to `\query\datalog{...}` syntax
- Define helper relation `\rel/is-presentation-like` for the union case (workshop references OR presentation taxon)

## How \rel/links-to/rtc is defined
```
\def\rel/links-to/tc{utensil.rel.links-to.transitive-closure}
\def\rel/links-to/rtc{utensil.rel.links-to.reflexive-transitive-closure}
\execute\datalog{\rel/links-to/tc ?X ?Y -: {\rel/links-to ?X ?Y}}
\execute\datalog{\rel/links-to/tc ?X ?Z -: {\rel/links-to/tc ?X ?Y}{\rel/links-to ?Y ?Z}}
\execute\datalog{\rel/links-to/rtc ?X ?X -: {\rel/is-node ?X}}
\execute\datalog{\rel/links-to/rtc ?X ?Y -: {\rel/links-to/tc ?X ?Y}}
```

## Test plan
- [x] `forester build` succeeds
- [x] Full `./build.sh` passes (1191 pages, ~8s)
- [x] `uts-0014` (lost notes) renders with 958 sections — query produces results
- [x] No new errors introduced

## Note on performance
The links-to RTC could be expensive on large forests. If performance degrades after version bump, consider simplifying to direct links only or limiting depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)