### PR TITLE
ci: add lightweight PR lint workflow

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -1,0 +1,35 @@
+name: PR Lint
+
+on:
+  pull_request:
+    paths-ignore:
+      - "LICENSE"
+      - "README.md"
+      - "docs/**"
+
+# Default to bash
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: false
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.2.22
+      - name: Setup Biome
+        uses: biomejs/setup-biome@v2
+        with:
+          version: latest
+      - name: Lint
+        run: |
+          ./chk.sh


### PR DESCRIPTION
## Summary
- Add `pr-lint.yml` workflow that triggers on all PRs
- Runs biome lint only (fast — no OCaml, forester, LaTeX, or WASM setup)
- Disable PR trigger from the full `gh-pages.yml` workflow (full build only on push to main)

## Result
- PRs get fast lint feedback (~30s)
- Full build+deploy only runs on push to main (saves CI minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)