### PR TITLE
fix: bump forester to latest HEAD (5ab7277)

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -101,7 +101,7 @@ jobs:
           sudo apt update
           sudo apt install libev-dev
           # opam pin add forester git+https://git.sr.ht/~jonsterling/ocaml-forester#36285a6bea37eb3f3fbde39f8e9c373a022dec06 --yes
-          opam pin add forester git+https://github.com/utensil/ocaml-forester#2e1207b814fdd382d01f566adb7c557ac782ef67 --yes
+          opam pin add forester git+https://git.sr.ht/~jonsterling/ocaml-forester#5ab7277 --yes
           opam install forester --yes
       # https://github.com/astral-sh/setup-uv
       - name: Setup Python via uv

--- a/prep.sh
+++ b/prep.sh
@@ -19,7 +19,7 @@ if ! which forester &> /dev/null; then
   brew install opam  watchexec
   opam init --auto-setup --yes
   opam update --yes
-  opam pin add forester git+https://git.sr.ht/~jonsterling/ocaml-forester#56de06afe952d752c1a13fdcd8bb56c5fef9956f --yes
+  opam pin add forester git+https://git.sr.ht/~jonsterling/ocaml-forester#5ab7277 --yes
 fi
 
 # if pandoc is not installed


### PR DESCRIPTION
## Summary

- Updates `prep.sh`: opam pin commit changed from `56de06afe952d752c1a13fdcd8bb56c5fef9956f` to `5ab7277` (latest HEAD of `~jonsterling/ocaml-forester`)
- Updates `.github/workflows/gh-pages.yml`: opam pin source changed from `github.com/utensil/ocaml-forester#2e1207b814fdd382d01f566adb7c557ac782ef67` to `git.sr.ht/~jonsterling/ocaml-forester#5ab7277`
- Both now point to the canonical upstream repo at `https://git.sr.ht/~jonsterling/ocaml-forester`

## Installation

`opam pin add forester git+https://git.sr.ht/~jonsterling/ocaml-forester#5ab7277 --yes` succeeded locally. `forester --version` reports `5ab7277`.

## Build issues found (pre-existing, not caused by version bump)

### Warnings in `ca-000O.tree`
Multiple `unresolved_identifier` warnings for `\placeholder`, `\vocab`, `\optional`, `\card`, `\newvocab` — these macros are either not defined or not imported in that tree file.

### Fatal LaTeX error
```
! LaTeX Error: File `diagrams.tex' not found.
```
This occurs when building SVG resources via LaTeX in `macros.tree`. The file `diagrams.tex` is referenced by `\latex-preamble/string-diagrams` but is not present in the local environment. This is a local environment issue unrelated to the forester version bump.

## Notes

- CI already uses OCaml 5.3.0 which satisfies the `5.3+` requirement of latest forester
- The worktree branch is `fix/forester-version-bump-wt`