### PR TITLE
fix: add missing imports to ca-000O.tree

### DIFF
--- a/trees/ca-000O.tree
+++ b/trees/ca-000O.tree
@@ -1,4 +1,5 @@
-% \import{spin-macros}
+\import{macros}
+\import{spin-macros}
 % clifford hopf spin draft
 \tag{clifford}
 


### PR DESCRIPTION
## Summary
- Add `\import{macros}` and `\import{spin-macros}` to `ca-000O.tree`
- Resolves all `warning[unresolved_identifier]` warnings during forester build
- The file used `\placeholder`, `\optional` (from spin-macros) and `\card`, `\vocab`, `\newvocab` (from macros) without importing them

## Test plan
- [x] `forester build` now has 0 unresolved_identifier warnings