### PR TITLE
fix: backup/restore HTML files around forester build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -157,11 +157,39 @@ function needs_update() {
 
 source convert_xml.sh
 
+function backup_html_before_forester() {
+    echo "⭐ Backing up HTML files before forester build"
+    mkdir -p output/forest/.html-bak
+    for html_file in output/forest/*/index.html; do
+        [ -f "$html_file" ] || continue
+        local note_id=$(basename $(dirname "$html_file"))
+        mkdir -p "output/forest/.html-bak/$note_id"
+        cp -f "$html_file" "output/forest/.html-bak/$note_id/index.html" 2>/dev/null || true
+    done
+}
+
+function restore_html_after_forester() {
+    echo "⭐ Restoring HTML files over forester redirect stubs"
+    local restored=0
+    for bak_file in output/forest/.html-bak/*/index.html; do
+        [ -f "$bak_file" ] || continue
+        local note_id=$(basename $(dirname "$bak_file"))
+        local html_file="output/forest/$note_id/index.html"
+        # Only restore if the current HTML is a redirect stub
+        if [ -f "$html_file" ] && grep -q 'meta.*http-equiv.*refresh.*index\.xml' "$html_file" 2>/dev/null; then
+            cp -f "$bak_file" "$html_file"
+            ((restored++))
+        fi
+    done
+    echo "  Restored $restored HTML files over redirect stubs"
+}
+
 function build {
     mkdir -p build
     echo "⭐ Rebuilding bun"
     bun_build
     backup_xml_files
+    backup_html_before_forester
     echo "⭐ Rebuilding forest"
     just forest
     show_result
@@ -170,6 +198,8 @@ function build {
         echo -e "\033[0;31mError: Forest build failed.\033[0m"
         exit 1
     fi
+
+    restore_html_after_forester
 
     # Check if index.xml was generated
     # if [ ! -f "output/index.xml" ]; then


### PR DESCRIPTION
## Summary
Forester 5.x generates HTML redirect stubs (`<meta http-equiv="refresh" content="0;url=index.xml">`) that overwrite our XSL-converted HTML during `forester build`.

This adds two functions to `build.sh`:
- `backup_html_before_forester()` — saves our rendered HTML before forester overwrites it
- `restore_html_after_forester()` — detects redirect stubs and replaces them with the backed-up HTML

This preserves incremental build behavior: only pages with changed XML get reconverted.

## Test plan
- [x] First build (no prior HTML): backup empty, restore 0, full convert 1183 pages
- [x] Second build (no changes): backup 1183, restore 1183, convert 1183 (convert_all=true)
- [x] All HTML files are proper XSL-rendered output (not redirect stubs)
- [x] ca-000O renders correctly with custom styles