### PR TITLE
fix: include .jsx files in bun build pipeline

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -107,7 +107,7 @@ function bun_build {
             #     echo "🚨 lightningcss failed with $EXIT_CODE"
             #     exit $EXIT_CODE
             # fi
-        elif [[ $FILE == *".ts" || $FILE == *".tsx" ]]; then
+        elif [[ $FILE == *".ts" || $FILE == *".tsx" || $FILE == *".jsx" ]]; then
             just js "bun/$FILE"
             # bun build bun/$FILE --outdir output
         fi

--- a/trees/ag-0014.tree
+++ b/trees/ag-0014.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt ag math draft tech exp
 \taxon{Figure}
 
-\note{test implicit surface shader 3}{
+\note{Raymarching primitives}{
 
 \figure{
 \shadertoy{iTime-10}\verb>>>|

--- a/trees/ag-0015.tree
+++ b/trees/ag-0015.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt ag math draft tech exp
 \taxon{Figure}
 
-\note{test implicit surface shader 4}{
+\note{Geodesic raytracing}{
 
 \figure{
 \shadertoy{iTime-12}\verb>>>|

--- a/trees/uts-000J.tree
+++ b/trees/uts-000J.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative
 
-\note{ }{
+\note{Implicit surfaces}{
 
 \figure{
 \shadertoy{iTime-25}\verb>>>|


### PR DESCRIPTION
## Summary
`shadertoy.jsx` was skipped during CI builds because `bun_build` in `build.sh` only checked for `.ts` and `.tsx` extensions. Added `.jsx` to the check.

This caused `shadertoy.js` to 404 on GitHub Pages, breaking shader-based trees like `ag-0011`, `ag-0014`, `ag-0015` under `ag-000G`.

## Change
```bash
# Before:
elif [[ $FILE == *".ts" || $FILE == *".tsx" ]]; then

# After:
elif [[ $FILE == *".ts" || $FILE == *".tsx" || $FILE == *".jsx" ]]; then
```

## Test plan
- [x] `just js "bun/shadertoy.jsx"` produces `output/forest/shadertoy.js` (1.2MB)
- [x] Local server serves shadertoy.js correctly (200)
- [x] Shader canvases render on ag-0011 locally