### PR TITLE
fix: suppress live reload errors when dev server is not running

### DIFF
--- a/bun/live.ts
+++ b/bun/live.ts
@@ -14,13 +14,18 @@ const reloadWithScroll = () => {
     window.location.reload()
 }
 
+let liveReloadFailed = false
+
 const startLiveReload = () => {
+    if (liveReloadFailed) return
+
     const hostname: string = window.location.hostname
     const port: string = window.location.port
 
     const ws: WebSocket = new WebSocket(`ws://${hostname}:${port}/live`)
     ws.onopen = () => {
         console.debug('live reload connected')
+        liveReloadFailed = false
         // const intervalID = setInterval(function() {
         //     if (ws.readyState === WebSocket.OPEN) {
         //         ws.send('ping');
@@ -29,8 +34,9 @@ const startLiveReload = () => {
         //     }
         // }, 10*60*1000);
     }
-    ws.onerror = (event: Event) => {
-        console.error('live reload error:', event)
+    ws.onerror = (_event: Event) => {
+        liveReloadFailed = true
+        console.debug('live reload not available (no dev server)')
     }
     ws.onmessage = (event: MessageEvent) => {
         // console.log(event);


### PR DESCRIPTION
## Summary
`live.js` connects to `ws://localhost:PORT/live` for live reload during development. When using a plain HTTP server (e.g. `python3 -m http.server`), this fails with:
```
WebSocket connection to 'ws://localhost:8239/live' failed
live reload error: ...
```

The error repeats on every page load and reconnect attempt.

## Fix
- Track connection failure with `liveReloadFailed` flag
- On first error, set flag and stop retrying
- Use `console.debug` instead of `console.error` (it's expected behavior, not an error)
- If dev server connects successfully, reset the flag

## Test plan
- [x] No console errors when serving with plain HTTP server
- [x] Live reload still works when dev server (`dev.sh`) is running (onopen resets flag)