### PR TITLE
Ground the first FGAP Hurwitz calculations

### DIFF
--- a/tex/forest.bib
+++ b/tex/forest.bib
@@ -1794,3 +1794,23 @@
   year={2025}
 }
 
+@book{voight2021quaternion,
+  title={Quaternion Algebras},
+  author={Voight, John},
+  year={2021},
+  publisher={Springer Cham},
+  series={Graduate Texts in Mathematics},
+  volume={288},
+  doi={10.1007/978-3-030-56694-4},
+  isbn={978-3-030-56694-4},
+  url={https://link.springer.com/book/10.1007/978-3-030-56694-4}
+}
+
+@article{wilson2021finite,
+  title={Finite symmetry groups in physics},
+  author={Wilson, Robert A.},
+  year={2021},
+  journal={arXiv preprint arXiv:2102.02817},
+  doi={10.48550/arXiv.2102.02817},
+  url={https://arxiv.org/abs/2102.02817}
+}

--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -1,0 +1,29 @@
+\import{macros}
+
+\title{Foundational Group Algebras (for) Physics}
+\meta{pdf}{true}
+
+\tag{notes}
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{quaternion}
+
+\author{utensil}
+\date{2026-07-28}
+
+\p{These notes study mathematical structures that may clarify questions
+suggested by physics beyond the Standard Model. No physical theory is proposed
+here. The immediate subject is the quaternionic realization of the binary
+tetrahedral group, used as a small and explicit route into finite real Group
+Algebras.}
+
+\p{The opening calculation follows the Hurwitz-unit treatment in
+\citet{ch. 11}{voight2021quaternion}. The choice of generator also matches
+\citet{eq. (6)}{wilson2021finite}, where the same finite group is explored for
+physical modeling. The standard mathematics and the physical suggestions are
+kept separate.}
+
+\transclude{fgap-0002}
+\transclude{fgap-0003}
+\transclude{fgap-0004}

--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -12,18 +12,18 @@
 \author{utensil}
 \date{2026-07-28}
 
-\p{These notes study mathematical structures that may clarify questions
-suggested by physics beyond the Standard Model. No physical theory is proposed
-here. The immediate subject is the quaternionic realization of the binary
-tetrahedral group, used as a small and explicit route into finite real Group
-Algebras.}
+\p{These notes are about mathematical structures suggested by questions in
+physics beyond the Standard Model. They do not propose a physical theory. We
+begin with the quaternionic realization of the binary tetrahedral group,
+because it gives a small and explicit route into finite real Group Algebras.}
 
-\p{The opening calculation follows the Hurwitz-unit treatment in
-\citet{ch. 11}{voight2021quaternion}. The choice of generator also matches
-\citet{eq. (6)}{wilson2021finite}, where the same finite group is explored for
-physical modeling. The standard mathematics and the physical suggestions are
-kept separate.}
+\p{For the mathematics, we follow the Hurwitz-unit treatment in
+\citet{ch. 11}{voight2021quaternion}. The generator is also the one used in
+\citet{eq. (6)}{wilson2021finite}, where the same finite group is considered
+for physical modeling. We keep the mathematics and the physical suggestions
+separate.}
 
 \transclude{fgap-0002}
 \transclude{fgap-0003}
 \transclude{fgap-0004}
+\transclude{fgap-0005}

--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -14,8 +14,9 @@
 
 \p{These notes are about mathematical structures suggested by questions in
 physics beyond the Standard Model. They do not propose a physical theory. We
-begin with the quaternionic realization of the binary tetrahedral group,
-because it gives a small and explicit route into finite real Group Algebras.}
+begin with Hamilton's Quaternions and the quaternionic realization of the
+binary tetrahedral group, because they give a small and explicit route into
+finite real Group Algebras.}
 
 \p{For the mathematics, we follow the Hurwitz-unit treatment in
 \citet{ch. 11}{voight2021quaternion}. The generator is also the one used in
@@ -23,6 +24,7 @@ because it gives a small and explicit route into finite real Group Algebras.}
 for physical modeling. We keep the mathematics and the physical suggestions
 separate.}
 
+\transclude{fgap-0006}
 \transclude{fgap-0002}
 \transclude{fgap-0003}
 \transclude{fgap-0004}

--- a/trees/fgap-0002.tree
+++ b/trees/fgap-0002.tree
@@ -1,0 +1,37 @@
+\import{macros}
+
+\parent{fgap-0001}
+\taxon{Convention}
+\title{Quaternion generator convention}
+
+\tag{math}
+\tag{fgap}
+\tag{quaternion}
+
+\p{Write #{\mathbb{H}} for Hamilton's real quaternion algebra. It has the real
+basis #{1,i,j,k}, with multiplication fixed by
+##{
+i^2=j^2=k^2=ijk=-1,\qquad
+ij=k,\quad jk=i,\quad ki=j.
+}
+The reversed products are therefore
+##{
+ji=-k,\qquad kj=-i,\qquad ik=-j.
+}
+This is the convention used in
+\citet{ch. 11, pp. 165--166}{voight2021quaternion} and
+\citet{p. 2, eq. (1)}{wilson2021finite}.}
+
+\p{For an invertible quaternion #{q}, \newvocab{left conjugation} means
+##{
+q\mathbin{\triangleright}x=qxq^{-1}.
+}
+The direction matters. Conjugation by #{q^{-1}} gives the inverse permutation,
+so a phrase such as "cyclically permutes #{i,j,k}" does not by itself fix the
+three equations needed in a calculation.}
+
+\p{Quaternions can also be obtained from suitable Clifford Algebras, which
+connects this convention with [[ca-0001]]. The present notes use the
+quaternion multiplication directly. In mathlib, the corresponding type is
+documented in
+[Mathlib.Algebra.Quaternion](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Quaternion.html).}

--- a/trees/fgap-0002.tree
+++ b/trees/fgap-0002.tree
@@ -2,28 +2,13 @@
 
 \parent{fgap-0001}
 \taxon{Convention}
-\title{Quaternion generator convention}
+\title{left conjugation}
 
 \tag{math}
 \tag{fgap}
 \tag{quaternion}
 
-\p{We write #{\mathbb{H}} for Hamilton's real quaternion algebra. It has the
-basis #{1,i,j,k}, with multiplication fixed by
-##{
-i^2=j^2=k^2=ijk=-1,\qquad
-ij=k,\quad jk=i,\quad ki=j.
-}
-The reversed products are therefore
-##{
-ji=-k,\qquad kj=-i,\qquad ik=-j.
-}
-This is the convention used in
-\citet{ch. 11, pp. 165--166}{voight2021quaternion} and
-\citet{p. 2, eq. (1)}{wilson2021finite}.}
-
-\p{For an invertible quaternion #{q}, we use \newvocab{left conjugation} to
-mean
+\p{For a nonzero quaternion #{q}, we use \newvocab{left conjugation} to mean
 ##{
 q\mathbin{\triangleright}x=qxq^{-1}.
 }
@@ -31,6 +16,5 @@ See the \vocabk{remark on the conjugation calculation}{fgap-0005} for why the
 direction is recorded explicitly.}
 
 \p{Quaternions can also be obtained from suitable Clifford Algebras; see
-[[ca-0001]]. Here we use quaternion multiplication directly. The corresponding
-mathlib type is documented in
-[Mathlib.Algebra.Quaternion](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Quaternion.html).}
+[[ca-0001]]. Here we use the multiplication in \vocabk{Hamilton's
+Quaternions}{fgap-0006} directly.}

--- a/trees/fgap-0002.tree
+++ b/trees/fgap-0002.tree
@@ -8,7 +8,7 @@
 \tag{fgap}
 \tag{quaternion}
 
-\p{Write #{\mathbb{H}} for Hamilton's real quaternion algebra. It has the real
+\p{We write #{\mathbb{H}} for Hamilton's real quaternion algebra. It has the
 basis #{1,i,j,k}, with multiplication fixed by
 ##{
 i^2=j^2=k^2=ijk=-1,\qquad
@@ -22,16 +22,15 @@ This is the convention used in
 \citet{ch. 11, pp. 165--166}{voight2021quaternion} and
 \citet{p. 2, eq. (1)}{wilson2021finite}.}
 
-\p{For an invertible quaternion #{q}, \newvocab{left conjugation} means
+\p{For an invertible quaternion #{q}, we use \newvocab{left conjugation} to
+mean
 ##{
 q\mathbin{\triangleright}x=qxq^{-1}.
 }
-The direction matters. Conjugation by #{q^{-1}} gives the inverse permutation,
-so a phrase such as "cyclically permutes #{i,j,k}" does not by itself fix the
-three equations needed in a calculation.}
+See the \vocabk{remark on the conjugation calculation}{fgap-0005} for why the
+direction is recorded explicitly.}
 
-\p{Quaternions can also be obtained from suitable Clifford Algebras, which
-connects this convention with [[ca-0001]]. The present notes use the
-quaternion multiplication directly. In mathlib, the corresponding type is
-documented in
+\p{Quaternions can also be obtained from suitable Clifford Algebras; see
+[[ca-0001]]. Here we use quaternion multiplication directly. The corresponding
+mathlib type is documented in
 [Mathlib.Algebra.Quaternion](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Quaternion.html).}

--- a/trees/fgap-0003.tree
+++ b/trees/fgap-0003.tree
@@ -2,21 +2,21 @@
 
 \parent{fgap-0001}
 \taxon{Lemma}
-\title{A Hurwitz unit of order three}
+\title{a Hurwitz unit of order three}
 
 \tag{math}
 \tag{fgap}
 \tag{quaternion}
 \tag{hurwitz}
 
-\p{Set
+\p{Let
 ##{
 a=i+j+k,\qquad
 \omega=\frac{-1+i+j+k}{2}=\frac{-1+a}{2}.
 }
-This is one of the Hurwitz units. The convention and the quadratic relation
-below appear in \citet{p. 165}{voight2021quaternion}. The same choice of
-#{\omega} appears as #{w} in \citet{p. 4, eq. (6)}{wilson2021finite}.}
+Then #{\omega} is a Hurwitz unit of order three. This choice appears in
+\citet{p. 165}{voight2021quaternion}, and as #{w} in
+\citet{p. 4, eq. (6)}{wilson2021finite}.}
 
 \p{The mixed terms in #{a^2} cancel in pairs:
 ##{
@@ -42,8 +42,3 @@ Hence #{\omega^2+\omega+1=0}, and multiplication by #{\omega-1} gives
 Thus #{\omega} is invertible, has inverse
 #{\omega^{-1}=\omega^2=(-1-i-j-k)/2}, and has order three because
 #{\omega\ne 1}.}
-
-\p{This calculation is deliberately elementary. The complete set of 24
-Hurwitz units and its identification with the binary tetrahedral group belong
-to a later note. The first Lean development only needs the displayed
-identities.}

--- a/trees/fgap-0003.tree
+++ b/trees/fgap-0003.tree
@@ -1,0 +1,49 @@
+\import{macros}
+
+\parent{fgap-0001}
+\taxon{Lemma}
+\title{A Hurwitz unit of order three}
+
+\tag{math}
+\tag{fgap}
+\tag{quaternion}
+\tag{hurwitz}
+
+\p{Set
+##{
+a=i+j+k,\qquad
+\omega=\frac{-1+i+j+k}{2}=\frac{-1+a}{2}.
+}
+This is one of the Hurwitz units. The convention and the quadratic relation
+below appear in \citet{p. 165}{voight2021quaternion}. The same choice of
+#{\omega} appears as #{w} in \citet{p. 4, eq. (6)}{wilson2021finite}.}
+
+\p{The mixed terms in #{a^2} cancel in pairs:
+##{
+\begin{aligned}
+a^2
+&=i^2+j^2+k^2+(ij+ji)+(jk+kj)+(ki+ik)\\
+&=-3.
+\end{aligned}
+}
+It follows that
+##{
+\begin{aligned}
+\omega^2
+&=\frac{(-1+a)^2}{4}\\
+&=\frac{1-2a+a^2}{4}\\
+&=\frac{-1-a}{2}.
+\end{aligned}
+}
+Hence #{\omega^2+\omega+1=0}, and multiplication by #{\omega-1} gives
+##{
+\omega^3=1.
+}
+Thus #{\omega} is invertible, has inverse
+#{\omega^{-1}=\omega^2=(-1-i-j-k)/2}, and has order three because
+#{\omega\ne 1}.}
+
+\p{This calculation is deliberately elementary. The complete set of 24
+Hurwitz units and its identification with the binary tetrahedral group belong
+to a later note. The first Lean development only needs the displayed
+identities.}

--- a/trees/fgap-0004.tree
+++ b/trees/fgap-0004.tree
@@ -1,0 +1,46 @@
+\import{macros}
+
+\parent{fgap-0001}
+\taxon{Lemma}
+\title{The Hurwitz conjugation cycle}
+
+\tag{math}
+\tag{fgap}
+\tag{quaternion}
+\tag{group-action}
+
+\p{For the Hurwitz unit #{\omega=(-1+i+j+k)/2}, left conjugation has the
+orientation
+##{
+\omega i\omega^{-1}=k,\qquad
+\omega j\omega^{-1}=i,\qquad
+\omega k\omega^{-1}=j.
+}
+In other words, the cycle is #{i\mapsto k\mapsto j\mapsto i}. Voight states
+that conjugation cyclically rotates these units in
+\citet{sec. 11.2.4, p. 168}{voight2021quaternion}; the calculation here fixes
+the direction. Wilson describes the same order-three automorphisms in
+\citet{sec. 1.4, p. 4}{wilson2021finite}.}
+
+\p{There is no need to expand three full quaternion products. Direct
+multiplication gives
+##{
+\omega i=k\omega,\qquad
+\omega j=i\omega,\qquad
+\omega k=j\omega.
+}
+For example,
+##{
+\omega i
+=\frac{-1-i+j-k}{2}
+=k\omega.
+}
+Right multiplication by #{\omega^{-1}} proves the three conjugation
+equations.}
+
+\p{This is the first concrete group action needed for the binary tetrahedral
+group. General group actions and semidirect products will be developed in
+companion notes before the full group construction. In Lean, the three
+equations will first be proved with the type documented in
+[Mathlib.Algebra.Quaternion](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Quaternion.html);
+the abstract action is a later interface.}

--- a/trees/fgap-0004.tree
+++ b/trees/fgap-0004.tree
@@ -1,29 +1,28 @@
 \import{macros}
 
 \parent{fgap-0001}
-\taxon{Lemma}
-\title{The Hurwitz conjugation cycle}
+\taxon{Example}
+\title{conjugation by a Hurwitz unit}
 
 \tag{math}
 \tag{fgap}
 \tag{quaternion}
 \tag{group-action}
 
-\p{For the Hurwitz unit #{\omega=(-1+i+j+k)/2}, left conjugation has the
-orientation
+\p{Consider left conjugation by the Hurwitz unit
+#{\omega=(-1+i+j+k)/2}. We have
 ##{
 \omega i\omega^{-1}=k,\qquad
 \omega j\omega^{-1}=i,\qquad
 \omega k\omega^{-1}=j.
 }
-In other words, the cycle is #{i\mapsto k\mapsto j\mapsto i}. Voight states
-that conjugation cyclically rotates these units in
+Thus the cycle is #{i\mapsto k\mapsto j\mapsto i}. Voight says that
+conjugation cyclically rotates these units in
 \citet{sec. 11.2.4, p. 168}{voight2021quaternion}; the calculation here fixes
 the direction. Wilson describes the same order-three automorphisms in
 \citet{sec. 1.4, p. 4}{wilson2021finite}.}
 
-\p{There is no need to expand three full quaternion products. Direct
-multiplication gives
+\p{It is enough to calculate
 ##{
 \omega i=k\omega,\qquad
 \omega j=i\omega,\qquad
@@ -37,10 +36,3 @@ For example,
 }
 Right multiplication by #{\omega^{-1}} proves the three conjugation
 equations.}
-
-\p{This is the first concrete group action needed for the binary tetrahedral
-group. General group actions and semidirect products will be developed in
-companion notes before the full group construction. In Lean, the three
-equations will first be proved with the type documented in
-[Mathlib.Algebra.Quaternion](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Quaternion.html);
-the abstract action is a later interface.}

--- a/trees/fgap-0005.tree
+++ b/trees/fgap-0005.tree
@@ -1,0 +1,27 @@
+\date{2026-07-28T10:19:08Z}
+\import{macros}
+
+\parent{fgap-0001}
+\taxon{Remark}
+\title{what the conjugation calculation gives}
+
+\tag{math}
+\tag{fgap}
+\tag{quaternion}
+\tag{group-action}
+
+\p{Saying that conjugation cyclically permutes #{i,j,k} does not by itself
+tell us which cycle is meant. Left conjugation by #{\omega} gives the cycle in
+the \vocabk{conjugation example}{fgap-0004}. Conjugation by
+#{\omega^{-1}} gives the inverse cycle. This is why we record the three
+equations instead of only saying "cyclically permutes."}
+
+\p{The calculation is the first concrete group action needed for the binary
+tetrahedral group. It does not yet identify the complete set of 24 Hurwitz
+units with that group. General group actions, semidirect products, and the full
+group construction belong to later notes.}
+
+\p{In Lean, the three equations will first be proved with the type documented
+in
+[Mathlib.Algebra.Quaternion](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Quaternion.html).
+The abstract group action will be a later interface.}

--- a/trees/fgap-0006.tree
+++ b/trees/fgap-0006.tree
@@ -1,0 +1,52 @@
+\date{2026-07-28T11:05:25Z}
+\import{macros}
+
+\parent{fgap-0001}
+\taxon{Definition}
+\title{Hamilton's Quaternions}
+
+\tag{math}
+\tag{fgap}
+\tag{quaternion}
+
+\p{The algebra of real \newvocab{quaternion}s is the four-dimensional real
+vector space
+##{
+\mathbb{H}
+=\mathbb{R}1\oplus\mathbb{R}i\oplus\mathbb{R}j\oplus\mathbb{R}k.
+}
+Thus every quaternion can be written uniquely as
+##{
+q=a+bi+cj+dk,\qquad a,b,c,d\in\mathbb{R}.
+}
+Addition and real scalar multiplication are coordinatewise. Multiplication is
+extended bilinearly from #{1} as the multiplicative identity and the table
+##{
+\begin{gathered}
+i^2=j^2=k^2=ijk=-1,\\
+ij=k,\quad jk=i,\quad ki=j,\\
+ji=-k,\quad kj=-i,\quad ik=-j.
+\end{gathered}
+}
+This makes #{\mathbb{H}} an associative, noncommutative real algebra. In
+Voight's notation, #{\mathbb{H}=(-1,-1\mid\mathbb{R})}; see
+\citet{def. 2.2.1 and ex. 2.2.3}{voight2021quaternion}.}
+
+\p{For #{q=a+bi+cj+dk}, its \newvocab{quaternion conjugate} and
+\newvocab{reduced norm} are
+##{
+\overline{q}=a-bi-cj-dk,\qquad
+\operatorname{nrd}(q)=q\overline{q}
+=a^2+b^2+c^2+d^2.
+}
+We also have #{\overline{q}q=\operatorname{nrd}(q)}. If #{q\ne 0}, then
+#{\operatorname{nrd}(q)>0} and
+##{
+q^{-1}=\frac{\overline{q}}{\operatorname{nrd}(q)}.
+}
+So every nonzero quaternion is invertible. This is the standard involution and
+reduced norm specialized to Hamilton's Quaternions; see
+\citet{secs. 3.1--3.3}{voight2021quaternion}.}
+
+\p{The corresponding mathlib type is documented in
+[Mathlib.Algebra.Quaternion](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Quaternion.html).}

--- a/trees/refs/voight2021quaternion.tree
+++ b/trees/refs/voight2021quaternion.tree
@@ -1,0 +1,20 @@
+% ["forest"]
+\title{Quaternion algebras}
+\date{2021}
+\author/literal{John Voight}
+\taxon{Reference}
+\meta{external}{https://link.springer.com/book/10.1007/978-3-030-56694-4}
+
+\meta{bibtex}{\startverb
+@book{voight2021quaternion,
+ title = {Quaternion Algebras},
+ author = {Voight, John},
+ year = {2021},
+ publisher = {Springer Cham},
+ series = {Graduate Texts in Mathematics},
+ volume = {288},
+ doi = {10.1007/978-3-030-56694-4},
+ isbn = {978-3-030-56694-4},
+ url = {https://link.springer.com/book/10.1007/978-3-030-56694-4}
+}
+\stopverb}

--- a/trees/refs/wilson2021finite.tree
+++ b/trees/refs/wilson2021finite.tree
@@ -1,0 +1,17 @@
+% ["forest"]
+\title{Finite symmetry groups in physics}
+\date{2021}
+\author/literal{Robert A. Wilson}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2102.02817}
+
+\meta{bibtex}{\startverb
+@article{wilson2021finite,
+ title = {Finite symmetry groups in physics},
+ author = {Wilson, Robert A.},
+ year = {2021},
+ journal = {arXiv preprint arXiv:2102.02817},
+ doi = {10.48550/arXiv.2102.02817},
+ url = {https://arxiv.org/abs/2102.02817}
+}
+\stopverb}


### PR DESCRIPTION
## Summary

- open the `fgap-*` Forest note series with its mathematical scope and claim boundary
- present the first reading unit as a definition, convention, lemma, example, and remark in the style of the `tt-*` series
- define Hamilton’s Quaternions explicitly before using them: coordinates, operations, multiplication, conjugation, reduced norm, and inverses
- prove an order-three Hurwitz unit calculation and determine its conjugation cycle
- cite Voight as the primary mathematical reference and Wilson for the matching convention and motivation

## Grounding

- John Voight, *Quaternion Algebras*, Definition 2.2.1, Example 2.2.3, §§3.1–3.3, and Chapter 11, especially pp. 165–168
- Robert A. Wilson, *Finite symmetry groups in physics*, especially eq. (6) and §1.4

The notes reproduce the identities used later rather than importing them from either source. Mathematical constructions are kept separate from physical suggestions.

## Verification

- targeted Forester build
- transcluded `fgap-0001` PDF build and five-page visual review