### PR TITLE
Correct topos limits and geometric-morphism adjoints

### DIFF
--- a/tex/forest.bib
+++ b/tex/forest.bib
@@ -1794,3 +1794,14 @@
   year={2025}
 }
 
+@book{maclane1992sheaves,
+  author={Mac Lane, Saunders and Moerdijk, Ieke},
+  title={Sheaves in Geometry and Logic: A First Introduction to Topos Theory},
+  series={Universitext},
+  publisher={Springer-Verlag},
+  address={New York},
+  year={1992},
+  isbn={978-0-387-97710-2},
+  doi={10.1007/978-1-4612-0927-0},
+  url={https://doi.org/10.1007/978-1-4612-0927-0}
+}

--- a/trees/refs/maclane1992sheaves.tree
+++ b/trees/refs/maclane1992sheaves.tree
@@ -1,0 +1,20 @@
+% ["forest"]
+\title{Sheaves in geometry and logic: a first introduction to topos theory}
+\date{1992}
+\author/literal{Saunders Mac Lane and Ieke Moerdijk}
+\taxon{Reference}
+\meta{external}{https://doi.org/10.1007/978-1-4612-0927-0}
+
+\meta{bibtex}{\startverb
+@book{maclane1992sheaves,
+ author = {Mac Lane, Saunders and Moerdijk, Ieke},
+ title = {Sheaves in Geometry and Logic: A First Introduction to Topos Theory},
+ series = {Universitext},
+ publisher = {Springer-Verlag},
+ address = {New York},
+ year = {1992},
+ isbn = {978-0-387-97710-2},
+ doi = {10.1007/978-1-4612-0927-0},
+ url = {https://doi.org/10.1007/978-1-4612-0927-0}
+}
+\stopverb}

--- a/trees/tt-004O.tree
+++ b/trees/tt-004O.tree
@@ -12,27 +12,29 @@
 
 \refdeft{topos}{7.1}{kostecki2011introduction}{
 \p{
-A \newvocab{topos} or \newvocab{elementary topos} is a category satisfying one of these equivalent conditions:
+A \newvocab{topos}, or \newvocab{elementary topos}, is a category with
+\vocabk{all finite limits}{tt-002F}, \vocabk{exponential}{tt-004G}s, and a
+\vocabk{subobject classifier}{tt-004I}. Equivalently, exponentials may be
+replaced by \vocabk{power object}{tt-004L}s. See
+\citet{sec. IV.1, pp. 161--163}{maclane1992sheaves}.}
 
-\ul{
-  \li{it is a \vocabk{complete}{tt-002F} category with \vocabk{exponential}{tt-004G}s and \vocabk{subobject classifier}{tt-004I}}
-  \li{it is a \vocab{complete} category with \vocab{subobject classifier} and its \vocabk{power object}{tt-004L}}
-  \li{it is a \vocabk{cartesian closed}{tt-004H} category with \vocabk{equalizer}{tt-000Q}s and \vocab{subobject classifier}}
-}
+\p{Every elementary topos also has
+\vocabk{all finite colimits}{tt-003C}; see
+\citet{sec. IV.5, pp. 180--184}{maclane1992sheaves}. Arbitrary small limits
+and colimits are not part of the elementary definition. They do exist in a
+Grothendieck topos of sheaves on a site; see
+\citet{sec. III.6, pp. 134--135}{maclane1992sheaves}.}
 
-}
-
-\p{Since the \vocab{completeness} of a category with subobject classifier implies its \vocab{cocompleteness}. Thus a topos not only \vocabk{has all finite limits}{tt-002F}, but also \vocabk{has all finite colimits}{tt-003C}.}
-
-\p{This means that topos is such category which has, in particular,
+\p{Thus an elementary topos has, in particular,
 
 \ol{
 \li{terminal object}
 \li{equalizers}
 \li{pullbacks}
-\li{all other limits}
+\li{all other finite limits}
 \li{exponential objects}
 \li{subobject classifier}
+\li{all finite colimits}
 }
 
 }

--- a/trees/tt-004Q.tree
+++ b/trees/tt-004Q.tree
@@ -12,7 +12,22 @@
 
 \refdeft{geometric morphism, Topoi}{7.2}{kostecki2011introduction}{
 \p{
-If #{\E_1} and #{\E_2} are \vocabk{topos}{tt-004O}es, then a \newvocab{geometric morphism} #{\fG: \E_1 \to \E_2} is defined as a pair of \vocab{adjoint functor}s #{\fG^* \dashv \fG_*} between #{\E_1} and #{\E_2}, such that #{\fG^*} \vocabk{preserves finite limits}{tt-002H} (i.e. is \vocab{left exact}), which implies #{\fG_*} \vocab{preserves colimits} (i.e. is \vocab{right exact}).}
+If #{\E_1} and #{\E_2} are \vocabk{topos}{tt-004O}es, then a
+\newvocab{geometric morphism} #{\fG: \E_1 \to \E_2} is a pair of
+\vocab{adjoint functor}s
+##{
+\fG^*:\E_2\to\E_1,\qquad
+\fG_*:\E_1\to\E_2,\qquad
+\fG^*\dashv\fG_*,
+}
+such that the inverse-image functor #{\fG^*}
+\vocabk{preserves finite limits}{tt-002H}; that is, #{\fG^*} is left exact.
+See \citet{sec. VII.1, pp. 348--352}{maclane1992sheaves}.}
+
+\p{As a left adjoint, #{\fG^*} preserves every colimit that exists. As a
+right adjoint, #{\fG_*} preserves every limit that exists. The additional
+left-exactness condition on #{\fG^*} is not automatic for a left adjoint,
+and right adjointness does not in general make #{\fG_*} preserve colimits.}
 
 \p{The category of toposes and their geometric morphisms is denoted #{\Topoi}.
 }


### PR DESCRIPTION
## Summary

- distinguish finite elementary-topos structure from small limits and colimits in Grothendieck topoi
- correct the preservation properties of inverse- and direct-image functors
- cite Mac Lane and Moerdijk at the exact supporting sections

## Verification

- selectively checked the cited sections of *Sheaves in Geometry and Logic*
- built the Forester source and cumulative `tt-0001` PDF
- inspected the repaired definitions and bibliography in the rendered PDF