### PR TITLE
FGAP: test a finite topos layer

### DIFF
--- a/tex/forest.bib
+++ b/tex/forest.bib
@@ -1794,3 +1794,14 @@
   year={2025}
 }
 
+@book{maclane1992sheaves,
+  author={Mac Lane, Saunders and Moerdijk, Ieke},
+  title={Sheaves in Geometry and Logic: A First Introduction to Topos Theory},
+  series={Universitext},
+  publisher={Springer-Verlag},
+  address={New York},
+  year={1992},
+  isbn={978-0-387-97710-2},
+  doi={10.1007/978-1-4612-0927-0},
+  url={https://doi.org/10.1007/978-1-4612-0927-0}
+}

--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -31,3 +31,4 @@ separate.}
 \transclude{fgap-0005}
 \transclude{fgap-0007}
 \transclude{fgap-000E}
+\transclude{fgap-000M}

--- a/trees/fgap-000M.tree
+++ b/trees/fgap-000M.tree
@@ -1,0 +1,31 @@
+\import{macros}
+
+\parent{fgap-0001}
+\title{Finite tests for a topos layer}
+
+\tag{notes}
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{topos}
+
+\p{Group Actions, Group Algebras, and action groupoids already describe much
+of the finite symmetry data needed in these notes. The question here is
+narrower: does passing to a \vocabk{topos}{tt-004O} add universal
+classification, a common inverse-image language, or internal reasoning that
+is not already present below the topos level?}
+
+\p{Five finite tests give a guarded answer. Ordinary actions and action
+groupoids do not need topoi. Torsor classification, inverse-image
+constructions, and internal inhabitation do add something, but only when
+their extra structure is actually used. Questions about local and global
+symmetry motivate these tests; they do not decide them.}
+
+\transclude{fgap-000N}
+\transclude{fgap-000O}
+\transclude{fgap-000P}
+\transclude{fgap-000Q}
+\transclude{fgap-000R}
+\transclude{fgap-000S}
+\transclude{fgap-000T}
+\transclude{fgap-000U}

--- a/trees/fgap-000N.tree
+++ b/trees/fgap-000N.tree
@@ -1,0 +1,68 @@
+\import{macros}
+
+\parent{fgap-000M}
+\taxon{Example}
+\title{the real Group Algebra of a cyclic group of order three}
+
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{commutative-algebra}
+
+\p{Let #{C_3=\langle g\mid g^3=1\rangle}. Sending #{g} to #{x} gives
+##{
+\mathbb{R}[C_3]\cong\mathbb{R}[x]/(x^3-1).
+}
+Over the real numbers,
+##{
+x^3-1=(x-1)(x^2+x+1),
+}
+and the two factors are coprime. The Chinese remainder theorem and the
+identification
+#{\mathbb{R}[x]/(x^2+x+1)\cong\mathbb{C}} therefore give
+##{
+\mathbb{R}[C_3]\cong\mathbb{R}\times\mathbb{C}.
+}
+}
+
+\p{More concretely, if #{\zeta} is a primitive complex cube root of unity,
+the isomorphism is
+##{
+a+bg+cg^2\longmapsto
+\bigl(a+b+c,\ a+b\zeta+c\zeta^2\bigr).
+}
+The two factors can be read in three compatible ways:
+##{
+\begin{array}{c|c|c}
+\text{factor of }x^3-1&
+\text{real algebra block}&
+\text{real representation}\\ \hline
+x-1&\mathbb{R}&\text{trivial line}\\
+x^2+x+1&\mathbb{C}&\text{rotation plane}.
+\end{array}
+}
+The rotation plane is the linearization of the nontrivial part of the regular
+\vocabk{Group Action}{fgap-0008}. More explicitly, the generator cyclically
+permutes the basis #{1,g,g^2}. The averaging element
+##{
+e_0=\frac{1+g+g^2}{3}
+}
+projects onto the fixed line #{\mathbb{R}(1+g+g^2)}, while its complementary
+kernel is the augmentation plane
+##{
+\{a+bg+cg^2:a+b+c=0\}.
+}
+Orbits, freeness, and transitivity belong to the action; the projector and
+invariant subspaces appear only after linearization.}
+
+\p{Since the spectrum of a product is the disjoint union of the spectra,
+##{
+\operatorname{Spec}\mathbb{R}[C_3]
+\cong
+\operatorname{Spec}\mathbb{R}
+\sqcup
+\operatorname{Spec}\mathbb{C}.
+}
+This is a useful commutative picture. It is not yet a reason to introduce a
+topos, and it does not extend without choices to noncommutative Group
+Algebras.}

--- a/trees/fgap-000O.tree
+++ b/trees/fgap-000O.tree
@@ -1,0 +1,68 @@
+\import{macros}
+
+\parent{fgap-000M}
+\taxon{Remark}
+\title{the center is a commutative shadow}
+
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{quaternion}
+\tag{commutative-algebra}
+
+\p{The quaternion group #{Q_8} has a real Group Algebra decomposition
+##{
+\mathbb{R}[Q_8]\cong\mathbb{R}^4\times\mathbb{H}.
+}
+This can be seen directly from the concrete copy
+#{Q_8\subset\mathbb{H}^{\times}} in [[fgap-0009]], rather than assumed from a
+classification theorem.}
+
+\p{Let #{u_q} denote the basis element of the Group Algebra indexed by
+#{q\in Q_8}, and write a general element as
+#{x=\sum_{q\in Q_8}a_qu_q}. The four characters of
+#{Q_8/\{\pm1\}\cong C_2\times C_2} and the quaternionic map
+#{u_q\mapsto q} combine to an algebra homomorphism
+##{
+\Phi:\mathbb{R}[Q_8]\longrightarrow\mathbb{R}^4\times\mathbb{H}.
+}
+For
+#{q\in\{1,i,j,k\}}, put
+#{s_q=a_q+a_{-q}} and #{d_q=a_q-a_{-q}}. The quaternion coordinate of
+#{\Phi} recovers
+##{
+d_1+d_i i+d_j j+d_k k.
+}
+The four real coordinates recover the Hadamard transform
+##{
+s_1+\epsilon s_i+\delta s_j+\epsilon\delta s_k,
+\qquad \epsilon,\delta\in\{\pm1\}.
+}
+The Hadamard matrix is invertible, so these four values recover every
+#{s_q}. Together with the four differences, they recover every coefficient.
+Thus #{\Phi} has zero kernel. Both sides have real dimension eight, so
+#{\Phi} is an isomorphism. The quaternionic realization and multiplication
+used here are developed in [[fgap-0006]] and
+\citet{sec. 11.2, p. 166}{voight2021quaternion}.}
+
+\p{Taking centers now gives
+##{
+Z\bigl(\mathbb{R}[Q_8]\bigr)
+\cong
+Z\bigl(\mathbb{R}^4\times\mathbb{H}\bigr)
+\cong\mathbb{R}^5.
+}
+The comparison is:
+##{
+\begin{array}{c|c|c}
+\text{object}&\text{retained data}&\text{forgotten data}\\ \hline
+\mathbb{R}[Q_8]&4\mathbb{R}\text{ and }\mathbb{H}&\text{none here}\\
+Z(\mathbb{R}[Q_8])&\text{five central factors}&
+\mathbb{H}\text{ and block size or type}.
+\end{array}
+}
+For a real-centered simple block, the center alone cannot distinguish matrix
+size or real from quaternionic type. A complex block still has complex
+center. Hence
+#{\operatorname{Spec}Z(\mathbb{R}[Q_8])} is a selected commutative shadow,
+not a lossless localization of the noncommutative algebra.}

--- a/trees/fgap-000P.tree
+++ b/trees/fgap-000P.tree
@@ -1,0 +1,47 @@
+\import{macros}
+
+\parent{fgap-000M}
+\taxon{Example}
+\title{isotropy survives the coarse quotient}
+
+\tag{math}
+\tag{fgap}
+\tag{group-action}
+\tag{groupoid}
+\tag{topos}
+
+\p{Let #{C_2=\{1,s\}} act on #{X=\{-1,0,1\}} by
+#{s\mathbin{\cdot}x=-x}. The action groupoid #{C_2\ltimes X} has the points
+of #{X} as objects and an arrow #{(h,x):x\to h\mathbin{\cdot}x} for every
+#{h\in C_2}. Omitting identity arrows, its shape is
+\tikzfig{\begin{tikzcd}[column sep=large]
+-1 \arrow[r, bend left=18, "s"]&
+1 \arrow[l, bend left=18, "s"]&
+0 \arrow[loop right, "s"]
+\end{tikzcd}}
+Thus
+##{
+\operatorname{Aut}(0)\cong C_2,\qquad
+\operatorname{Aut}(1)=\operatorname{Aut}(-1)=1.
+}
+}
+
+\p{The coarse quotient remembers only the two orbits:
+\tikzfig{\begin{tikzcd}[column sep=huge]
+\{-1,1\}&\{0\}.
+\end{tikzcd}}
+It has forgotten the nonidentity automorphism at #{0}. By contrast, the action
+groupoid has one component equivalent to the terminal groupoid and one
+component equivalent to #{BC_2}. Therefore
+##{
+\mathsf{Set}^{(C_2\ltimes X)^{\mathrm{op}}}
+\simeq
+\mathsf{Set}\times\mathsf{B}C_2,
+}
+while sheaves on the discrete coarse quotient form
+#{\mathsf{Set}\times\mathsf{Set}}.}
+
+\p{The retained information is already the isotropy arrow in the action
+groupoid. Passing to its \vocabk{presheaf}{tt-002Q} category organizes
+families of such data, but does not create that arrow. This test supports the
+groupoid bridge and does not, by itself, admit a topos layer.}

--- a/trees/fgap-000Q.tree
+++ b/trees/fgap-000Q.tree
@@ -20,7 +20,7 @@
 }
 is an isomorphism. The second condition is the internal form of freeness and
 transitivity. See
-\citet{sec. VIII.2, pp. 423--427}{maclane1992sheaves}.}
+\citet{sec. VIII.2, pp. 429--430}{maclane1992sheaves}.}
 
 \p{For an ordinary group #{G}, write
 ##{
@@ -29,8 +29,9 @@ transitivity. See
 for the topos of right #{G}-sets, regarded as
 \vocabk{presheaf}{tt-002Q}s on the one-object category #{BG}. Its
 \newvocab{universal torsor} #{U_G} has underlying right #{G}-set #{G} with
-regular right multiplication. Left multiplication supplies the torsor
-action; the left and right actions commute.}
+regular right multiplication. The constant group object #{\underline{G}},
+whose right #{G}-action is trivial, acts on #{U_G} by left multiplication.
+This supplies the torsor action; the left and right actions commute.}
 
 \p{For #{C_2}, the regular left action is a torsor in #{\mathsf{Set}}:
 ##{

--- a/trees/fgap-000Q.tree
+++ b/trees/fgap-000Q.tree
@@ -1,0 +1,44 @@
+\import{macros}
+
+\parent{fgap-000M}
+\taxon{Definition}
+\title{torsors and the universal torsor}
+
+\tag{math}
+\tag{fgap}
+\tag{group-action}
+\tag{torsor}
+\tag{topos}
+
+\p{Let #{G} be a group object in a \vocabk{topos}{tt-004O}
+#{\mathcal{E}}. A left #{G}-object #{T} is a \newvocab{torsor} when
+#{T\to1} is an epimorphism and
+##{
+(\mu,\pi_2):G\times T\longrightarrow T\times T,
+\qquad
+(g,t)\longmapsto(g\mathbin{\cdot}t,t)
+}
+is an isomorphism. The second condition is the internal form of freeness and
+transitivity. See
+\citet{sec. VIII.2, pp. 423--427}{maclane1992sheaves}.}
+
+\p{For an ordinary group #{G}, write
+##{
+\mathsf{B}G=\mathsf{Set}^{BG^{\mathrm{op}}}
+}
+for the topos of right #{G}-sets, regarded as
+\vocabk{presheaf}{tt-002Q}s on the one-object category #{BG}. Its
+\newvocab{universal torsor} #{U_G} has underlying right #{G}-set #{G} with
+regular right multiplication. Left multiplication supplies the torsor
+action; the left and right actions commute.}
+
+\p{For #{C_2}, the regular left action is a torsor in #{\mathsf{Set}}:
+##{
+C_2\times C_2\longrightarrow C_2\times C_2,
+\qquad
+(g,h)\longmapsto(gh,h)
+}
+is a bijection. The trivial action on a two-point set #{D}, despite
+#{D\to1} being onto, is not a torsor. Its corresponding map sends
+#{(g,d)} to #{(d,d)}, so it is neither injective nor surjective. Inhabitation
+and cardinality alone do not supply a torsor.}

--- a/trees/fgap-000R.tree
+++ b/trees/fgap-000R.tree
@@ -1,0 +1,55 @@
+\import{macros}
+
+\parent{fgap-000M}
+\taxon{Theorem}
+\title{the classifying property of BG}
+
+\tag{math}
+\tag{fgap}
+\tag{torsor}
+\tag{topos}
+\tag{geometric-morphism}
+
+\p{Let #{G} be a group and #{\mathcal{E}} a topos. There is a natural
+equivalence
+##{
+\operatorname{Geom}(\mathcal{E},\mathsf{B}G)
+\simeq
+\operatorname{Tor}(\mathcal{E},G)
+}
+between geometric morphisms to #{\mathsf{B}G} and #{G}-torsors in
+#{\mathcal{E}}. Under this equivalence, a
+\vocabk{geometric morphism}{tt-004Q}
+##{
+f:\mathcal{E}\longrightarrow\mathsf{B}G
+}
+classifies the torsor #{f^*U_G}.}
+
+\p{This is Theorem VIII.2.7 of \citek{maclane1992sheaves}; its construction
+is developed on printed pp. 423--433.}
+
+\p{The two directions are visible in the diagram
+\tikzfig{\begin{tikzcd}[column sep=huge]
+\mathcal{E} \arrow[r, "f"]&
+\mathsf{B}G\\
+f^*U_G&
+U_G \arrow[l, mapsto, "f^*"']
+\end{tikzcd}}
+The geometric morphism points toward the classifying topos. Its inverse-image
+functor carries the universal torsor back to the topos in which the classified
+torsor lives.}
+
+\proof{
+\p{Inverse image preserves finite limits and, as a left adjoint, colimits.
+Every epimorphism in a topos is regular, so inverse image carries the
+universal torsor equations, including the epimorphic map to #{1}, to torsor
+equations in #{\mathcal{E}}. Conversely,
+the cited theorem constructs a geometric morphism from a torsor and proves
+that the two constructions are naturally inverse. The complete construction
+belongs to the classifying theorem; the point used here is its variance and
+universal property.}
+}
+
+\p{For a single finite action, freeness and transitivity can be checked
+without topoi. The added value here is one universal object classifying
+torsors in every suitable base topos and carrying them along inverse image.}

--- a/trees/fgap-000R.tree
+++ b/trees/fgap-000R.tree
@@ -10,23 +10,23 @@
 \tag{topos}
 \tag{geometric-morphism}
 
-\p{Let #{G} be a group and #{\mathcal{E}} a topos. There is a natural
-equivalence
+\p{Let #{G} be a group and #{\mathcal{E}} a topos over
+#{\mathsf{Set}}. There is a natural equivalence
 ##{
-\operatorname{Geom}(\mathcal{E},\mathsf{B}G)
+\operatorname{Geom}_{/\mathsf{Set}}(\mathcal{E},\mathsf{B}G)
 \simeq
 \operatorname{Tor}(\mathcal{E},G)
 }
-between geometric morphisms to #{\mathsf{B}G} and #{G}-torsors in
-#{\mathcal{E}}. Under this equivalence, a
+between geometric morphisms over #{\mathsf{Set}} to #{\mathsf{B}G} and
+#{G}-torsors in #{\mathcal{E}}. Under this equivalence, a
 \vocabk{geometric morphism}{tt-004Q}
 ##{
 f:\mathcal{E}\longrightarrow\mathsf{B}G
 }
 classifies the torsor #{f^*U_G}.}
 
-\p{This is Theorem VIII.2.7 of \citek{maclane1992sheaves}; its construction
-is developed on printed pp. 423--433.}
+\p{This is Theorem VIII.2.7 of \citek{maclane1992sheaves}; its theorem and
+proof are on printed pp. 431--433.}
 
 \p{The two directions are visible in the diagram
 \tikzfig{\begin{tikzcd}[column sep=huge]
@@ -52,4 +52,5 @@ universal property.}
 
 \p{For a single finite action, freeness and transitivity can be checked
 without topoi. The added value here is one universal object classifying
-torsors in every suitable base topos and carrying them along inverse image.}
+torsors in every topos over #{\mathsf{Set}} and carrying them along inverse
+image.}

--- a/trees/fgap-000S.tree
+++ b/trees/fgap-000S.tree
@@ -1,0 +1,51 @@
+\import{macros}
+
+\parent{fgap-000M}
+\taxon{Convention}
+\title{geometric morphisms and inverse image}
+
+\tag{math}
+\tag{fgap}
+\tag{topos}
+\tag{geometric-morphism}
+\tag{sheaf}
+
+\p{For a \vocabk{geometric morphism}{tt-004Q}
+##{
+f:\mathcal{E}\longrightarrow\mathcal{F},
+}
+we write
+##{
+f^*:\mathcal{F}\longrightarrow\mathcal{E},
+\qquad
+f_*:\mathcal{E}\longrightarrow\mathcal{F},
+\qquad
+f^*\dashv f_*.
+}
+Thus the morphism and its inverse-image functor point in opposite directions.
+The functor #{f^*} preserves finite limits.}
+
+\p{Two examples fix the convention:
+##{
+\begin{array}{c|c|c}
+\text{input map}&\text{geometric morphism}&\text{inverse image}\\ \hline
+i:\{x\}\hookrightarrow X&
+\mathsf{Set}\to\mathsf{Sh}(X)&
+i^*F=F_x=\displaystyle\varinjlim_{x\in U}F(U)\\[3pt]
+\varphi:H\to G&
+\mathsf{B}H\to\mathsf{B}G&
+\operatorname{Res}^G_H:\mathsf{B}G\to\mathsf{B}H.
+\end{array}
+}
+In the first row, the stalk is the \vocabk{filtered colimit}{tt-0050} of all
+neighborhood sections, not the value on one chosen neighborhood.}
+
+\p{Mac Lane and Moerdijk construct inverse-image sheaves through pulled-back
+étale spaces in \citet{sec. II.9}{maclane1992sheaves}, especially printed
+pp. 99--101.}
+
+\p{In the second row, right actions are presheaves. Precomposition with
+#{B\varphi^{\mathrm{op}}} is restriction of actions. It has both
+Kan-extension adjoints, so it is the inverse-image part of the displayed
+geometric morphism. The homomorphism and geometric morphism point from #{H}
+to #{G}; restriction points from #{G}-objects to #{H}-objects.}

--- a/trees/fgap-000T.tree
+++ b/trees/fgap-000T.tree
@@ -1,0 +1,46 @@
+\import{macros}
+
+\parent{fgap-000M}
+\taxon{Example}
+\title{internal inhabitation without a global point}
+
+\tag{math}
+\tag{fgap}
+\tag{group-action}
+\tag{topos}
+\tag{internal-logic}
+
+\p{Work in #{\mathsf{B}C_2}, the topos of right #{C_2}-sets, and let
+#{U=C_2} carry the regular right action. The unique equivariant map
+#{U\to1} is an epimorphism because its underlying function is surjective.
+In the internal language, this says that #{U} is inhabited. Internal Group
+Actions are developed in
+\citet{sec. V.2, pp. 237--240}{maclane1992sheaves}.}
+
+\p{A global element would be an equivariant map #{1\to U}. Its value would
+have to satisfy #{u\mathbin{\cdot}s=u}, but the regular action has no fixed
+point. Hence
+##{
+\operatorname{Hom}_{\mathsf{B}C_2}(1,U)=\varnothing.
+}
+The two external tests are:
+##{
+\begin{array}{c|c}
+\text{internal statement}&\text{external test}\\ \hline
+U\text{ is inhabited}&U\to1\text{ is epi}\\
+U\text{ has a global point}&U^{C_2}\neq\varnothing.
+\end{array}
+}
+}
+
+\p{More generally, for a nontrivial group #{G}, the regular right
+#{G}-object #{U_G=G} satisfies
+##{
+U_G\to1\text{ is epi},
+\qquad
+\Gamma(U_G)=U_G^G=\varnothing.
+}
+Indeed, if #{xg=x} for every #{g}, cancellation forces every #{g} to be
+#{1}. Internal existence is therefore generalized or local existence; it
+does not choose a global invariant element. This distinction is not a
+physical existence claim.}

--- a/trees/fgap-000U.tree
+++ b/trees/fgap-000U.tree
@@ -1,0 +1,38 @@
+\import{macros}
+
+\parent{fgap-000M}
+\taxon{Remark}
+\title{where the topos layer begins}
+
+\tag{math}
+\tag{fgap}
+\tag{topos}
+\tag{group-algebra}
+\tag{scope}
+
+\p{The finite tests separate calculations that merely take place in a topos
+from calculations that use topos-level structure:
+##{
+\begin{array}{c|c|c|c}
+\text{test}&\text{lower level}&\text{topos value}&\text{verdict}\\ \hline
+C_3\text{ action}&\text{linear action}&\text{none}&\text{fail}\\
+C_2\ltimes X&\text{isotropy}&\text{none}&\text{fail}\\
+C_2\text{ torsor}&\text{free/transitive}&\text{classification}&\text{conditional}\\
+\text{context}&\text{pullback/restriction}&\text{inverse image}&\text{conditional}\\
+U_G&\text{no fixed point}&\text{internal inhabitation}&\text{strict}.
+\end{array}
+}
+}
+
+\p{Topoi enter these notes only when a result uses universal torsor
+classification, organizes several constructions as inverse image or base
+change, or relies on internal reasoning that differs from global sections.
+Ordinary Group Actions, Group Algebra calculations, and action groupoids stay
+below that layer.}
+
+\p{This boundary also excludes several stronger claims. The spectrum of a
+center is not the original noncommutative Group Algebra. The action-groupoid
+example does not require a quotient stack. No site, descent theorem, or
+physical correspondence has been supplied by these finite tests. Each of
+those would need its own mathematical construction before extending the
+present layer.}

--- a/trees/refs/maclane1992sheaves.tree
+++ b/trees/refs/maclane1992sheaves.tree
@@ -1,0 +1,20 @@
+% ["forest"]
+\title{Sheaves in geometry and logic: a first introduction to topos theory}
+\date{1992}
+\author/literal{Saunders Mac Lane and Ieke Moerdijk}
+\taxon{Reference}
+\meta{external}{https://doi.org/10.1007/978-1-4612-0927-0}
+
+\meta{bibtex}{\startverb
+@book{maclane1992sheaves,
+ author = {Mac Lane, Saunders and Moerdijk, Ieke},
+ title = {Sheaves in Geometry and Logic: A First Introduction to Topos Theory},
+ series = {Universitext},
+ publisher = {Springer-Verlag},
+ address = {New York},
+ year = {1992},
+ isbn = {978-0-387-97710-2},
+ doi = {10.1007/978-1-4612-0927-0},
+ url = {https://doi.org/10.1007/978-1-4612-0927-0}
+}
+\stopverb}

--- a/trees/tt-004O.tree
+++ b/trees/tt-004O.tree
@@ -12,27 +12,29 @@
 
 \refdeft{topos}{7.1}{kostecki2011introduction}{
 \p{
-A \newvocab{topos} or \newvocab{elementary topos} is a category satisfying one of these equivalent conditions:
+A \newvocab{topos}, or \newvocab{elementary topos}, is a category with
+\vocabk{all finite limits}{tt-002F}, \vocabk{exponential}{tt-004G}s, and a
+\vocabk{subobject classifier}{tt-004I}. Equivalently, exponentials may be
+replaced by \vocabk{power object}{tt-004L}s. See
+\citet{sec. IV.1, pp. 161--163}{maclane1992sheaves}.}
 
-\ul{
-  \li{it is a \vocabk{complete}{tt-002F} category with \vocabk{exponential}{tt-004G}s and \vocabk{subobject classifier}{tt-004I}}
-  \li{it is a \vocab{complete} category with \vocab{subobject classifier} and its \vocabk{power object}{tt-004L}}
-  \li{it is a \vocabk{cartesian closed}{tt-004H} category with \vocabk{equalizer}{tt-000Q}s and \vocab{subobject classifier}}
-}
+\p{Every elementary topos also has
+\vocabk{all finite colimits}{tt-003C}; see
+\citet{sec. IV.5, pp. 180--184}{maclane1992sheaves}. Arbitrary small limits
+and colimits are not part of the elementary definition. They do exist in a
+Grothendieck topos of sheaves on a site; see
+\citet{sec. III.6, pp. 134--135}{maclane1992sheaves}.}
 
-}
-
-\p{Since the \vocab{completeness} of a category with subobject classifier implies its \vocab{cocompleteness}. Thus a topos not only \vocabk{has all finite limits}{tt-002F}, but also \vocabk{has all finite colimits}{tt-003C}.}
-
-\p{This means that topos is such category which has, in particular,
+\p{Thus an elementary topos has, in particular,
 
 \ol{
 \li{terminal object}
 \li{equalizers}
 \li{pullbacks}
-\li{all other limits}
+\li{all other finite limits}
 \li{exponential objects}
 \li{subobject classifier}
+\li{all finite colimits}
 }
 
 }

--- a/trees/tt-004Q.tree
+++ b/trees/tt-004Q.tree
@@ -12,7 +12,22 @@
 
 \refdeft{geometric morphism, Topoi}{7.2}{kostecki2011introduction}{
 \p{
-If #{\E_1} and #{\E_2} are \vocabk{topos}{tt-004O}es, then a \newvocab{geometric morphism} #{\fG: \E_1 \to \E_2} is defined as a pair of \vocab{adjoint functor}s #{\fG^* \dashv \fG_*} between #{\E_1} and #{\E_2}, such that #{\fG^*} \vocabk{preserves finite limits}{tt-002H} (i.e. is \vocab{left exact}), which implies #{\fG_*} \vocab{preserves colimits} (i.e. is \vocab{right exact}).}
+If #{\E_1} and #{\E_2} are \vocabk{topos}{tt-004O}es, then a
+\newvocab{geometric morphism} #{\fG: \E_1 \to \E_2} is a pair of
+\vocab{adjoint functor}s
+##{
+\fG^*:\E_2\to\E_1,\qquad
+\fG_*:\E_1\to\E_2,\qquad
+\fG^*\dashv\fG_*,
+}
+such that the inverse-image functor #{\fG^*}
+\vocabk{preserves finite limits}{tt-002H}; that is, #{\fG^*} is left exact.
+See \citet{sec. VII.1, pp. 348--352}{maclane1992sheaves}.}
+
+\p{As a left adjoint, #{\fG^*} preserves every colimit that exists. As a
+right adjoint, #{\fG_*} preserves every limit that exists. The additional
+left-exactness condition on #{\fG^*} is not automatic for a left adjoint,
+and right adjointness does not in general make #{\fG_*} preserve colimits.}
 
 \p{The category of toposes and their geometric morphisms is denoted #{\Topoi}.
 }


### PR DESCRIPTION
## Summary

- add a nine-tree FGAP unit testing where topoi add structure beyond finite Group Actions, Group Algebras, and action groupoids
- calculate the real Group Algebras of C3 and Q8, including the exact information lost by passing to the center
- develop finite torsors, the classifying property of BG, inverse-image variance, and internal inhabitation without global points
- finish with a restricted admission boundary and explicit exclusions

## Dependency

This branch merges the approved repairs from #59 because the new trees depend on the corrected elementary-topos and geometric-morphism conventions.

## Verification

- Forester build completed; only the two pre-existing broken-link warnings for the site root remain
- all ten affected FGAP pages were rendered and checked as nonempty, nonredirect HTML
- the cumulative `fgap-0001` PDF builds to 20 pages and was visually reviewed
- staged-diff and whitespace checks passed

No Lean implementation is included in this pull request.