### PR TITLE
Central involutions and complementary summands

### DIFF
--- a/tex/forest.bib
+++ b/tex/forest.bib
@@ -1844,3 +1844,21 @@
   doi={10.1007/978-1-4612-0927-0},
   url={https://doi.org/10.1007/978-1-4612-0927-0}
 }
+
+@unpublished{sengupta2010representations,
+  author={Sengupta, Ambar N.},
+  title={Representations of Algebras and Finite Groups: An Introduction},
+  year={2010},
+  month={May},
+  note={Course manuscript},
+  url={https://math.uchicago.edu/~margalit/repthy/sengupta\%2C\%20finitegrouprepresent.pdf}
+}
+
+@unpublished{webb2007finite,
+  author={Webb, Peter},
+  title={Finite Group Representations for the Pure Mathematician},
+  year={2007},
+  month={December},
+  note={Course manuscript, December 12, 2007},
+  url={https://www.math.uchicago.edu/~margalit/repthy/Webb\%2C\%20Finite\%20group\%20reps\%20for\%20the\%20pure\%20mathematician.pdf}
+}

--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -32,3 +32,4 @@ separate.}
 \transclude{fgap-0007}
 \transclude{fgap-000E}
 \transclude{fgap-000M}
+\transclude{fgap-000V}

--- a/trees/fgap-000V.tree
+++ b/trees/fgap-000V.tree
@@ -1,0 +1,37 @@
+\import{macros}
+
+\title{Central involutions and complementary summands}
+
+\tag{notes}
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{idempotent}
+
+\p{A central element whose square is one produces two complementary
+idempotents whenever two is invertible. The construction separates a module
+into the two eigenspaces of that element and separates the algebra itself
+into two algebra factors. No semisimplicity or representation
+classification is needed.}
+
+\p{The reading order follows the implications
+##{
+\begin{array}{ccccc}
+z^2=1,\ z\in Z(A)&\longrightarrow&e_+,e_-&
+\longrightarrow&M=e_+M\oplus e_-M\\
+&&\big\downarrow&&\\
+&&A\cong e_+A\times e_-A.&&
+\end{array}
+}
+Centrality is needed for the lower algebra statement. The upper module
+decomposition is an additive direct sum from the complementary-idempotent
+equations; centrality makes its summands #{A}-submodules.}
+
+\transclude{fgap-000W}
+\transclude{fgap-000X}
+\transclude{fgap-000Y}
+\transclude{fgap-000Z}
+\transclude{fgap-0010}
+\transclude{fgap-0011}
+\transclude{fgap-0012}
+\transclude{fgap-0013}

--- a/trees/fgap-000W.tree
+++ b/trees/fgap-000W.tree
@@ -1,0 +1,29 @@
+\import{macros}
+
+\taxon{Definition}
+\title{central involution in an algebra}
+
+\tag{math}
+\tag{fgap}
+\tag{algebra}
+\tag{idempotent}
+
+\p{Let #{R} be a commutative ring, let #{A} be an associative unital
+#{R}-algebra, and suppose #{2\cdot1_R} is invertible. Write
+##{
+h=(2\cdot1_R)^{-1}.
+}
+A \newvocab{central involution} for this construction is an element
+#{z\in A} such that
+##{
+z^2=1_A,\qquad za=az\quad\text{for every }a\in A.
+}
+We then define
+##{
+e_+=h(1_A+z),\qquad e_-=h(1_A-z),
+}
+using the structural map #{R\to A} for the scalar #{h}.}
+
+\p{Only the equation #{z^2=1_A} is used. The element need not have exact
+order two: the extra condition #{z\neq1_A} merely excludes the degenerate
+case #{e_-=0}. The algebra #{A} need not be commutative.}

--- a/trees/fgap-000X.tree
+++ b/trees/fgap-000X.tree
@@ -1,0 +1,29 @@
+\import{macros}
+
+\taxon{Example}
+\title{a central group element inside a Group Algebra}
+
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{idempotent}
+
+\p{Let #{G} be a group and let #{z_G\in G} satisfy
+##{
+z_G^2=1_G,\qquad z_Gg=gz_G\quad\text{for every }g\in G.
+}
+In the Group Algebra #{R[G]}, write #{[z_G]} for the basis element indexed
+by #{z_G}. Then
+##{
+[z_G]^2=[1_G]=1_{R[G]},
+}
+and #{[z_G]} commutes with every basis element #{[g]}. By linearity it is a
+\vocabk{central involution}{fgap-000W} in the algebra. The Group Algebra and
+the passage from group representations to its modules are developed in
+\citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}; compare
+\citet{pp. 1--4}{webb2007finite}.}
+
+\p{The brackets matter. The basis element #{[z_G]} is not the scalar
+#{-1_{R[G]}}. If #{z_G\neq1_G}, their supports are different. If
+#{z_G=1_G}, then #{[z_G]=1_{R[G]}\neq-1_{R[G]}} because two is invertible
+and the base ring is nonzero.}

--- a/trees/fgap-000X.tree
+++ b/trees/fgap-000X.tree
@@ -23,7 +23,8 @@ the passage from group representations to its modules are developed in
 \citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}; compare
 \citet{pp. 1--4}{webb2007finite}.}
 
-\p{The brackets matter. The basis element #{[z_G]} is not the scalar
-#{-1_{R[G]}}. If #{z_G\neq1_G}, their supports are different. If
-#{z_G=1_G}, then #{[z_G]=1_{R[G]}\neq-1_{R[G]}} because two is invertible
-and the base ring is nonzero.}
+\p{The brackets matter. If the base ring #{R} is nontrivial, then the basis
+element #{[z_G]} is not the scalar #{-1_{R[G]}}. If moreover
+#{z_G\neq1_G}, their supports are different. If #{z_G=1_G}, then the
+comparison reduces to #{1_{R[G]}\neq-1_{R[G]}}, which follows because two
+is invertible in the nontrivial base ring.}

--- a/trees/fgap-000X.tree
+++ b/trees/fgap-000X.tree
@@ -23,8 +23,6 @@ the passage from group representations to its modules are developed in
 \citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}; compare
 \citet{pp. 1--4}{webb2007finite}.}
 
-\p{The brackets matter. If the base ring #{R} is nontrivial, then the basis
-element #{[z_G]} is not the scalar #{-1_{R[G]}}. If moreover
-#{z_G\neq1_G}, their supports are different. If #{z_G=1_G}, then the
-comparison reduces to #{1_{R[G]}\neq-1_{R[G]}}, which follows because two
-is invertible in the nontrivial base ring.}
+\p{The brackets matter. Assume #{R} is nontrivial. Then
+#{[z_G]\neq-1_{R[G]}}: their supports differ when #{z_G\neq1_G}; when
+#{z_G=1_G}, this is #{1_{R[G]}\neq-1_{R[G]}}, since two is invertible.}

--- a/trees/fgap-000Y.tree
+++ b/trees/fgap-000Y.tree
@@ -1,0 +1,43 @@
+\import{macros}
+
+\taxon{Lemma}
+\title{the two idempotents of a central involution}
+
+\tag{math}
+\tag{fgap}
+\tag{algebra}
+\tag{idempotent}
+
+\p{For the elements #{e_+} and #{e_-} associated with a
+\vocabk{central involution}{fgap-000W},
+##{
+e_+^2=e_+,\qquad e_-^2=e_-,\qquad
+e_+e_-=e_-e_+=0,\qquad e_++e_-=1_A.
+}
+Both idempotents are central.}
+
+\proof{
+\p{Since #{2h=1_R} and #{z^2=1_A},
+##{
+\begin{aligned}
+e_+^2
+ &=h^2(1+2z+z^2)
+ =2h^2(1+z)
+ =e_+,\\
+e_-^2
+ &=h^2(1-2z+z^2)
+ =2h^2(1-z)
+ =e_-,\\
+e_+e_-
+ &=h^2(1-z^2)
+ =0.
+\end{aligned}
+}
+The reverse mixed product is the same calculation, and
+#{e_++e_-=2h=1_A}. Each #{e_\pm} is a scalar linear combination of the
+central elements #{1_A} and #{z}, so it is central.}
+}
+
+\p{These equations are the elementary two-idempotent instance of the
+projection calculus discussed in
+\citet{sec. 4.5, pp. 63--68}{sengupta2010representations}.}

--- a/trees/fgap-000Z.tree
+++ b/trees/fgap-000Z.tree
@@ -1,0 +1,46 @@
+\import{macros}
+
+\taxon{Theorem}
+\title{the eigenspace decomposition of a module}
+
+\tag{math}
+\tag{fgap}
+\tag{module}
+\tag{idempotent}
+
+\p{Let #{z} be a \vocabk{central involution}{fgap-000W} in #{A}, let
+#{e_+,e_-} be its associated idempotents, and let #{M} be a left
+#{A}-module. Put
+##{
+M_+=e_+M,\qquad M_-=e_-M.
+}
+Then
+##{
+M=M_+\oplus M_-.
+}
+These summands are precisely the two eigenspaces for the action of #{z}:
+##{
+M_+=\{m\in M:zm=m\},\qquad
+M_-=\{m\in M:zm=-m\}.
+}
+}
+
+\proof{
+\p{Every #{m\in M} satisfies
+##{
+m=(e_++e_-)m=e_+m+e_-m.
+}
+If #{x=e_+m=e_-n}, then
+#{x=e_+x=e_+e_-n=0}, so the sum is direct. Direct calculation gives
+#{ze_+=e_+} and #{ze_-=-e_-}, proving one eigenspace inclusion in each
+case. Conversely, if #{zm=m}, then
+##{
+e_+m=h(m+zm)=2hm=m.
+}
+If #{zm=-m}, the analogous calculation gives #{e_-m=m}.}
+}
+
+\p{Idempotents as projections and complementary orthogonal idempotents as
+direct decompositions are recorded in
+\citet{exercise 2.7, p. 15}{webb2007finite}; see also
+\citet{props. 4.5.1--4.5.3, pp. 63--67}{sengupta2010representations}.}

--- a/trees/fgap-0010.tree
+++ b/trees/fgap-0010.tree
@@ -1,0 +1,51 @@
+\import{macros}
+
+\taxon{Theorem}
+\title{the central-idempotent algebra product}
+
+\tag{math}
+\tag{fgap}
+\tag{algebra}
+\tag{idempotent}
+
+\p{For a \vocabk{central involution}{fgap-000W} #{z} and its associated
+idempotents, put
+##{
+A_+=e_+A,\qquad A_-=e_-A.
+}
+Because #{e_+} and #{e_-} are central, these are two-sided ideals and
+#{e_\pm A=Ae_\pm}. Each is a unital #{R}-algebra in its own right, with
+unit #{e_\pm} and structural map #{r\mapsto re_\pm}. There is an
+#{R}-algebra isomorphism
+##{
+\begin{aligned}
+\Phi:A&\longrightarrow A_+\times A_-,
+&a&\longmapsto(e_+a,e_-a),\\
+\Psi:A_+\times A_-&\longrightarrow A,
+&(x,y)&\longmapsto x+y.
+\end{aligned}
+}
+}
+
+\proof{
+\p{For #{a,b\in A},
+#{a(e_\pm b)=e_\pm(ab)} and #{(e_\pm b)a=e_\pm(ba)}, so #{A_\pm} are
+two-sided ideals. If #{x=e_+a\in A_+}, then #{e_+x=x}; thus #{e_+} is the
+unit of #{A_+}, and similarly for #{A_-}.}
+
+\p{Mixed products vanish:
+##{
+(e_+a)(e_-b)=e_+e_-ab=0,
+}
+and likewise in the reverse order. It follows that #{\Phi} and #{\Psi}
+preserve multiplication. Finally,
+##{
+\Psi\Phi(a)=(e_++e_-)a=a,
+}
+while #{\Phi\Psi(x,y)=(x,y)} because the matching idempotent fixes each
+factor and the other annihilates it.}
+}
+
+\p{The use of local units on idempotent-generated ideals follows the
+standard discussion in
+\citet{secs. 4.5--4.6, pp. 63--73}{sengupta2010representations}.}

--- a/trees/fgap-0011.tree
+++ b/trees/fgap-0011.tree
@@ -1,0 +1,33 @@
+\import{macros}
+
+\taxon{Example}
+\title{splitting the Group Algebra of C₂}
+
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{idempotent}
+
+\p{Let #{C_2=\{1,s\}} with #{s^2=1}, and suppose two is invertible in the
+nonzero commutative ring #{R}. The basis element #{[s]} is central, and
+##{
+e_+=\frac{[1]+[s]}2,\qquad
+e_-=\frac{[1]-[s]}2.
+}
+The algebra-product theorem becomes
+##{
+R[C_2]\cong R\times R.
+}
+}
+
+\p{The isomorphism and its inverse are explicit:
+##{
+\begin{aligned}
+a[1]+b[s]&\longmapsto(a+b,a-b),\\
+(x,y)&\longmapsto
+\frac{x+y}{2}[1]+\frac{x-y}{2}[s].
+\end{aligned}
+}
+Under this map, #{e_+} goes to #{(1,0)} and #{e_-} goes to #{(0,1)}.
+Thus the two idempotents are the coordinate projections, not merely a
+dimension count.}

--- a/trees/fgap-0012.tree
+++ b/trees/fgap-0012.tree
@@ -1,0 +1,30 @@
+\import{macros}
+
+\taxon{Remark}
+\title{three levels of splitting}
+
+\tag{math}
+\tag{fgap}
+\tag{algebra}
+\tag{module}
+\tag{idempotent}
+
+\p{The same formulas support three conclusions, but their structures should
+not be conflated:
+##{
+\begin{array}{c|c|c}
+\text{level}&\text{conclusion}&\text{input}\\ \hline
+\text{additive}&M=e_+M\oplus e_-M&
+e_++e_-=1,\ e_+e_-=e_-e_+=0\\
+\text{module}&M_\pm\text{ are eigensubmodules}&
+\text{central action of }z\\
+\text{algebra}&A\cong e_+A\times e_-A&
+e_+,e_-\text{ central}.
+\end{array}
+}
+}
+
+\p{An arbitrary idempotent still acts as a projection and splits the
+underlying regular module. Without centrality, its image need not be a
+two-sided ideal, and the two summands need not be algebra factors. The
+product theorem is therefore stronger than the direct-sum statement.}

--- a/trees/fgap-0013.tree
+++ b/trees/fgap-0013.tree
@@ -1,0 +1,21 @@
+\import{macros}
+
+\taxon{Remark}
+\title{mathematical summands and physical readings}
+
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{physics}
+
+\p{A central involution canonically separates the algebra and its modules
+into two mathematical summands. This alone does not identify either summand
+with particles, interactions, chirality, or any other physical sector. Such
+an interpretation requires additional data: a representation, selected
+observables or forms, dynamics, and a map from the mathematics to measurable
+quantities.}
+
+\p{The split is useful precisely because it can be calculated before those
+choices are made. Later notes may test proposed physical correspondences
+against it, but the algebra decomposition remains valid independently of
+whether any such proposal succeeds.}

--- a/trees/refs/sengupta2010representations.tree
+++ b/trees/refs/sengupta2010representations.tree
@@ -1,0 +1,17 @@
+% ["forest"]
+\title{Representations of Algebras and Finite Groups: An Introduction}
+\date{2010}
+\author/literal{Ambar N. Sengupta}
+\taxon{Reference}
+\meta{external}{https://math.uchicago.edu/~margalit/repthy/sengupta\%2C\%20finitegrouprepresent.pdf}
+
+\meta{bibtex}{\startverb
+@unpublished{sengupta2010representations,
+  author = {Sengupta, Ambar N.},
+  title = {Representations of Algebras and Finite Groups: An Introduction},
+  year = {2010},
+  month = {May},
+  note = {Course manuscript},
+  url = {https://math.uchicago.edu/~margalit/repthy/sengupta\%2C\%20finitegrouprepresent.pdf}
+}
+\stopverb}

--- a/trees/refs/webb2007finite.tree
+++ b/trees/refs/webb2007finite.tree
@@ -1,0 +1,17 @@
+% ["forest"]
+\title{Finite Group Representations for the Pure Mathematician}
+\date{2007}
+\author/literal{Peter Webb}
+\taxon{Reference}
+\meta{external}{https://www.math.uchicago.edu/~margalit/repthy/Webb\%2C\%20Finite\%20group\%20reps\%20for\%20the\%20pure\%20mathematician.pdf}
+
+\meta{bibtex}{\startverb
+@unpublished{webb2007finite,
+  author = {Webb, Peter},
+  title = {Finite Group Representations for the Pure Mathematician},
+  year = {2007},
+  month = {December},
+  note = {Course manuscript, December 12, 2007},
+  url = {https://www.math.uchicago.edu/~margalit/repthy/Webb\%2C\%20Finite\%20group\%20reps\%20for\%20the\%20pure\%20mathematician.pdf}
+}
+\stopverb}


### PR DESCRIPTION
Develop the generic central-involution split used by the independent CENTRAL-SPLIT lane.

The reading unit derives the complementary central idempotents, the module eigenspace decomposition, the two algebra factors with local units, and an explicit C2 calibration. It keeps the Group Algebra basis element distinct from the scalar minus one and separates mathematical summands from physical readings.

The exact inspected Sengupta and Webb manuscripts are registered under new citation keys with their open-access URLs.

Verification: Forester build, cumulative 25-page FGAP PDF build, citation resolution, exact URL checks, and rendered inspection of the new pages.