### PR TITLE
docs(fgap): specialize the abstract 2T central split

### DIFF
--- a/trees/fgap-000E.tree
+++ b/trees/fgap-000E.tree
@@ -35,3 +35,4 @@ elements.}
 \transclude{fgap-000J}
 \transclude{fgap-000K}
 \transclude{fgap-000L}
+\transclude{fgap-0014}

--- a/trees/fgap-000L.tree
+++ b/trees/fgap-000L.tree
@@ -18,9 +18,9 @@ quaternion coordinates.}
 \p{The isomorphism #{(q,c)\mapsto qc} compares the first two models. It is
 not an equality of their elements.}
 
-\p{The present notes stop at the concrete quaternionic subgroup and its
-external factorization. A later formalization step may transport this
-structure to abstract factors such as \code{QuaternionGroup 2} and
-\code{Multiplicative (ZMod 3)}. That transport needs explicit isomorphisms
-and equivariance proofs; it is not supplied by the order computation
-#{|T|=24}.}
+\p{The next note transports the distinguished central involution and
+cardinality to an abstract binary tetrahedral model. Transporting the full
+factorization to factors such as \code{QuaternionGroup 2} and
+\code{Multiplicative (ZMod 3)} also needs explicit isomorphisms and
+equivariance proofs. None of this follows from the order computation
+#{|T|=24} alone.}

--- a/trees/fgap-000V.tree
+++ b/trees/fgap-000V.tree
@@ -30,6 +30,7 @@ equations; centrality makes its summands #{A}-submodules.}
 \transclude{fgap-000W}
 \transclude{fgap-000X}
 \transclude{fgap-000Y}
+\transclude{fgap-0015}
 \transclude{fgap-000Z}
 \transclude{fgap-0010}
 \transclude{fgap-0011}

--- a/trees/fgap-0014.tree
+++ b/trees/fgap-0014.tree
@@ -1,0 +1,45 @@
+\import{macros}
+
+\taxon{Definition}
+\title{the distinguished involution of abstract 2T}
+
+\tag{math}
+\tag{fgap}
+\tag{group}
+\tag{binary-tetrahedral}
+
+\p{Let #{T\leq\mathbb{H}^{\times}} be the binary tetrahedral group of
+Hurwitz units from [[fgap-000J]], and let #{B} be the abstract
+semidirect-product model obtained from the same Hurwitz action. Choose the
+group isomorphism
+##{
+\rho:B\mathbin{\cong}T
+}
+that compares these two models. Voight identifies #{T} with the Hurwitz unit
+group and with #{Q_8\rtimes\mathbb{Z}/3\mathbb{Z}} in
+\citet{sec. 11.2.4, p. 168}{voight2021quaternion}.}
+
+\p{The quaternion #{-1} belongs to #{T}; it is central, its square is one,
+and it is not one. Define the \newvocab{distinguished central involution} of
+#{B} by
+##{
+z=\rho^{-1}(-1).
+}
+Since an isomorphism preserves multiplication and reflects equality,
+##{
+z\in Z(B),\qquad z^2=1,\qquad z\neq1.
+}
+Thus the abstract group retains the central involution supplied by its
+quaternionic realization. The element #{z} is not identified with the
+quaternion #{-1}; the isomorphism #{\rho} relates them.}
+
+\p{The same isomorphism transports cardinality. Since the calculation in
+[[fgap-000K]] gives #{|T|=24},
+##{
+|B|=|T|=24.
+}
+The corresponding Lean result is expected to state
+\code{Nat.card BinaryTetrahedral.Abstract = 24}.}
+
+\p{The occurrence of #{-1} among the twenty-four Hurwitz units is explicit
+in \citet{sec. 11.2, p. 166}{voight2021quaternion}.}

--- a/trees/fgap-0015.tree
+++ b/trees/fgap-0015.tree
@@ -1,0 +1,39 @@
+\import{macros}
+
+\taxon{Example}
+\title{the central split of the real Group Algebra of 2T}
+
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{idempotent}
+\tag{binary-tetrahedral}
+
+\p{Let #{B} be the abstract binary tetrahedral group, let #{z\in B} be its
+\vocabk{distinguished central involution}{fgap-0014}, and put
+##{
+A=\mathbb{R}[B].
+}
+The group element #{z}, its basis image #{[z]\in A}, and the scalar
+#{-1_A} are different kinds of objects. The image #{[z]} is central in
+#{A} and satisfies #{[z]^2=1_A}, by [[fgap-000X]].}
+
+\p{The two elements
+##{
+e_+=\frac{1_A+[z]}2,\qquad
+e_-=\frac{1_A-[z]}2
+}
+therefore satisfy
+##{
+e_+^2=e_+,\qquad e_-^2=e_-,\qquad
+e_+e_-=e_-e_+=0,\qquad e_++e_-=1_A.
+}
+They are central by [[fgap-000Y]]. Hence left multiplication by
+#{e_+} and #{e_-} gives two complementary projections on the regular
+#{A}-module. This specializes the generic central-involution split to
+#{\mathbb{R}[B]}; no representation-theoretic classification is used.}
+
+\p{The Group Algebra convention is developed in
+\citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}. The
+projection interpretation of complementary idempotents is compared with
+\citet{exercise 2.7, p. 15}{webb2007finite}.}


### PR DESCRIPTION
## Summary

- transport the distinguished central involution and cardinality from the Hurwitz-unit model to abstract `2T`
- specialize the generic complementary-idempotent construction to the real Group Algebra of abstract `2T`
- connect both notes to the existing finite-symmetry and central-split note sequences

## Mathematical contribution

For an isomorphism `ρ : B ≃ T` from abstract `2T` to the Hurwitz-unit subgroup, the new definition sets `z = ρ⁻¹(-1)` and records `z ∈ Z(B)`, `z² = 1`, `z ≠ 1`, and `|B| = 24`. In `ℝ[B]`, it then distinguishes `z`, its basis image `[z]`, and the scalar `-1`, and obtains the central complementary idempotents

$$
e_+ = \frac{1 + [z]}{2}, \qquad e_- = \frac{1 - [z]}{2}.
$$

This is an explicit specialization of the generic split. It does not use irreducible characters or a Wedderburn classification.

## Citations

- John Voight, *Quaternion Algebras*, sections 11.2 and 11.2.4, pages 166 and 168
- Ambar N. Sengupta, *Representing Finite Groups: A Semisimple Introduction*, sections 3.1–3.3, pages 39–42
- Peter Webb, *A Course in Finite Group Representation Theory*, exercise 2.7, page 15

## Scope

The source change adds two notes, updates their two transclusion roots, and clarifies the preceding comparison of internal, external, and abstract models. It does not change bibliography records or generated assets.

## Verification

A fresh sequential `just build` followed by `./lize.sh fgap-0001` produced the canonical 26-page PDF. The new abstract-group material on page 12, the specialized Group-Algebra split on page 21, and their adjacent page transitions were inspected. The final LaTeX pass contains no undefined citations or references, and the changed sources contain no private paths.