### PR TITLE
docs(fgap): frame the 2T test case

### DIFF
--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -19,10 +19,8 @@ binary tetrahedral group, because they give a small and explicit route into
 finite real Group Algebras.}
 
 \p{For the mathematics, we follow the Hurwitz-unit treatment in
-\citet{ch. 11}{voight2021quaternion}. The generator is also the one used in
-\citet{eq. (6)}{wilson2021finite}, where the same finite group is considered
-for physical modeling. We keep the mathematics and the physical suggestions
-separate.}
+\citet{ch. 11}{voight2021quaternion}. We keep the mathematics and the
+physical suggestions separate.}
 
 \transclude{fgap-0018}
 \transclude{fgap-0006}

--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -24,6 +24,7 @@ finite real Group Algebras.}
 for physical modeling. We keep the mathematics and the physical suggestions
 separate.}
 
+\transclude{fgap-0018}
 \transclude{fgap-0006}
 \transclude{fgap-0016}
 \transclude{fgap-0017}

--- a/trees/fgap-0003.tree
+++ b/trees/fgap-0003.tree
@@ -14,8 +14,7 @@ a=i+j+k,\qquad
 \omega=\frac{-1+i+j+k}{2}=\frac{-1+a}{2}.
 }
 Then #{\omega} is a Hurwitz unit of order #{3}. This choice appears in
-\citet{p. 165}{voight2021quaternion}, and as #{w} in
-\citet{p. 4, eq. (6)}{wilson2021finite}.}
+\citet{p. 165}{voight2021quaternion}.}
 
 \p{The mixed terms in #{a^2} cancel in pairs:
 ##{

--- a/trees/fgap-0004.tree
+++ b/trees/fgap-0004.tree
@@ -18,8 +18,10 @@
 Thus the cycle is #{i\mapsto k\mapsto j\mapsto i}. Voight says that
 conjugation cyclically rotates these units in
 \citet{sec. 11.2.4, p. 168}{voight2021quaternion}; the calculation here fixes
-the direction. Wilson describes the same order-three automorphisms in
-\citet{sec. 1.4, p. 4}{wilson2021finite}.}
+the direction. Wilson discusses an abstract order-three automorphism cycling
+the quaternion generators in
+\citet{sec. 4.3, pp. 12--13, v5}{wilson2021finite}. That discussion does not
+select the exact quaternion or fix the oriented cycle calculated here.}
 
 \p{It is enough to calculate
 ##{

--- a/trees/fgap-0018.tree
+++ b/trees/fgap-0018.tree
@@ -16,9 +16,11 @@ Algebras, and the quaternionic structures familiar from spin mathematics.
 Its quaternionic realization is described in
 \citet{sec. 11.2, pp. 166--168}{voight2021quaternion}, while the relation
 between representations and Group-Algebra modules is developed in
-\citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}. Wilson's use
-of the same group and its order-three automorphisms supplies physical
-motivation in \citet{sec. 1.4, p. 4}{wilson2021finite}.}
+\citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}. Wilson uses
+order-three automorphisms as physical motivation in
+\citet{sec. 1.4, p. 4}{wilson2021finite}, then constructs #{2T} from #{Q_8}
+and the selected Hurwitz unit in
+\citet{sec. 2.1, pp. 4--5}{wilson2021finite}.}
 
 \p{Any physical identification remains a hypothesis. A proposed
 correspondence must specify an action and representation, an algebra map, any

--- a/trees/fgap-0018.tree
+++ b/trees/fgap-0018.tree
@@ -1,0 +1,26 @@
+\import{macros}
+
+\taxon{Remark}
+\title{why begin with 2T?}
+
+\tag{math}
+\tag{fgap}
+\tag{physics}
+\tag{group-algebra}
+\tag{binary-tetrahedral}
+\tag{quaternion}
+
+\p{The binary tetrahedral group #{2T} is small enough for explicit
+calculations, yet it connects finite symmetry, representations, real Group
+Algebras, and the quaternionic structures familiar from spin mathematics.
+Its quaternionic realization is described in
+\citet{sec. 11.2, pp. 166--168}{voight2021quaternion}, while the relation
+between representations and Group-Algebra modules is developed in
+\citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}. Wilson's use
+of the same group and its order-three automorphisms supplies physical
+motivation in \citet{sec. 1.4, p. 4}{wilson2021finite}.}
+
+\p{Any physical identification remains a hypothesis. A proposed
+correspondence must specify an action and representation, an algebra map, any
+preserved structure or form, a unit-group choice where applicable, and the
+intended physical meaning. Resemblance alone is not a model.}

--- a/trees/fgap-0018.tree
+++ b/trees/fgap-0018.tree
@@ -13,14 +13,16 @@
 \p{The binary tetrahedral group #{2T} is small enough for explicit
 calculations, yet it connects finite symmetry, representations, real Group
 Algebras, and the quaternionic structures familiar from spin mathematics.
-Its quaternionic realization is described in
+Its concrete realization by Hurwitz units, and their identification with
+#{2T}, are described in
 \citet{sec. 11.2, pp. 166--168}{voight2021quaternion}, while the relation
 between representations and Group-Algebra modules is developed in
 \citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}. Wilson uses
-order-three automorphisms as physical motivation in
-\citet{sec. 1.4, p. 4}{wilson2021finite}, then constructs #{2T} from #{Q_8}
-and the selected Hurwitz unit in
-\citet{sec. 2.1, pp. 4--5}{wilson2021finite}.}
+order-three automorphisms of #{Q_8} to discuss possible physical
+interpretations in
+\citet{sec. 4.3, pp. 12--13, v5}{wilson2021finite}. He later adjoins an
+abstract generator #{f} of order three to #{Q_8} to form #{2T} in
+\citet{sec. 6.1, p. 18, v5}{wilson2021finite}.}
 
 \p{Any physical identification remains a hypothesis. A proposed
 correspondence must specify an action and representation, an algebra map, any


### PR DESCRIPTION
## Summary

- add an opening remark explaining why the binary tetrahedral group is the first FGAP test case
- ground the concrete Hurwitz-unit realization and Group-Algebra module bridge in Voight and Sengupta
- cite Wilson v5 only for the abstract order-three automorphism, the later construction of 2T, and the physical motivation
- state the mathematical data required before a physical correspondence can be treated as a model

## Source boundary

The selected Hurwitz unit and its oriented conjugation cycle are attributed only to Voight. Wilson section 4.3 supplies the abstract order-three automorphism and possible physical interpretations; section 6.1 supplies the abstract generator extension forming 2T.

## Verification

- Forester rebuilt the cumulative note corpus successfully.
- The root note produced a 27-page PDF with resolved citations.
- Pages 1 through 3 and the landed Hurwitz-action, binary-tetrahedral, and central-involution sections were inspected for source locators, formulas, and layout.