### PR TITLE
docs(fgap): clarify the mathematical storyline

### DIFF
--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -23,14 +23,8 @@ finite real Group Algebras.}
 physical suggestions separate.}
 
 \transclude{fgap-0018}
-\transclude{fgap-0006}
-\transclude{fgap-0016}
-\transclude{fgap-0017}
-\transclude{fgap-0003}
-\transclude{fgap-0002}
-\transclude{fgap-0004}
-\transclude{fgap-0005}
+\transclude{fgap-0019}
 \transclude{fgap-0007}
 \transclude{fgap-000E}
-\transclude{fgap-000M}
 \transclude{fgap-000V}
+\transclude{fgap-001A}

--- a/trees/fgap-0005.tree
+++ b/trees/fgap-0005.tree
@@ -15,12 +15,13 @@ the \vocabk{conjugation example}{fgap-0004}. Conjugation by
 #{\omega^{-1}} gives the inverse cycle. This is why we record the three
 equations instead of only saying "cyclically permutes."}
 
-\p{The calculation is the first concrete group action needed for the binary
-tetrahedral group. It does not yet identify the complete set of 24 Hurwitz
-units with that group. General group actions, semidirect products, and the full
-group construction belong to later notes.}
+\p{The calculation supplies the first concrete group action used for the
+binary tetrahedral group. The next notes restrict this action to the quaternion
+subgroup and then use it in the semidirect-product construction. The three
+equations alone do not identify the complete set of #{24} Hurwitz units with
+that group.}
 
-\p{In Lean, the three equations will first be proved with the type documented
-in
+\p{In Lean, the three equations give the computational interface to the type
+documented in
 [Mathlib.Algebra.Quaternion](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Algebra/Quaternion.html).
-The abstract group action will be a later interface.}
+The abstract action is then recovered from this concrete calculation.}

--- a/trees/fgap-000D.tree
+++ b/trees/fgap-000D.tree
@@ -27,7 +27,9 @@ The action must then be transported through these isomorphisms and proved
 equivariant. This keeps later abstract calculations connected to the
 quaternion realization that supplied them.}
 
-\p{In Lean, \code{QuaternionGroup 2} is expected to model #{Q}.
-\code{Multiplicative (ZMod 3)} is expected to model #{C}. The isomorphisms and
-the transported action are formalization results to be proved, not definitions
-to be assumed.}
+\p{In Lean, \code{QuaternionGroup 2} models the abstract quaternion factor,
+and \code{Multiplicative (ZMod 3)} models the abstract cyclic factor. The
+concrete subgroups remain the main computational model. Explicit isomorphisms
+recover the abstract interface from that model, and equivariance connects the
+transported action to quaternion conjugation. Formalization therefore keeps
+these bridges as results rather than treating them as definitions.}

--- a/trees/fgap-0014.tree
+++ b/trees/fgap-0014.tree
@@ -38,7 +38,7 @@ quaternion #{-1}; the isomorphism #{\rho} relates them.}
 ##{
 |B|=|T|=24.
 }
-The corresponding Lean result is expected to state
+The corresponding Lean target is
 \code{Nat.card BinaryTetrahedral.Abstract = 24}.}
 
 \p{The occurrence of #{-1} among the twenty-four Hurwitz units is explicit

--- a/trees/fgap-0019.tree
+++ b/trees/fgap-0019.tree
@@ -1,0 +1,21 @@
+\import{macros}
+
+\title{Quaternion and Hurwitz foundations}
+
+\tag{notes}
+\tag{math}
+\tag{fgap}
+\tag{quaternion}
+\tag{hurwitz}
+
+\p{We first introduce Hamilton's Quaternions, the Hurwitz order, and a
+distinguished unit. Its order and conjugation action provide the concrete
+calculations used by the group constructions in the next two sections.}
+
+\transclude{fgap-0006}
+\transclude{fgap-0016}
+\transclude{fgap-0017}
+\transclude{fgap-0003}
+\transclude{fgap-0002}
+\transclude{fgap-0004}
+\transclude{fgap-0005}

--- a/trees/fgap-001A.tree
+++ b/trees/fgap-001A.tree
@@ -1,0 +1,12 @@
+\import{macros}
+
+\title{Appendix}
+
+\tag{notes}
+\tag{math}
+\tag{fgap}
+
+\p{The appendix records exploratory structures that are not needed for the
+quaternionic and Group-Algebra spine.}
+
+\transclude{fgap-000M}


### PR DESCRIPTION
## Summary

- add an explicit section for the quaternion and Hurwitz foundations
- retain the subgroup, binary-tetrahedral, and central-split sections as the main mathematical spine
- move the finite topos tests into an appendix
- replace stale future-work wording with the concrete-to-abstract formalization bridge

## Theory modeling implications

The concrete quaternion subgroups remain the computational model. Explicit isomorphisms recover the abstract factor models, while equivariance connects their transported action to quaternion conjugation. No mathematical statement or existing note address changes.

## Verification

- all 44 non-root FGAP trees are reachable exactly once from the root, with no duplicate transclusions or parent tags
- the rendered HTML places the five main sections at one level and the finite topos tests under the appendix
- the 29-page PDF was rebuilt and visually checked at every structural transition