### PR TITLE
fix(bib): identify the inspected Etingof edition

### DIFF
--- a/tex/forest.bib
+++ b/tex/forest.bib
@@ -1502,9 +1502,14 @@
 }
 
 @book{etingof2024introduction,
-  title={Introduction to representation theory},
-  author={Etingof, Pavel et al.},
-  year={2024},
+  author={Etingof, Pavel and Golberg, Oleg and Hensel, Sebastian and Liu, Tiankai and Schwendner, Alex and Vaintrob, Dmitry and Yudovina, Elena},
+  title={Introduction to Representation Theory},
+  series={Student Mathematical Library},
+  volume={59},
+  publisher={American Mathematical Society},
+  year={2011},
+  isbn={978-0-8218-5351-1, 978-1-4704-1222-7},
+  url={https://math.mit.edu/~etingof/replect.pdf}
 }
 
 @book{flori2013first,

--- a/trees/refs/etingof2024introduction.tree
+++ b/trees/refs/etingof2024introduction.tree
@@ -1,13 +1,19 @@
 % ["forest"]
-\title{Introduction to representation theory}
-\date{2024}
-\author/literal{Pavel et al. Etingof}
+\title{Introduction to Representation Theory}
+\date{2011}
+\author/literal{Pavel Etingof}\author/literal{Oleg Golberg}\author/literal{Sebastian Hensel}\author/literal{Tiankai Liu}\author/literal{Alex Schwendner}\author/literal{Dmitry Vaintrob}\author/literal{Elena Yudovina}
 \taxon{Reference}
+\meta{external}{https://math.mit.edu/~etingof/replect.pdf}
 
 \meta{bibtex}{\startverb
 @book{etingof2024introduction,
- title = {Introduction to representation theory},
- author = {Etingof, Pavel et al.},
- year = {2024}
+  author={Etingof, Pavel and Golberg, Oleg and Hensel, Sebastian and Liu, Tiankai and Schwendner, Alex and Vaintrob, Dmitry and Yudovina, Elena},
+  title={Introduction to Representation Theory},
+  series={Student Mathematical Library},
+  volume={59},
+  publisher={American Mathematical Society},
+  year={2011},
+  isbn={978-0-8218-5351-1, 978-1-4704-1222-7},
+  url={https://math.mit.edu/~etingof/replect.pdf}
 }
 \stopverb}


### PR DESCRIPTION
## Summary

Correct both Forest bibliography representations for the stable `etingof2024introduction` key to the inspected 2011 AMS edition of *Introduction to Representation Theory*.

The BibTeX database and rendered reference tree now name all seven authors and record the Student Mathematical Library series and volume, publisher, softcover and eBook ISBNs, and the author-hosted open-access text. The citation key remains unchanged.

## Verification

- parsed both BibTeX representations and checked that their corrected fields agree under the unique stable key
- verified the two ISBNs and publication metadata against the AMS catalog
- confirmed that the author-hosted PDF is linked from Pavel Etingof's MIT page and responds successfully
- completed the Forest build; optional-WASM and XSL warnings predate and do not involve this bibliography correction