### PR TITLE
docs(fgap): ground the binary tetrahedral McKay route

### DIFF
--- a/tex/forest.bib
+++ b/tex/forest.bib
@@ -1859,6 +1859,17 @@
   url={https://math.uchicago.edu/~margalit/repthy/sengupta\%2C\%20finitegrouprepresent.pdf}
 }
 
+@book{stekolshchik2008notes,
+  author={Stekolshchik, Rafael},
+  title={Notes on Coxeter Transformations and the McKay Correspondence},
+  series={Springer Monographs in Mathematics},
+  publisher={Springer Berlin, Heidelberg},
+  year={2008},
+  doi={10.1007/978-3-540-77399-3},
+  isbn={978-3-540-77398-6, 978-3-642-09604-4, 978-3-540-77399-3},
+  url={https://www-users.cse.umn.edu/~reiner/ReadingSeminars/McKaySeminar2016/Stekolshchik.pdf}
+}
+
 @unpublished{webb2007finite,
   author={Webb, Peter},
   title={Finite Group Representations for the Pure Mathematician},

--- a/trees/refs/stekolshchik2008notes.tree
+++ b/trees/refs/stekolshchik2008notes.tree
@@ -1,0 +1,19 @@
+% ["forest"]
+\title{Notes on Coxeter Transformations and the McKay Correspondence}
+\date{2008}
+\author/literal{Rafael Stekolshchik}
+\taxon{Reference}
+\meta{external}{https://www-users.cse.umn.edu/~reiner/ReadingSeminars/McKaySeminar2016/Stekolshchik.pdf}
+
+\meta{bibtex}{\startverb
+@book{stekolshchik2008notes,
+  author = {Stekolshchik, Rafael},
+  title = {Notes on Coxeter Transformations and the McKay Correspondence},
+  series = {Springer Monographs in Mathematics},
+  publisher = {Springer Berlin, Heidelberg},
+  year = {2008},
+  doi = {10.1007/978-3-540-77399-3},
+  isbn = {978-3-540-77398-6, 978-3-642-09604-4, 978-3-540-77399-3},
+  url = {https://www-users.cse.umn.edu/~reiner/ReadingSeminars/McKaySeminar2016/Stekolshchik.pdf}
+}
+\stopverb}


### PR DESCRIPTION
## Summary

Add a stable scholarly citation for the binary-tetrahedral case of the McKay correspondence.

## Scope

- add the conventional BibTeX entry for Rafael Stekolshchik’s 2008 monograph;
- add the matching Forester reference tree;
- retain the Springer DOI, published-edition metadata and ISBNs, and an openly accessible manuscript URL.

## Motivation

Example A.11, p. 174 identifies the irreducible representations of the binary tetrahedral group with the vertices of the extended Dynkin diagram of type $\widetilde E_6$ and gives the tensor-product decompositions that determine its edges. The citation will ground a separate FGAP remark about this representation-theoretic route.

## Verification

The two citation representations were compared field by field. The open manuscript resolves as a PDF, the DOI and published metadata were checked against Springer, and the Forest build accepts the new reference.

[AGENT: peri]