### PR TITLE
docs(fgap): compare binary tetrahedral models and routes

### DIFF
--- a/trees/fgap-001D.tree
+++ b/trees/fgap-001D.tree
@@ -1,0 +1,66 @@
+\import{macros}
+
+\taxon{Remark}
+\title{what the models of 2T retain}
+
+\tag{math}
+\tag{fgap}
+\tag{group}
+\tag{quaternion}
+\tag{semidirect-product}
+\tag{formalization}
+
+\p{The same binary tetrahedral symmetry now has several models. They answer
+different questions.}
+
+\ul{
+  \li{The \newvocab{concrete model}
+  #{T\leq\mathbb{H}^{\times}} retains quaternion coordinates, multiplication,
+  conjugation, and norm. It is the model for explicit calculations.}
+
+  \li{The \newvocab{internal semidirect-product structure} retains the same
+  group #{T}, but also marks the subgroups #{Q,C\leq T}. The facts
+  ##{
+  T=QC,\qquad Q\mathrel{\trianglelefteq}T,\qquad Q\cap C=\{1\}
+  }
+  say that every element of #{T} has a unique factorization #{qc}. They
+  expose how the two parts fit inside the concrete group.}
+
+  \li{The \newvocab{external model} #{Q\rtimes_{\alpha}C} replaces a
+  quaternion by a pair #{(q,c)}. It retains the factors and records their
+  interaction in the conjugation action
+  #{\alpha(c)(q)=cqc^{-1}}. Its multiplication is
+  ##{
+  (q,c)(q',c')
+  =\bigl(q\alpha(c)(q'),cc'\bigr).
+  }}
+
+  \li{An \newvocab{abstract model} can specify the binary tetrahedral group
+  without quaternion coordinates. This is convenient when only its group
+  structure is needed, but coordinates and named factors must be restored
+  by additional maps.}
+}
+
+\p{The multiplication map
+##{
+\mu:Q\rtimes_{\alpha}C\longrightarrow T,\qquad(q,c)\longmapsto qc
+}
+is an isomorphism by [[fgap-000I]]. Indeed,
+##{
+\mu\bigl((q,c)(q',c')\bigr)
+=q(cq'c^{-1})cc'
+=qcq'c'
+=\mu(q,c)\mu(q',c').
+}
+Thus the external multiplication is not an analogy: it is exactly the
+concrete multiplication written in factor coordinates. The two carriers are
+still different, so a theorem or construction passes between them only
+through an explicit isomorphism. If it refers to the named factors or their
+action, the transport must also record the corresponding compatibility.}
+
+\p{The internal and external constructions are developed in
+\citet{sec. 4.2.13, pp. 62--63}{fre2023discrete} and
+\citet{sec. 1.4.2, pp. 58--61}{isaev2018theory}. The concrete identification
+of #{2T} with the Hurwitz unit group and
+#{Q_8\rtimes\mathbb{Z}/3\mathbb{Z}} is given in
+\citet{sec. 11.2.4, p. 168}{voight2021quaternion}.}

--- a/trees/fgap-001E.tree
+++ b/trees/fgap-001E.tree
@@ -1,0 +1,98 @@
+\import{macros}
+
+\taxon{Remark}
+\title{two routes from binary tetrahedral symmetry}
+
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{representation}
+\tag{mckay}
+\tag{physics}
+
+\p{The semidirect-product model and the quaternion model open two different
+routes from the same group. One rewrites the Group Algebra in interacting
+factor data. The other places the group inside #{\mathrm{SU}(2)} and leads to
+the McKay graph.}
+
+\subtree{
+  \title{The Group-Algebra route}
+
+  \p{Extend the conjugation action
+  #{\alpha:C\to\operatorname{Aut}(Q)} linearly to real-algebra
+  automorphisms
+  ##{
+  \overline{\alpha}_c:\mathbb{R}[Q]\longrightarrow\mathbb{R}[Q].
+  }
+  On the vector space
+  #{\mathbb{R}[Q]\otimes_{\mathbb{R}}\mathbb{R}[C]}, write a pure tensor as
+  #{a\mathbin{\#}c} and define
+  ##{
+  (a\mathbin{\#}c)(b\mathbin{\#}d)
+  =a\,\overline{\alpha}_c(b)\mathbin{\#}cd,
+  }
+  extending bilinearly. This convention defines the
+  \newvocab{skew Group Algebra}
+  #{\mathbb{R}[Q]\rtimes_{\overline{\alpha}}C}; it is also a crossed product
+  with trivial twisting cocycle.}
+
+  \p{The basis map
+  ##{
+  [q]\mathbin{\#}c\longmapsto[qc]
+  }
+  respects multiplication by the calculation in [[fgap-001D]], and unique
+  factorization makes it a bijection. Hence
+  ##{
+  \mathbb{R}[Q]\rtimes_{\overline{\alpha}}C
+  \mathbin{\cong_{\mathbb{R}\text{-alg}}}\mathbb{R}[T].
+  }
+  This is the Group-Algebra form of
+  #{T\cong Q\rtimes_{\alpha}C}. The extension of group maps to Group-Algebra
+  maps follows the convention in
+  \citet{secs. 3.1--3.2, pp. 39--41}{sengupta2010representations}.}
+
+  \p{A module over this skew Group Algebra can be read as an
+  #{\mathbb{R}[Q]}-module #{M} together with a linear action of #{C}
+  satisfying
+  ##{
+  c\mathbin{\cdot}(a\mathbin{\cdot}m)
+  =\overline{\alpha}_c(a)\mathbin{\cdot}
+  (c\mathbin{\cdot}m).
+  }
+  The external model therefore exposes the compatibility needed to assemble
+  representations from the two factors. It does not by itself decompose
+  #{\mathbb{R}[T]} into simple blocks. That requires further
+  representation-theoretic input.}
+}
+
+\subtree{
+  \title{The McKay route}
+
+  \p{Under the standard matrix realization of the unit quaternions as
+  #{\mathrm{SU}(2)}, the concrete group #{T} becomes a finite subgroup of
+  #{\mathrm{SU}(2)}. Let #{\tau_3} be its faithful two-dimensional complex
+  representation. The McKay graph has one vertex for each irreducible
+  complex representation #{\tau_i}; the number of edges from #{\tau_i} to
+  #{\tau_j} is the multiplicity of #{\tau_j} in
+  ##{
+  \tau_3\otimes\tau_i.
+  }
+  For the binary tetrahedral group this graph is the affine Dynkin diagram
+  #{\widetilde{E}_6}. The character table, the seven irreducible
+  representations, and the tensor-product calculation are given in
+  \citet{table A.12, prop. A.10, and ex. A.11, pp. 172--174}{stekolshchik2008notes}.}
+
+  \p{This graph connects the representation theory of #{2T} with quivers
+  and the ADE classification. The same source relates a binary polyhedral
+  subgroup #{G\leq\mathrm{SU}(2)} to the quotient
+  #{\mathbb{C}^2/G}, its invariant algebra, and its Kleinian singularity in
+  \citet{secs. A.3--A.4, pp. 158--161}{stekolshchik2008notes}. These are
+  routes toward quotient geometry and related orbifold constructions. They
+  are not consequences of the semidirect-product theorem alone.}
+
+  \p{Neither route assigns physical meaning to #{Q}, #{C}, an algebra
+  block, or a vertex of #{\widetilde{E}_6}. They supply mathematical
+  structures on which a physical correspondence could be stated and
+  tested. A proposed correspondence must still identify the action,
+  representation, preserved structure, and physical interpretation.}
+}

--- a/trees/fgap-001F.tree
+++ b/trees/fgap-001F.tree
@@ -1,0 +1,21 @@
+\import{macros}
+
+\title{Models and routes from binary tetrahedral structure}
+\meta{pdf}{true}
+
+\tag{notes}
+\tag{math}
+\tag{fgap}
+\tag{group-algebra}
+\tag{representation}
+
+\author{utensil}
+\date{2026-07-30}
+
+\p{The concrete, internal, external, and abstract models of #{2T} retain
+different data. Their comparison opens a Group-Algebra route through the
+semidirect factors and a representation-theoretic route through the McKay
+correspondence.}
+
+\transclude{fgap-001D}
+\transclude{fgap-001E}


### PR DESCRIPTION
## Summary

- distinguish the concrete, internal, external, and abstract models of the binary tetrahedral group
- derive the skew Group-Algebra multiplication and its compatible-module condition from the semidirect action
- define the McKay graph for the faithful two-dimensional representation and record the affine E6 and quotient-singularity routes
- keep the notes in a standalone transclusion root without changing the established storyline

## Mathematical contribution

The notes explain which data each model retains and why transport requires an explicit isomorphism. They then show how the conjugation action extends to a skew Group Algebra isomorphic to the real Group Algebra of 2T. Separately, the quaternion realization places 2T in SU(2), where the McKay graph is affine E6. The physical discussion is kept as motivation and does not assign meaning to factors, blocks, or graph vertices.

## Grounding

The semidirect-product comparison uses Fre, Isaev and Rubakov, and Voight. The Group-Algebra map uses Sengupta. The binary-tetrahedral character table and McKay calculation use Stekolshchik, Table A.12, Proposition A.10, and Example A.11 on printed pages 172 through 174.

## Verification

- Forester build completed successfully
- standalone five-page PDF compiled successfully
- rendered pages were inspected for layout, citations, and mathematical notation