### PR TITLE
docs(fgap): reflect central-split formalization

### DIFF
--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -27,4 +27,5 @@ physical suggestions separate.}
 \transclude{fgap-0007}
 \transclude{fgap-000E}
 \transclude{fgap-000V}
+\transclude{fgap-001C}
 \transclude{fgap-001A}

--- a/trees/fgap-000Y.tree
+++ b/trees/fgap-000Y.tree
@@ -17,25 +17,27 @@ e_+e_-=e_-e_+=0,\qquad e_++e_-=1_A.
 Both idempotents are central.}
 
 \proof{
-\p{Since #{2h=1_R} and #{z^2=1_A},
+\p{First,
+##{
+e_++e_-=h(1+z)+h(1-z)=2h=1_A,
+}
+so #{e_-=1_A-e_+}. Since #{2h=1_R} and #{z^2=1_A},
+##{
+e_+^2
+=h^2(1+2z+z^2)
+=2h^2(1+z)
+=e_+.
+}
+The remaining identities now follow from this one idempotence calculation:
 ##{
 \begin{aligned}
-e_+^2
- &=h^2(1+2z+z^2)
- =2h^2(1+z)
- =e_+,\\
-e_-^2
- &=h^2(1-2z+z^2)
- =2h^2(1-z)
- =e_-,\\
-e_+e_-
- &=h^2(1-z^2)
- =0.
+e_-^2&=(1_A-e_+)^2=1_A-e_+=e_-,\\
+e_+e_-&=e_+(1_A-e_+)=0,\\
+e_-e_+&=(1_A-e_+)e_+=0.
 \end{aligned}
 }
-The reverse mixed product is the same calculation, and
-#{e_++e_-=2h=1_A}. Each #{e_\pm} is a scalar linear combination of the
-central elements #{1_A} and #{z}, so it is central.}
+Finally, each #{e_\pm} is a scalar linear combination of the central
+elements #{1_A} and #{z}, so it is central.}
 }
 
 \p{These equations are the elementary two-idempotent instance of the

--- a/trees/fgap-000Z.tree
+++ b/trees/fgap-000Z.tree
@@ -10,11 +10,30 @@
 
 \p{Let #{z} be a \vocabk{central involution}{fgap-000W} in #{A}, let
 #{e_+,e_-} be its associated idempotents, and let #{M} be a left
-#{A}-module. Put
+#{A}-module. Left multiplication defines #{A}-linear projections
 ##{
-M_+=e_+M,\qquad M_-=e_-M.
+p_\pm:M\longrightarrow M,\qquad p_\pm(m)=e_\pm m.
 }
-Then
+They satisfy
+##{
+p_\pm^2=p_\pm,\qquad
+p_++p_-=\mathrm{id}_M,\qquad
+p_+p_-=p_-p_+=0.
+}
+Their ranges and kernels are
+##{
+\begin{aligned}
+\operatorname{range}(p_+)&=e_+M,&
+\ker(p_+)&=\operatorname{range}(p_-)=e_-M,\\
+\operatorname{range}(p_-)&=e_-M,&
+\ker(p_-)&=\operatorname{range}(p_+)=e_+M.
+\end{aligned}
+}
+Consequently, if
+##{
+M_+=e_+M,\qquad M_-=e_-M,
+}
+then
 ##{
 M=M_+\oplus M_-.
 }
@@ -26,14 +45,21 @@ M_-=\{m\in M:zm=-m\}.
 }
 
 \proof{
-\p{Every #{m\in M} satisfies
+\p{The idempotent and mixed-product identities from [[fgap-000Y]] give the
+displayed projection identities after acting on #{M}. Centrality of #{e_\pm}
+makes #{p_\pm} #{A}-linear. Their ranges are #{e_\pm M} by definition. If
+#{p_+(m)=0}, then
 ##{
-m=(e_++e_-)m=e_+m+e_-m.
+m=(p_++p_-)(m)=p_-(m),
 }
-If #{x=e_+m=e_-n}, then
-#{x=e_+x=e_+e_-n=0}, so the sum is direct. Direct calculation gives
-#{ze_+=e_+} and #{ze_-=-e_-}, proving one eigenspace inclusion in each
-case. Conversely, if #{zm=m}, then
+so #{m} lies in the range of #{p_-}. Conversely,
+#{p_+p_-=0} shows that every element in that range lies in
+#{\ker(p_+)}. This proves the first kernel-range equality; the second is
+symmetric. The identity #{p_++p_-=\mathrm{id}_M} now gives the displayed direct
+sum.}
+
+\p{Direct calculation gives #{ze_+=e_+} and #{ze_-=-e_-}, proving one
+eigenspace inclusion in each case. Conversely, if #{zm=m}, then
 ##{
 e_+m=h(m+zm)=2hm=m.
 }

--- a/trees/fgap-0012.tree
+++ b/trees/fgap-0012.tree
@@ -24,7 +24,14 @@ e_+,e_-\text{ central}.
 }
 }
 
-\p{An arbitrary idempotent still acts as a projection and splits the
-underlying regular module. Without centrality, its image need not be a
-two-sided ideal, and the two summands need not be algebra factors. The
-product theorem is therefore stronger than the direct-sum statement.}
+\p{For an arbitrary idempotent #{e\in A}, left multiplication by #{e} and
+#{1-e} gives a split of the underlying #{R}-module,
+##{
+A=eA\oplus(1-e)A,
+}
+and therefore also of the underlying additive group. Without centrality,
+these projections need not be homomorphisms of the left regular
+#{A}-module: #{eA} and #{(1-e)A} are right ideals, but need not be left
+ideals or two-sided ideals. The two summands therefore need not be algebra
+factors. The product theorem is stronger than this #{R}-module direct-sum
+statement.}

--- a/trees/fgap-001C.tree
+++ b/trees/fgap-001C.tree
@@ -1,7 +1,6 @@
 \import{macros}
 
 \title{Real blocks of the quaternion Group Algebra}
-\meta{pdf}{true}
 
 \tag{notes}
 \tag{math}
@@ -12,7 +11,9 @@
 \author{utensil}
 \date{2026-07-30}
 
-\p{An explicit calculation of the real blocks of the quaternion Group
-Algebra.}
+\p{The preceding central-involution construction isolates algebra factors
+without classifying all representations. For the quaternion group, the
+following direct coefficient calculation goes further and makes every real
+block explicit.}
 
 \transclude{fgap-001B}


### PR DESCRIPTION
## Summary

- reorganize the central-involution proof around the complementary identity $e_-=1-e_+$
- introduce the projections $p_\pm$, their ranges, both kernel/range equalities, and only then the eigenspace decomposition
- state the arbitrary-idempotent split at the correct level of the underlying $R$-module and additive group
- place the explicit real blocks of $\mathbb R[Q_8]$ after the central-involution section and before the Appendix

## Formalization feedback

The formalization showed that the minus idempotent and mixed-zero identities are consequences of one plus-idempotence calculation together with complementation. The notes now use that proof spine instead of repeating parallel expansions.

It also exposed a structural boundary that the earlier prose blurred. For a noncentral idempotent, left multiplication is an $R$-linear projection and its image is a right ideal, but it need not be a homomorphism of the left regular module. Centrality is what upgrades the summands to two-sided ideals and algebra factors.

The storyline now moves from generic complementary-idempotent calculus to the explicit real-block calculation for $Q_8$, then to the exploratory Topos appendix.

## Verification

- Forester accepted the revised transclusion graph and references.
- The cumulative `fgap-0001` document compiled to a 31-page PDF.
- Pages 16–20 were inspected for projection formulas, theorem-box continuity, section hierarchy, and page overflow.