### PR TITLE
docs(fgap): narrow mathematical numeral style

### DIFF
--- a/trees/fgap-0004.tree
+++ b/trees/fgap-0004.tree
@@ -18,7 +18,7 @@
 Thus the cycle is #{i\mapsto k\mapsto j\mapsto i}. Voight says that
 conjugation cyclically rotates these units in
 \citet{sec. 11.2.4, p. 168}{voight2021quaternion}; the calculation here fixes
-the direction. Wilson discusses an abstract order-three automorphism cycling
+the direction. Wilson discusses an abstract order-3 automorphism cycling
 the quaternion generators in
 \citet{sec. 4.3, pp. 12--13, v5}{wilson2021finite}. That discussion does not
 select the exact quaternion or fix the oriented cycle calculated here.}

--- a/trees/fgap-0006.tree
+++ b/trees/fgap-0006.tree
@@ -8,7 +8,7 @@
 \tag{fgap}
 \tag{quaternion}
 
-\p{The algebra of real \newvocab{quaternion}s is the four-dimensional real
+\p{The algebra of real \newvocab{quaternion}s is the 4-dimensional real
 vector space
 ##{
 \mathbb{H}

--- a/trees/fgap-0009.tree
+++ b/trees/fgap-0009.tree
@@ -23,7 +23,7 @@ closed under multiplication and inverses. It is therefore a subgroup of
 i^4=1,\qquad i^2=j^2=-1,\qquad ji=i^{-1}j.
 }
 These are the usual relations for the quaternion group. Hence #{Q} is a
-concrete copy of #{Q_8}. Voight identifies the same eight units in
+concrete copy of #{Q_8}. Voight identifies the same 8 units in
 \citet{sec. 11.2, p. 166}{voight2021quaternion}.}
 
 \p{Here #{Q} always means this particular subgroup of the quaternions. An

--- a/trees/fgap-000A.tree
+++ b/trees/fgap-000A.tree
@@ -17,12 +17,12 @@ Consequently,
 Q=\langle i,j\rangle
 =\{i^a j^b:0\leq a<4,\ 0\leq b<2\}
 }
-and #{Q} has eight elements.}
+and #{Q} has 8 elements.}
 
 \proof{
 \p{The relation #{ji=i^{-1}j} moves each occurrence of #{j} to the right.
 The relations #{i^4=1} and #{j^2=i^2} then reduce every word in #{i,j} to
-the stated form. The eight resulting quaternions are}
+the stated form. The 8 resulting quaternions are}
 ##{
 \begin{array}{cccc}
 1&i&-1&-i\\

--- a/trees/fgap-000B.tree
+++ b/trees/fgap-000B.tree
@@ -18,13 +18,13 @@ It follows that
 ##{
 C=\langle\omega\rangle=\{1,\omega,\omega^2\}
 }
-is a cyclic subgroup of #{\mathbb{H}^{\times}} of order three. In particular,
+is a cyclic subgroup of #{\mathbb{H}^{\times}} of order 3. In particular,
 #{C\cong\mathbb{Z}/3\mathbb{Z}}. This subgroup appears in
 \citet{sec. 11.2.4, p. 168}{voight2021quaternion}.}
 
 \proof{
-\p{Every power of #{\omega} reduces modulo three, so
+\p{Every power of #{\omega} reduces modulo 3, so
 #{C\subseteq\{1,\omega,\omega^2\}}. The reverse inclusion is immediate.
 If #{\omega^2=1}, multiplying by #{\omega} would give #{\omega=1}, contrary
-to the coordinate formula. Thus the three displayed elements are distinct.}
+to the coordinate formula. Thus the 3 displayed elements are distinct.}
 }

--- a/trees/fgap-000C.tree
+++ b/trees/fgap-000C.tree
@@ -20,7 +20,7 @@ Indeed, [[fgap-0004]] gives
 \omega k\omega^{-1}=j,\qquad
 \omega j\omega^{-1}=i.
 }
-Thus conjugation by the generator preserves all eight elements of #{Q}. Its
+Thus conjugation by the generator preserves all 8 elements of #{Q}. Its
 conjugation powers preserve #{Q} as well, so every #{c\in C} gives the stated
 automorphism. The generator's action can be read from the two oriented cycles
 ##{

--- a/trees/fgap-000E.tree
+++ b/trees/fgap-000E.tree
@@ -17,7 +17,7 @@ unique factorization, and unique factorization produces an internal
 semidirect product.}
 
 \p{Applying these steps inside #{\mathbb{H}^{\times}} gives a concrete group
-with twenty-four elements:
+with 24 elements:
 ##{
 Q,\ C
 \longrightarrow

--- a/trees/fgap-000J.tree
+++ b/trees/fgap-000J.tree
@@ -21,7 +21,7 @@ T=QC,\qquad Q\mathrel{\trianglelefteq}T.
 }
 }
 
-\p{The groups #{Q} and #{C} have orders eight and three. The order of their
+\p{The groups #{Q} and #{C} have orders 8 and 3. The order of their
 intersection divides both, so
 ##{
 Q\cap C=\{1\}.

--- a/trees/fgap-000K.tree
+++ b/trees/fgap-000K.tree
@@ -36,7 +36,7 @@ Q\omega\sqcup Q\omega^2
 \epsilon_r\in\{\pm1\}
 \right\}.
 }
-The coordinates are distinct, so these are the sixteen half-integral units.
+The coordinates are distinct, so these are the 16 half-integral units.
 Together with #{Q}, they are exactly the 24 Hurwitz units listed in
 \citet{sec. 11.2, p. 166}{voight2021quaternion}. Thus the subgroup #{T} is
 the unit group of the Hurwitz order, not merely another group of the same

--- a/trees/fgap-000K.tree
+++ b/trees/fgap-000K.tree
@@ -27,7 +27,7 @@ Since
 \omega=\frac{-1+i+j+k}{2},\qquad
 \omega^2=\frac{-1-i-j-k}{2},
 }
-left multiplication by the eight elements of #{Q} gives
+left multiplication by the 8 elements of #{Q} gives
 ##{
 Q\omega\sqcup Q\omega^2
 =
@@ -37,7 +37,7 @@ Q\omega\sqcup Q\omega^2
 \right\}.
 }
 The coordinates are distinct, so these are the sixteen half-integral units.
-Together with #{Q}, they are exactly the twenty-four Hurwitz units listed in
+Together with #{Q}, they are exactly the 24 Hurwitz units listed in
 \citet{sec. 11.2, p. 166}{voight2021quaternion}. Thus the subgroup #{T} is
 the unit group of the Hurwitz order, not merely another group of the same
 cardinality.}

--- a/trees/fgap-000O.tree
+++ b/trees/fgap-000O.tree
@@ -39,7 +39,7 @@ s_1+\epsilon s_i+\delta s_j+\epsilon\delta s_k,
 }
 The Hadamard matrix is invertible, so these four values recover every
 #{s_q}. Together with the four differences, they recover every coefficient.
-Thus #{\Phi} has zero kernel. Both sides have real dimension eight, so
+Thus #{\Phi} has zero kernel. Both sides have real dimension 8, so
 #{\Phi} is an isomorphism. The quaternionic realization and multiplication
 used here are developed in [[fgap-0006]] and
 \citet{sec. 11.2, p. 166}{voight2021quaternion}.}

--- a/trees/fgap-000Q.tree
+++ b/trees/fgap-000Q.tree
@@ -38,7 +38,7 @@ C_2\times C_2\longrightarrow C_2\times C_2,
 \qquad
 (g,h)\longmapsto(gh,h)
 }
-is a bijection. The trivial action on a two-point set #{D}, despite
+is a bijection. The trivial action on a 2-point set #{D}, despite
 #{D\to1} being onto, is not a torsor. Its corresponding map sends
 #{(g,d)} to #{(d,d)}, so it is neither injective nor surjective. Inhabitation
 and cardinality alone do not supply a torsor.}

--- a/trees/fgap-000W.tree
+++ b/trees/fgap-000W.tree
@@ -25,5 +25,5 @@ e_+=h(1_A+z),\qquad e_-=h(1_A-z),
 using the structural map #{R\to A} for the scalar #{h}.}
 
 \p{Only the equation #{z^2=1_A} is used. The element need not have exact
-order two: the extra condition #{z\neq1_A} merely excludes the degenerate
+order 2: the extra condition #{z\neq1_A} merely excludes the degenerate
 case #{e_-=0}. The algebra #{A} need not be commutative.}

--- a/trees/fgap-000X.tree
+++ b/trees/fgap-000X.tree
@@ -25,4 +25,4 @@ the passage from group representations to its modules are developed in
 
 \p{The brackets matter. Assume #{R} is nontrivial. Then
 #{[z_G]\neq-1_{R[G]}}: their supports differ when #{z_G\neq1_G}; when
-#{z_G=1_G}, this is #{1_{R[G]}\neq-1_{R[G]}}, since two is invertible.}
+#{z_G=1_G}, this is #{1_{R[G]}\neq-1_{R[G]}}, since 2 is invertible.}

--- a/trees/fgap-0011.tree
+++ b/trees/fgap-0011.tree
@@ -8,7 +8,7 @@
 \tag{group-algebra}
 \tag{idempotent}
 
-\p{Let #{C_2=\{1,s\}} with #{s^2=1}, and suppose two is invertible in the
+\p{Let #{C_2=\{1,s\}} with #{s^2=1}, and suppose 2 is invertible in the
 nonzero commutative ring #{R}. The basis element #{[s]} is central, and
 ##{
 e_+=\frac{[1]+[s]}2,\qquad

--- a/trees/fgap-0014.tree
+++ b/trees/fgap-0014.tree
@@ -19,8 +19,8 @@ that compares these two models. Voight identifies #{T} with the Hurwitz unit
 group and with #{Q_8\rtimes\mathbb{Z}/3\mathbb{Z}} in
 \citet{sec. 11.2.4, p. 168}{voight2021quaternion}.}
 
-\p{The quaternion #{-1} belongs to #{T}; it is central, its square is one,
-and it is not one. Define the \newvocab{distinguished central involution} of
+\p{The quaternion #{-1} belongs to #{T}; it is central, its square is 1,
+and it is not 1. Define the \newvocab{distinguished central involution} of
 #{B} by
 ##{
 z=\rho^{-1}(-1).
@@ -41,5 +41,5 @@ quaternion #{-1}; the isomorphism #{\rho} relates them.}
 The corresponding Lean target is
 \code{Nat.card BinaryTetrahedral.Abstract = 24}.}
 
-\p{The occurrence of #{-1} among the twenty-four Hurwitz units is explicit
+\p{The occurrence of #{-1} among the 24 Hurwitz units is explicit
 in \citet{sec. 11.2, p. 166}{voight2021quaternion}.}

--- a/trees/fgap-0018.tree
+++ b/trees/fgap-0018.tree
@@ -18,10 +18,10 @@ Its concrete realization by Hurwitz units, and their identification with
 \citet{sec. 11.2, pp. 166--168}{voight2021quaternion}, while the relation
 between representations and Group-Algebra modules is developed in
 \citet{secs. 3.1--3.3, pp. 39--42}{sengupta2010representations}. Wilson uses
-order-three automorphisms of #{Q_8} to discuss possible physical
+order-3 automorphisms of #{Q_8} to discuss possible physical
 interpretations in
 \citet{sec. 4.3, pp. 12--13, v5}{wilson2021finite}. He later adjoins an
-abstract generator #{f} of order three to #{Q_8} to form #{2T} in
+abstract generator #{f} of order 3 to #{Q_8} to form #{2T} in
 \citet{sec. 6.1, p. 18, v5}{wilson2021finite}.}
 
 \p{Any physical identification remains a hypothesis. A proposed

--- a/trees/fgap-001B.tree
+++ b/trees/fgap-001B.tree
@@ -83,14 +83,14 @@ a_q=\frac{s_q+d_q}{2},\qquad
 a_{-q}=\frac{s_q-d_q}{2},
 }
 so #{\Phi(x)} recovers all eight coefficients of #{x}. Hence #{\Phi} is
-injective. Its domain and codomain both have real dimension eight, so it is
+injective. Its domain and codomain both have real dimension 8, so it is
 bijective.}
 }
 
 \p{The quaternion coordinate alone is surjective, because its basis values
 include #{1,i,j,k}. It vanishes exactly when
 #{d_1=d_i=d_j=d_k=0}, or equivalently when #{a_q=a_{-q}} for
-#{q\in\{1,i,j,k\}}. Its kernel is therefore the four-dimensional span of
+#{q\in\{1,i,j,k\}}. Its kernel is therefore the 4-dimensional span of
 ##{
 u_1+u_{-1},\quad
 u_i+u_{-i},\quad

--- a/trees/fgap-001E.tree
+++ b/trees/fgap-001E.tree
@@ -70,7 +70,7 @@ the McKay graph.}
 
   \p{Under the standard matrix realization of the unit quaternions as
   #{\mathrm{SU}(2)}, the concrete group #{T} becomes a finite subgroup of
-  #{\mathrm{SU}(2)}. Let #{\tau_3} be its faithful two-dimensional complex
+  #{\mathrm{SU}(2)}. Let #{\tau_3} be its faithful 2-dimensional complex
   representation. The McKay graph has one vertex for each irreducible
   complex representation #{\tau_i}; the number of edges from #{\tau_i} to
   #{\tau_j} is the multiplicity of #{\tau_j} in


### PR DESCRIPTION
## Purpose

Mirror the narrowed numeral convention from utensil/fgap#19 in the FGAP Forest notes.

## Rule

Use digits only for intrinsic mathematical numeric data: formula values, orders, dimensions, cardinalities, and explicit indices or exponents. Keep words for lexical compounds, incidental enumeration, and logistical prose.

## Scope

28 numeral substitutions on 27 candidate lines across 18 `trees/fgap-*` files. The complete audit classified 97 candidate lines in 39 trees as 27 changed, 64 kept as words, and 6 excluded titles. The branch contains the initial sweep plus one focused reviewer correction for the previously missed half-integral-unit cardinality.

## Exclusions

Preserves titles, quotations, bibliographic text, code identifiers, citation locators, and tree addresses. No mathematical claims, citations, ordering, Q8 sector/kernel feedback, or issue #18 API/docstring concerns changed.

## Verification

- `git diff --check`: exit 0.
- `just chk`: exit 0.
- `TEXINPUTS=.:$PWD/tex/: just forest`: exit 0; only the 2 pre-existing `https://utensil.github.io/` broken-link warnings.
- `TEXINPUTS=.:$PWD/tex/: ./lize.sh fgap-0001`: exit 0; cumulative 30-page PDF generated and inspected by text extraction and rendered page 13.
- Remote readback: branch head `6c63c3de1fce885438b44c86f90a3832618c0e6f`; `origin/fgap` unchanged at `b3a460681ff6aa1fb3c75c35325fb69c883295c3`.

## Review focus

Check the 27 changed lines against the intrinsic-data boundary, especially formula prose, `N`-dimensional/`N`-point compounds, group orders, finite-set cardinalities, and the 16 half-integral Hurwitz units. Confirm that counts of routes, identities, coordinates, factors, and other ordinary enumeration remain words.