### PR TITLE
fix(bib): register Woit 2024 citation

### DIFF
--- a/tex/math-2024.bib
+++ b/tex/math-2024.bib
@@ -136,6 +136,14 @@
   publisher={Springer}
 }
 
+@misc{woit2024quantum,
+ title = {Quantum Theory, Groups and Representations: An Introduction},
+ author = {Woit, Peter},
+ year = {2024},
+ note = {Revised and expanded manuscript, January 9, 2024},
+ url = {https://www.math.columbia.edu/~woit/QMbook/}
+}
+
 @article{ewing2022zeon,
   title={Zeon and Idem-Clifford Formulations of Hypergraph Problems},
   author={Ewing, Samuel and Staples, G Stacey},


### PR DESCRIPTION
## Summary

- add the missing `woit2024quantum` BibTeX authority already cited by `fgap-0008`
- keep the existing Forest note and reference tree unchanged

## Scope

This is the separate upstream FGAP citation repair identified while validating the FCAP retirement change. It does not modify FCAP PR #73 or change any mathematical statement or source locator.

## Verification

- complete pdf-land citation validator: 22 citation keys and 22 PDF records against 346 Forest keys
- `just forest`: pass, with only the 2 pre-existing `https://utensil.github.io/` broken-link warnings
- added BibTeX metadata matches `trees/refs/woit2024quantum.tree` exactly
