### PR TITLE
docs(fcap): record transported exterior-basis anchors

### DIFF
--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -1,0 +1,16 @@
+\import{spin-macros}
+
+\title{Formalized Clifford Algebra Programme}
+\meta{pdf}{true}
+
+\tag{notes}
+\tag{math}
+\tag{fcap}
+\tag{clifford}
+
+\author{utensil}
+\date{2026-08-02}
+
+\p{These notes collect the mathematical work paired with FCAP.}
+
+\transclude{fcap-0002}

--- a/trees/fcap-0002.tree
+++ b/trees/fcap-0002.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{clifford}
+\tag{notes}
+\tag{draft}
+
+\title{Coordinate representations}
+
+\p{A coordinate representation begins by choosing data that the abstract construction leaves open. For Clifford algebra, a basis of the generating module gives one route through the exterior algebra. The first two coordinate anchors of that route give later product and encoding work a named starting point rather than an implicit choice.}
+
+\transclude{fcap-0003}

--- a/trees/fcap-0003.tree
+++ b/trees/fcap-0003.tree
@@ -1,0 +1,24 @@
+\import{spin-macros}
+\tag{fcap}
+\tag{clifford}
+\tag{draft}
+
+\refnote{Transported exterior-basis coordinates}{wieser2024formalizing}{
+\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and choose a basis #{b} indexed by a linearly ordered type. Write #{E_b(s)} for the exterior-basis vector indexed by a finite subset #{s}. For a quadratic form #{Q}, the linear equivalence #{\Cl(Q) \simeq \ExteriorAlgebra R M} gives a coordinate basis
+
+##{B_{Q,b}(s) = \operatorname{equivExterior}(Q)^{-1}(E_b(s)).}
+
+This basis is a choice transported through a linear equivalence. It does not say that the equivalence preserves multiplication or that Clifford multiplication becomes exterior multiplication. The basis-free formalization gives the surrounding context \citek{wieser2022formalizing}; the exterior-equivalence construction used here is treated in \citet{9.3.5}{wieser2024formalizing}. This note fixes the particular coordinate data needed for the next executable boundary.}
+
+\p{Two calculations anchor the choice. The empty subset maps to the scalar unit,
+
+##{B_{Q,b}(\varnothing) = 1,}
+
+and a singleton maps to the corresponding Clifford generator,
+
+##{B_{Q,b}(\{i\}) = \iota_Q(b(i)).}
+
+The paired Lean module names the basis \lean{CliffordAlgebra.transportedExteriorBasis} and proves these two equalities using \lean{CliffordAlgebra.equivExterior}. The claims are deliberately module-level: they say how the selected coordinates begin, not how arbitrary coordinates multiply.}
+
+\p{What remains is equally important. This note does not prove a formula for multi-element subsets, an algebra equivalence, an ordering or sign convention for blades, or an encoding into machine slots. Each requires its own representation and proof obligation before a symbolic or numerical implementation may rely on it.}
+}


### PR DESCRIPTION
## Scope

- create a separate FCAP note tree for the coordinate-representation thread
- record the empty and singleton anchors of the transported exterior basis
- identify the paired Lean interface

## Boundary

This is a module-basis transport through a linear equivalence. It does not claim multiplicative preservation, blade-product rules, sign conventions, machine encodings, or executable behavior.

## Stack

This PR is based on `fcap`.

## Verification

- `git diff --check`
- no-theme Forester build