### PR TITLE
docs(fcap): record orthogonal pair transport

### DIFF
--- a/trees/fcap-0002.tree
+++ b/trees/fcap-0002.tree
@@ -10,3 +10,5 @@
 \p{A coordinate representation begins by choosing data that the abstract construction leaves open. For Clifford algebra, a basis of the generating module gives one route through the exterior algebra. The first two coordinate anchors of that route give later product and encoding work a named starting point rather than an implicit choice.}
 
 \transclude{fcap-0003}
+
+\transclude{fcap-0004}

--- a/trees/fcap-0004.tree
+++ b/trees/fcap-0004.tree
@@ -1,0 +1,19 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{clifford}
+\tag{draft}
+
+\refnote{Orthogonal pair transport}{wieser2024formalizing}{
+\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. Write #{T_Q} for the linear equivalence from #{\Cl(Q)} to the exterior algebra supplied by #{\operatorname{equivExterior}(Q)}. It is a module equivalence, not an algebra equivalence.}
+
+\p{For vectors #{m,n \in M}, the change-of-form calculation for #{T_Q(\iota_Q(m)\iota_Q(n))} has one extra scalar contribution, evaluated by the bilinear form associated to #{-Q}. If #{m} and #{n} are #{Q}-orthogonal, that contribution vanishes. The resulting two-generator calculation is
+
+##{T_Q\bigl(\iota_Q(m)\iota_Q(n)\bigr)=\iota_0(m)\iota_0(n).}
+
+This is the first point at which an orthogonality hypothesis changes the transport calculation. It does not turn #{T_Q} into a multiplicative map.}
+
+\p{The change-of-form construction is the relevant mathematical background in \citet{8.4}{wieser2024formalizing}, and the Lean construction of #{\operatorname{equivExterior}} is described in \citet{9.3.5}{wieser2024formalizing}. The concrete geometric-product discussion in \citet{2.1.2}{wieser2024formalizing} motivates the role of orthogonality, but does not provide this note's formal interface.}
+
+\p{The paired Lean theorem is \lean{CliffordAlgebra.equivExterior_ι_mul_ι_of_isOrtho}. Its proof unfolds the two-generator change-of-form theorem and applies the exact orthogonality equality for the associated form. No basis choice, finite ordered product, blade-product formula, sign convention, or executable encoding is used here. Those boundaries remain separate work.}
+}


### PR DESCRIPTION
## Scope

- add a separate FCAP note for the two-generator orthogonal transport calculation
- state the scalar-correction boundary of the exterior equivalence
- name the paired Lean theorem

## Boundary

This note treats a linear module equivalence. It makes no multiplicative-equivalence, basis, ordered-product, blade, sign, encoding, or executable claim.

## Verification

- `git diff --check`
- no-theme Forester build