### PR TITLE
docs(fcap): record vanishing list contraction

### DIFF
--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -14,3 +14,5 @@
 \p{These notes collect the mathematical work paired with FCAP.}
 
 \transclude{fcap-0002}
+
+\transclude{fcap-0005}

--- a/trees/fcap-0005.tree
+++ b/trees/fcap-0005.tree
@@ -1,0 +1,23 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{clifford}
+\tag{draft}
+
+\note{Vanishing list contraction}{
+\p{Let #{R} be a commutative ring, #{M} an #{R}-module, #{Q} a quadratic form on #{M}, and #{d : M \to R} a linear functional. For a list #{l} of generators, define an ordered product by
+
+##{P_Q([])=1, \qquad P_Q(m::l)=\iota_Q(m)P_Q(l),}
+
+and write #{C_{Q,d}} for left contraction by #{d}. The condition #{\forall m\in l,\ d(m)=0} forces #{C_{Q,d}(P_Q(l))=0}.}
+
+\p{There is one induction calculation. The empty product contracts to zero. At a head #{m}, the generator recurrence
+
+##{C_{Q,d}(P_Q(m::l))=d(m)P_Q(l)-\iota_Q(m)C_{Q,d}(P_Q(l))}
+
+is the local rule in \citet{8.4, (8.54)}{wieser2024formalizing}. The hypothesis deletes the first summand, and the induction hypothesis deletes the second. This turns the recurrence into a finite-list vanishing criterion rather than a calculation for one fixed product.}
+
+\p{The paired Lean declaration is \lean{CliffordAlgebra.contractLeft_list_prod_ι_of_forall_eq_zero}; it states this criterion for \lean{List.map} and \lean{List.prod}. This note isolates its proof interface from later transport.}
+
+\p{The scope stops before ordered transport, change of form, bases, finite subsets, signs, coordinates, masks, PGA, and execution.}
+}


### PR DESCRIPTION
## Scope

- add a compact note for vanishing left contraction on an ordered generator product
- connect the note from the FCAP root

## Boundary

The note isolates the contraction criterion required by later order-preserving transport. It makes no transport, basis, sign, encoding, or executable claim.

## Verification

- `just build`