### PR TITLE
docs(fcap): record pairwise orthogonal list transport

### DIFF
--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -16,3 +16,5 @@
 \transclude{fcap-0002}
 
 \transclude{fcap-0005}
+
+\transclude{fcap-0006}

--- a/trees/fcap-0006.tree
+++ b/trees/fcap-0006.tree
@@ -1,0 +1,23 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{clifford}
+\tag{draft}
+
+\refnote{Pairwise orthogonal list transport}{wieser2024formalizing}{
+\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. For a list #{l} of vectors, write
+
+##{P_Q([])=1, \qquad P_Q(m::l)=\iota_Q(m)P_Q(l),}
+
+and write #{T_Q} for the linear equivalence #{\operatorname{equivExterior}(Q)} from #{\Cl(Q)} to #{\ExteriorAlgebra R M}. In the corresponding zero-form product notation, suppose every earlier vector in #{l} is #{Q}-orthogonal to every later vector. Then
+
+##{T_Q(P_Q(l))=P_0(l).}
+
+The order of the list is unchanged. The equality concerns this product under the stated orthogonality condition; it does not say that #{T_Q} preserves arbitrary products.}
+
+\p{The calculation proceeds from the head of the list. The one-generator change-of-form recurrence separates #{T_Q(P_Q(m::l))} into the zero-form generator #{\iota_0(m)} times the transported tail and a left-contraction correction. Pairwise orthogonality makes the associated dual vector vanish on every member of the tail. The criterion in \ref{fcap-0005} therefore kills the correction, and the induction hypothesis transports the tail.}
+
+\p{The contraction recurrence in \citet{8.4, (8.54)}{wieser2024formalizing}, the change-of-form recurrence in \citet{8.4, (8.55)}{wieser2024formalizing}, and the exterior-equivalence interface in \citet{9.3.5}{wieser2024formalizing} supply the ingredients. The pairwise-list induction is the FCAP formalization bridge; none of those source locations states this list theorem.}
+
+\p{The paired Lean declaration is \lean{CliffordAlgebra.equivExterior_list_prod_ι_of_pairwise_isOrtho}. It uses only Mathlib interfaces and the preceding vanishing-contraction theorem. The scope stops before reordering, finite subsets, ordered blades, coordinate signs, masks, PGA conventions, and executable representations.}
+}


### PR DESCRIPTION
## Summary

Add the Forest companion note for FCAP's pairwise-orthogonal ordered-list transport theorem and transclude it from the FCAP index.

## Pairing

The note pairs with [`CliffordAlgebra.equivExterior_list_prod_ι_of_pairwise_isOrtho`](https://github.com/utensil/fcap/pull/5). It records that `equivExterior` carries a pairwise-orthogonal generator product to the corresponding zero-form product without changing the list order.

## Grounding and contribution

Wieser's thesis supplies the contraction recurrence in §8.4 (8.54), the change-of-form recurrence in §8.4 (8.55), and the `equivExterior` context in §9.3.5. The finite pairwise-list induction is the FCAP bridge. The note keeps those source roles separate and does not suggest that `equivExterior` preserves arbitrary products.

## Scope

This adds one compact note and one index transclusion. It stops before reordering, finite subsets, ordered blades, coordinate signs, masks, PGA conventions, and executable representations.

## Verification

`opam exec -- forester build --no-theme` passes. The full `just build` reaches the Forester phase but fails on the checkout's absent `theme` directory after the optional WASM asset steps also report baseline setup failures; those failures are independent of this two-file diff.

Independent review passed at exact commit `1a8c6fc8c1fc8dd73a76e5cc33c557ee80bb3d33` with no findings.

## Stack

Base: `fcap` at `a48a6b26`. This note stays on the same single FCAP project front as the paired Lean pull request.
