### PR TITLE
fix(render): preserve Lean markers in rendered notes

### DIFF
--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -95,6 +95,12 @@
     <xsl:if test="f:frontmatter/f:title">
       <xsl:text>[{</xsl:text>
       <xsl:apply-templates select="f:frontmatter/f:title" />
+      <xsl:if test="f:frontmatter/f:meta[@name='lean']">
+        <xsl:text>\enspace{}</xsl:text>
+        <xsl:call-template name="lean-markers">
+          <xsl:with-param name="markers" select="f:frontmatter/f:meta[@name='lean']" />
+        </xsl:call-template>
+      </xsl:if>
       <xsl:text>}]</xsl:text>
     </xsl:if>
     <xsl:if test="f:frontmatter/f:display-uri[not(contains(text(), '#'))]">
@@ -106,6 +112,22 @@
     <xsl:text>\end{</xsl:text>
     <xsl:apply-templates select="f:frontmatter/f:taxon" />
     <xsl:text>}</xsl:text>
+  </xsl:template>
+
+  <xsl:template name="lean-markers">
+    <xsl:param name="markers" />
+    <xsl:variable name="marker" select="normalize-space(substring-before(concat($markers, ','), ','))" />
+    <xsl:text>\protect\href{https://leanprover-community.github.io/mathlib4_docs/find/\#doc/</xsl:text>
+    <xsl:value-of select="$marker" />
+    <xsl:text>}{\protect\leanmarker{\detokenize{</xsl:text>
+    <xsl:value-of select="$marker" />
+    <xsl:text>}}}</xsl:text>
+    <xsl:if test="contains($markers, ',')">
+      <xsl:text>\allowbreak\hspace{0.35em}</xsl:text>
+      <xsl:call-template name="lean-markers">
+        <xsl:with-param name="markers" select="substring-after($markers, ',')" />
+      </xsl:call-template>
+    </xsl:if>
   </xsl:template>
   <!-- use mdframed end -->
 

--- a/tex/code.tex
+++ b/tex/code.tex
@@ -1,4 +1,24 @@
 \usepackage{listings}
+\usepackage{fontspec}
+\newfontfamily\codefont{Noto Sans Mono}[Scale=MatchLowercase]
+
+\definecolor{leanmarkerborder}{HTML}{7A7A72}
+\definecolor{leanmarkerbackground}{HTML}{F7F7F4}
+\DeclareRobustCommand{\leanmarker}[1]{%
+  \tikz[baseline=(leanmarker.base)]{%
+    \node[
+      draw=leanmarkerborder,
+      text=leanmarkerborder,
+      fill=leanmarkerbackground,
+      rounded corners=1.5pt,
+      inner xsep=3.25pt,
+      inner ysep=1.5pt,
+      text height=1.45ex,
+      text depth=0.35ex,
+      font=\normalfont\codefont\footnotesize
+    ] (leanmarker) {#1};%
+  }%
+}
 
 % handle Lean code highlighting following https://lean-lang.org/lean4/doc/syntax_highlight_in_latex.html
 \definecolor{keywordcolor}{rgb}{0.7, 0.1, 0.1}   % red


### PR DESCRIPTION
## Summary

- Keep each `\lean{...}` payload as Lean metadata for the existing web header links and marker.
- Render each comma-separated declaration as its own padded inline badge in PDF theorem headings.
- Make every PDF badge link directly to the matching Mathlib documentation.
- Use a Unicode-safe monospace font and fixed text metrics for consistent padding and natural baseline alignment.

## General impact

This repairs PDF rendering for all 27 existing Forest notes that use the Lean marker. It is a general rendering change on top of `main`; it contains no FCAP or FGAP note content.

The web behavior is unchanged. The PDF now mirrors it: Lean metadata appears with the theorem heading in a compact, bordered marker style instead of as an unstyled standalone body line.

## Scope

The change is limited to the shared LaTeX renderer and its PDF marker command. Note content, the `\lean` macro, generic inline code rendering, and HTML rendering are unchanged.

## Verification

- `just chk`
- `just build`
- fresh Forester rebuild after touching all 27 Lean-marked sources
- all 35 declaration names reachable from `ca-0001` emitted as inline PDF badges
- all 35 badges expose their exact `#doc/<declaration>` Mathlib URL as a PDF annotation
- 18-page `ca-0001` PDF build, exact text extraction, embedded-font audit, and full-document visual inspection
- focused visual checks for single markers, multiple markers, Unicode identifiers, padding, and vertical alignment

The full build exits successfully. Its existing optional WASM setup continues to report skipped or unavailable local bundles before the successful Forester and asset phases.
