### PR TITLE
FCAP: add Spin reflection formalization appendix

### DIFF
--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -18,3 +18,5 @@
 \transclude{fcap-0005}
 
 \transclude{fcap-0006}
+
+\transclude{fcap-0007}

--- a/trees/fcap-0007.tree
+++ b/trees/fcap-0007.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{clifford}
+\tag{spin}
+\tag{notes}
+\tag{draft}
+
+\title{Appendix: Spin representation formalizations}
+\meta{pdf}{true}
+
+\transclude{fcap-0008}

--- a/trees/fcap-0008.tree
+++ b/trees/fcap-0008.tree
@@ -1,0 +1,16 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{clifford}
+\tag{spin}
+\tag{draft}
+
+\refnote{Reflection lifts and one Cartan--Dieudonné step}{lawson2016spin}{
+\p{Let #{q} be a nondegenerate quadratic form on a finite-dimensional vector space over a field of characteristic different from #{2}. If #{q(v) \ne 0}, twisted conjugation by #{v} is reflection in #{v^\perp}. This is Proposition 2.2 and equation (2.8); see \citet{I.2}{lawson2016spin}. Theorem 2.7 states that every orthogonal transformation is a product of at most #{\dim V} such reflections.}
+
+\p{The formalization first isolates the lift of one reflection. If #{q(v)} is invertible and #{-q(v)^{-1}} is a square, rescaling #{v} gives a Pin element acting by reflection in #{v}. If #{q(v)^{-1}q(w)^{-1}} is a square, the product of the two reflections lifts through the Spin action. Both conditions are automatic over a separably closed field. These local statements need neither finite dimensionality nor global nondegeneracy.}
+
+\p{The next lemma supplies one step of the Cartan--Dieudonné induction. For an orthogonal map #{g} and a vector #{v} of invertible norm, at least one of #{gv-v} and #{gv+v} has invertible norm. Reflection in the first sends #{gv} to #{v}; in the second case, reflections in #{gv+v} and #{v} do so. The resulting correction lies in the range of the Pin action.}
+
+\p{[TauCeti PR 2404](https://github.com/TauCetiProject/TauCeti/pull/2404) formalizes the single-reflection lift, its two-reflection Spin analogue, and the separably closed variants. [TauCeti PR 2410](https://github.com/TauCetiProject/TauCeti/pull/2410) formalizes the one-vector reduction. The exact declaration names are listed in the PRs. This is not the completed finite-dimensional induction. It does not include full surjectivity or the kernel calculation needed for the short exact sequences.}
+}


### PR DESCRIPTION
## Summary

- add an appendix for Spin representation results that FCAP may use later
- ground the reflection and Cartan–Dieudonné statements in Lawson–Michelsohn
- record the exact boundary reached by TauCeti PRs 2404 and 2410, without claiming full surjectivity or the kernel calculation

## Verification

- `just forest`
- `just chk`
- standalone `fcap-0007` PDF text, links, and layout inspected
- mathematical claims checked against the cited source and the merged TauCeti declarations