### PR TITLE
feat(render): support TauCeti Lean annotations

### DIFF
--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -96,10 +96,22 @@
       <xsl:text>[{</xsl:text>
       <xsl:apply-templates select="f:frontmatter/f:title" />
       <xsl:if test="f:frontmatter/f:meta[@name='lean']">
-        <xsl:text>\enspace{}</xsl:text>
+        <xsl:text>\allowbreak\hspace{0.35em}</xsl:text>
         <xsl:call-template name="lean-markers">
           <xsl:with-param name="markers" select="f:frontmatter/f:meta[@name='lean']" />
+          <xsl:with-param name="base" select="'https://leanprover-community.github.io/mathlib4_docs/find/\#doc/'" />
         </xsl:call-template>
+      </xsl:if>
+      <xsl:if test="f:frontmatter/f:meta[@name='lean-tauceti']">
+        <xsl:text>\allowbreak\hspace{0.35em}</xsl:text>
+        <xsl:call-template name="lean-markers">
+          <xsl:with-param name="markers" select="f:frontmatter/f:meta[@name='lean-tauceti']" />
+          <xsl:with-param name="base" select="'https://taucetiproject.github.io/TauCeti/docs/find/\#doc/'" />
+          <xsl:with-param name="short" select="true()" />
+        </xsl:call-template>
+      </xsl:if>
+      <xsl:if test="f:frontmatter/f:meta[@name='lean' or @name='lean-tauceti']">
+        <xsl:text>\hspace{0.35em}</xsl:text>
       </xsl:if>
       <xsl:text>}]</xsl:text>
     </xsl:if>
@@ -116,18 +128,49 @@
 
   <xsl:template name="lean-markers">
     <xsl:param name="markers" />
+    <xsl:param name="base" />
+    <xsl:param name="short" select="false()" />
     <xsl:variable name="marker" select="normalize-space(substring-before(concat($markers, ','), ','))" />
-    <xsl:text>\protect\href{https://leanprover-community.github.io/mathlib4_docs/find/\#doc/</xsl:text>
+    <xsl:variable name="display">
+      <xsl:choose>
+        <xsl:when test="$short">
+          <xsl:call-template name="lean-short-name">
+            <xsl:with-param name="name" select="$marker" />
+          </xsl:call-template>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="$marker" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+    <xsl:text>\protect\href{</xsl:text>
+    <xsl:value-of select="$base" />
     <xsl:value-of select="$marker" />
     <xsl:text>}{\protect\leanmarker{\detokenize{</xsl:text>
-    <xsl:value-of select="$marker" />
+    <xsl:value-of select="$display" />
     <xsl:text>}}}</xsl:text>
     <xsl:if test="contains($markers, ',')">
       <xsl:text>\allowbreak\hspace{0.35em}</xsl:text>
       <xsl:call-template name="lean-markers">
         <xsl:with-param name="markers" select="substring-after($markers, ',')" />
+        <xsl:with-param name="base" select="$base" />
+        <xsl:with-param name="short" select="$short" />
       </xsl:call-template>
     </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="lean-short-name">
+    <xsl:param name="name" />
+    <xsl:choose>
+      <xsl:when test="contains($name, '.')">
+        <xsl:call-template name="lean-short-name">
+          <xsl:with-param name="name" select="substring-after($name, '.')" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$name" />
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <!-- use mdframed end -->
 

--- a/assets/uts-overrides.xsl
+++ b/assets/uts-overrides.xsl
@@ -33,20 +33,48 @@
     <xsl:template name="splitlean">
         <xsl:param name="pText" select="." />
         <xsl:param name="sep" select="." />
+        <xsl:param name="base" />
+        <xsl:param name="short" select="false()" />
         <xsl:if test="string-length($pText)">
+            <xsl:variable name="marker" select="normalize-space(substring-before(concat($pText,$sep),$sep))" />
             <xsl:if test="not($pText=.)">
                 <!-- <xsl:text>,</xsl:text> -->
             </xsl:if>
             <a target="_blank"
-                href="https://leanprover-community.github.io/mathlib4_docs/find/#doc/{substring-before(concat($pText,$sep),$sep)}">
+                href="{$base}{$marker}">
                 <!-- <xsl:text>L∃∀N</xsl:text> -->
-                <xsl:value-of select="substring-before(concat($pText,$sep),$sep)" />
+                <xsl:choose>
+                    <xsl:when test="$short">
+                        <xsl:call-template name="lean-short-name">
+                            <xsl:with-param name="name" select="$marker" />
+                        </xsl:call-template>
+                    </xsl:when>
+                    <xsl:otherwise>
+                        <xsl:value-of select="$marker" />
+                    </xsl:otherwise>
+                </xsl:choose>
             </a>
             <xsl:call-template name="splitlean">
                 <xsl:with-param name="pText" select="substring-after($pText, $sep)" />
                 <xsl:with-param name="sep" select="$sep" />
+                <xsl:with-param name="base" select="$base" />
+                <xsl:with-param name="short" select="$short" />
             </xsl:call-template>
         </xsl:if>
+    </xsl:template>
+
+    <xsl:template name="lean-short-name">
+        <xsl:param name="name" />
+        <xsl:choose>
+            <xsl:when test="contains($name, '.')">
+                <xsl:call-template name="lean-short-name">
+                    <xsl:with-param name="name" select="substring-after($name, '.')" />
+                </xsl:call-template>
+            </xsl:when>
+            <xsl:otherwise>
+                <xsl:value-of select="$name" />
+            </xsl:otherwise>
+        </xsl:choose>
     </xsl:template>
 
     <xsl:template match="fr:meta[@name='lean']">
@@ -55,9 +83,24 @@
                 <xsl:call-template name="splitlean">
                     <xsl:with-param name="pText" select="." />
                     <xsl:with-param name="sep" select="','" />
+                    <xsl:with-param name="base" select="'https://leanprover-community.github.io/mathlib4_docs/find/#doc/'" />
                 </xsl:call-template>
             </div>
             <!-- <span class="meta-lean-symbol">✓</span> -->
+            <span class="meta-lean-symbol">L∃∀N</span>
+        </span>
+    </xsl:template>
+
+    <xsl:template match="fr:meta[@name='lean-tauceti']">
+        <span class="meta-lean">
+            <div class="meta-lean-list">
+                <xsl:call-template name="splitlean">
+                    <xsl:with-param name="pText" select="." />
+                    <xsl:with-param name="sep" select="','" />
+                    <xsl:with-param name="base" select="'https://taucetiproject.github.io/TauCeti/docs/find/#doc/'" />
+                    <xsl:with-param name="short" select="true()" />
+                </xsl:call-template>
+            </div>
             <span class="meta-lean-symbol">L∃∀N</span>
         </span>
     </xsl:template>
@@ -108,8 +151,8 @@
                 <a target="_blank" title="PDF" class="link-button link-pdf" href="{/fr:tree/@base-url}{../fr:display-uri}.pdf">
                     📄<span>PDF</span></a>
             </xsl:if>
-            <xsl:if test="../fr:meta[@name='lean']">
-                <xsl:apply-templates select="../fr:meta[@name='lean']" />
+            <xsl:if test="../fr:meta[@name='lean' or @name='lean-tauceti']">
+                <xsl:apply-templates select="../fr:meta[@name='lean' or @name='lean-tauceti']" />
             </xsl:if>
             <xsl:if test="../fr:display-uri=/fr:tree/fr:frontmatter/fr:display-uri and ../fr:meta[@name='multilang']">
                 <a id="langblock-toggle" class="link-button" href="javascript:void(0)"

--- a/tex/mdframed.tex
+++ b/tex/mdframed.tex
@@ -6,6 +6,11 @@
 \usepackage{thmtools}
 \usepackage[framemethod=TikZ]{mdframed}
 
+% Keep theorem headings ragged and breakable between atomic inline markers.
+\newcommand{\foresttheoremhead}{%
+	\parbox[t]{\linewidth}{\raggedright\NAME\ \NUMBER\ \NOTE}%
+}
+
 \theoremstyle{definition}
 \mdfdefinestyle{mdbluebox}{%
 	% same
@@ -40,6 +45,7 @@
 \declaretheoremstyle[%
 	% same
 	headpunct={\\[3pt]},
+	headformat={\foresttheoremhead},
 	% customizations
 	headfont=\sffamily\bfseries\color{MidnightBlue!70!black},
 	mdframed={style=mdbluebox}
@@ -76,6 +82,7 @@
 \declaretheoremstyle[
 	% same
 	headpunct={\\[3pt]},
+	headformat={\foresttheoremhead},
 	% customizations
 	postheadspace={0pt},
 	headfont=\bfseries\color{RawSienna},
@@ -115,6 +122,7 @@
 \declaretheoremstyle[
 	% same
 	headpunct={\\[3pt]},
+	headformat={\foresttheoremhead},
 	% customizations
 	headfont=\bfseries\sffamily\color{ForestGreen!70!black},
 	bodyfont=\normalfont,
@@ -124,6 +132,7 @@
 \declaretheoremstyle[
 	% same
 	headpunct={\\[3pt]},
+	headformat={\foresttheoremhead},
 	% customizations
 	headfont=\bfseries\sffamily\color{ForestGreen!70!black},
 	bodyfont=\normalfont,
@@ -142,6 +151,7 @@
 }
 \declaretheoremstyle[
 	headfont=\bfseries\sffamily,
+	headformat={\foresttheoremhead},
 	bodyfont=\normalfont\small,
 	spaceabove=0pt,
 	spacebelow=0pt,
@@ -150,6 +160,7 @@
 
 \declaretheoremstyle[
 	headfont=\bfseries\sffamily,
+	headformat={\foresttheoremhead},
 	bodyfont=\normalfont, %\small, %\sffamily,
 	spaceabove=12pt,
 	spacebelow=1pt,

--- a/trees/spin-macros.tree
+++ b/trees/spin-macros.tree
@@ -45,8 +45,11 @@
 
 \def\label[x]{}
 \def\leanok{}
+% AGENT-NOTE: Keep provider meta names aligned with the web and PDF XSL templates.
 % https://leanprover-community.github.io/mathlib4_docs/find/#doc/
 \def\lean[x]{\meta{lean}{\x}}
+% https://taucetiproject.github.io/TauCeti/docs/find/#doc/
+\def\lean/tauceti[x]{\meta{lean-tauceti}{\x}}
 \def\uses[x]{}
 
 \def\cite[x]{\citek{\x}}


### PR DESCRIPTION
## Summary

- add `\lean/tauceti{...}` while keeping plain `\lean{...}` as the Mathlib default
- resolve fully qualified TauCeti declarations through the TauCeti documentation finder in web and PDF output
- show compact declaration labels for TauCeti without shortening link targets
- keep each PDF badge atomic while naturally wrapping badge runs only between markers
- normalize comma-separated marker whitespace for both providers

## Verification

- `xmllint --noout assets/latex.xsl assets/uts-overrides.xsl`
- `just pre-push`
- full `just build`
- `opam exec -- forester build --no-theme`
- mixed Mathlib/TauCeti web transform checked for exact declaration URLs
- three-pass LuaLaTeX theorem and definition probes checked visually, with no overfull or underfull box warnings
- `pdfinfo -url` confirms all nine Mathlib and TauCeti declaration annotations in the rendered probe
- GitHub PR lint