### PR TITLE
fix(render): prevent citation overflow in theorem headings

### DIFF
--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -261,6 +261,10 @@
         <xsl:text>}</xsl:text>
       </xsl:when>
       <xsl:when test="/f:tree/f:backmatter//f:tree/f:frontmatter[f:taxon/text()='Reference' and f:display-uri/text()=current()/@display-uri]">
+        <!-- AGENT-NOTE: Named theorem-title citations need a continuation line before the hyperlink box. -->
+        <xsl:if test="ancestor::f:title and ancestor::f:tree[parent::f:mainmatter]/f:frontmatter/f:taxon and ../preceding-sibling::node()[normalize-space()]">
+          <xsl:text>\protect\newline</xsl:text>
+        </xsl:if>
         <xsl:text>{\sloppy\cite</xsl:text>
         <xsl:if test="../@tid">
           <xsl:text>[</xsl:text>


### PR DESCRIPTION
## Summary

- place citations in named nested theorem-style headings on a dedicated continuation line
- prevent the unbreakable citation hyperlink box from extending beyond the theorem frame
- leave standalone card titles and unnamed citation-only headings unchanged

## Verification

- reproduced citation-heading overflows of 85.18pt and 48.83pt with long Lawson–Michelsohn locators
- regenerated the same four-card PDF with no citation-heading overfull boxes
- visually checked definition and theorem heading layouts
- asserted four nested named headings receive the continuation line while standalone named and unnamed card titles receive none
- `xmllint --noout assets/latex.xsl`
- `opam exec -- forester build --no-theme`
- `just pre-push`

One unrelated pre-existing 19pt body-prose overfull warning remains in the fixture and is outside this PR.