### PR TITLE
docs(fcap): make formalized results taxonomic cards

### DIFF
--- a/trees/fcap-0003.tree
+++ b/trees/fcap-0003.tree
@@ -3,8 +3,12 @@
 \tag{clifford}
 \tag{draft}
 
-\refnote{Transported exterior-basis coordinates}{wieser2024formalizing}{
-\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and choose a basis #{b} indexed by a linearly ordered type. Write #{E_b(s)} for the exterior-basis vector indexed by a finite subset #{s}. For a quadratic form #{Q}, the linear equivalence #{\Cl(Q) \simeq \ExteriorAlgebra R M} gives a coordinate basis
+\taxon{Definition}
+\title{Transported exterior-basis coordinates \citet{9.3.5}{wieser2024formalizing}}
+\lean{CliffordAlgebra.transportedExteriorBasis}
+\lean{CliffordAlgebra.equivExterior}
+
+\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and choose a basis #{b} indexed by a linearly ordered type. Write #{E_b(s)} for the exterior-basis vector indexed by a finite subset #{s}. For a quadratic form #{Q}, the linear equivalence #{\Cl(Q) \simeq \bigwedge_R M} gives a coordinate basis
 
 ##{B_{Q,b}(s) = \operatorname{equivExterior}(Q)^{-1}(E_b(s)).}
 
@@ -18,7 +22,6 @@ and a singleton maps to the corresponding Clifford generator,
 
 ##{B_{Q,b}(\{i\}) = \iota_Q(b(i)).}
 
-The paired Lean module names the basis \lean{CliffordAlgebra.transportedExteriorBasis} and proves these two equalities using \lean{CliffordAlgebra.equivExterior}. The claims are deliberately module-level: they say how the selected coordinates begin, not how arbitrary coordinates multiply.}
+The paired declarations name the basis and the exterior equivalence used to prove these two equalities. The claims are deliberately module-level: they say how the selected coordinates begin, not how arbitrary coordinates multiply.}
 
 \p{What remains is equally important. This note does not prove a formula for multi-element subsets, an algebra equivalence, an ordering or sign convention for blades, or an encoding into machine slots. Each requires its own representation and proof obligation before a symbolic or numerical implementation may rely on it.}
-}

--- a/trees/fcap-0004.tree
+++ b/trees/fcap-0004.tree
@@ -4,7 +4,10 @@
 \tag{clifford}
 \tag{draft}
 
-\refnote{Orthogonal pair transport}{wieser2024formalizing}{
+\taxon{Lemma}
+\title{Orthogonal pair transport \citet{8.4}{wieser2024formalizing}}
+\lean{CliffordAlgebra.equivExterior_ι_mul_ι_of_isOrtho}
+
 \p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. Write #{T_Q} for the linear equivalence from #{\Cl(Q)} to the exterior algebra supplied by #{\operatorname{equivExterior}(Q)}. It is a module equivalence, not an algebra equivalence.}
 
 \p{For vectors #{m,n \in M}, the change-of-form calculation for #{T_Q(\iota_Q(m)\iota_Q(n))} has one extra scalar contribution, evaluated by the bilinear form associated to #{-Q}. If #{m} and #{n} are #{Q}-orthogonal, that contribution vanishes. The resulting two-generator calculation is
@@ -15,5 +18,4 @@ This is the first point at which an orthogonality hypothesis changes the transpo
 
 \p{The change-of-form construction is the relevant mathematical background in \citet{8.4}{wieser2024formalizing}, and the Lean construction of #{\operatorname{equivExterior}} is described in \citet{9.3.5}{wieser2024formalizing}. The concrete geometric-product discussion in \citet{2.1.2}{wieser2024formalizing} motivates the role of orthogonality, but does not provide this note's formal interface.}
 
-\p{The paired Lean theorem is \lean{CliffordAlgebra.equivExterior_ι_mul_ι_of_isOrtho}. Its proof unfolds the two-generator change-of-form theorem and applies the exact orthogonality equality for the associated form. No basis choice, finite ordered product, blade-product formula, sign convention, or executable encoding is used here. Those boundaries remain separate work.}
-}
+\p{The paired theorem unfolds the two-generator change-of-form identity and applies the exact orthogonality equality for the associated form. No basis choice, finite ordered product, blade-product formula, sign convention, or executable encoding is used here. Those boundaries remain separate work.}

--- a/trees/fcap-0005.tree
+++ b/trees/fcap-0005.tree
@@ -4,7 +4,12 @@
 \tag{clifford}
 \tag{draft}
 
-\note{Vanishing list contraction}{
+\taxon{Lemma}
+\title{Vanishing list contraction \citet{8.4, (8.54)}{wieser2024formalizing}}
+\lean{CliffordAlgebra.contractLeft_list_prod_ι_of_forall_eq_zero}
+\lean{List.map}
+\lean{List.prod}
+
 \p{Let #{R} be a commutative ring, #{M} an #{R}-module, #{Q} a quadratic form on #{M}, and #{d : M \to R} a linear functional. For a list #{l} of generators, define an ordered product by
 
 ##{P_Q([])=1, \qquad P_Q(m::l)=\iota_Q(m)P_Q(l),}
@@ -17,7 +22,6 @@ and write #{C_{Q,d}} for left contraction by #{d}. The condition #{\forall m\in 
 
 is the local rule in \citet{8.4, (8.54)}{wieser2024formalizing}. The hypothesis deletes the first summand, and the induction hypothesis deletes the second. This turns the recurrence into a finite-list vanishing criterion rather than a calculation for one fixed product.}
 
-\p{The paired Lean declaration is \lean{CliffordAlgebra.contractLeft_list_prod_ι_of_forall_eq_zero}; it states this criterion for \lean{List.map} and \lean{List.prod}. This note isolates its proof interface from later transport.}
+\p{The paired declaration states this criterion for mapped lists and their ordered products. This card isolates its proof interface from later transport.}
 
 \p{The scope stops before ordered transport, change of form, bases, finite subsets, signs, coordinates, masks, PGA, and execution.}
-}

--- a/trees/fcap-0006.tree
+++ b/trees/fcap-0006.tree
@@ -4,12 +4,15 @@
 \tag{clifford}
 \tag{draft}
 
-\refnote{Pairwise orthogonal list transport}{wieser2024formalizing}{
+\taxon{Theorem}
+\title{Pairwise orthogonal list transport \citet{8.4, (8.55)}{wieser2024formalizing}}
+\lean{CliffordAlgebra.equivExterior_list_prod_ι_of_pairwise_isOrtho}
+
 \p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. For a list #{l} of vectors, write
 
 ##{P_Q([])=1, \qquad P_Q(m::l)=\iota_Q(m)P_Q(l),}
 
-and write #{T_Q} for the linear equivalence #{\operatorname{equivExterior}(Q)} from #{\Cl(Q)} to #{\ExteriorAlgebra R M}. In the corresponding zero-form product notation, suppose every earlier vector in #{l} is #{Q}-orthogonal to every later vector. Then
+and write #{T_Q} for the linear equivalence #{\operatorname{equivExterior}(Q)} from #{\Cl(Q)} to #{\bigwedge_R M}. In the corresponding zero-form product notation, suppose every earlier vector in #{l} is #{Q}-orthogonal to every later vector. Then
 
 ##{T_Q(P_Q(l))=P_0(l).}
 
@@ -19,5 +22,4 @@ The order of the list is unchanged. The equality concerns this product under the
 
 \p{The contraction recurrence in \citet{8.4, (8.54)}{wieser2024formalizing}, the change-of-form recurrence in \citet{8.4, (8.55)}{wieser2024formalizing}, and the exterior-equivalence interface in \citet{9.3.5}{wieser2024formalizing} supply the ingredients. The pairwise-list induction is the FCAP formalization bridge; none of those source locations states this list theorem.}
 
-\p{The paired Lean declaration is \lean{CliffordAlgebra.equivExterior_list_prod_ι_of_pairwise_isOrtho}. It uses only Mathlib interfaces and the preceding vanishing-contraction theorem. The scope stops before reordering, finite subsets, ordered blades, coordinate signs, masks, PGA conventions, and executable representations.}
-}
+\p{The paired declaration uses only Mathlib interfaces and the preceding vanishing-contraction theorem. The scope stops before reordering, finite subsets, ordered blades, coordinate signs, masks, PGA conventions, and executable representations.}


### PR DESCRIPTION
## Summary

- convert the four existing coordinate/transport notes into Definition, Lemma, and Theorem cards
- move Lean declarations into heading metadata so the prose has no dropped inline slots
- retain the existing mathematical statements, source boundaries, and FCAP scope

## Verification

- full `just build` (1,115 XML documents)
- `./lize.sh fcap-0001`
- rendered PDF text, font, overflow, and link audit
- reviewed as the first commit of the exact combined evidence sent on Discord

Targets `forest:fcap`; no renderer or FGAP changes.