### PR TITLE
docs(fcap): add reflection and Clifford lift cards

### DIFF
--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -18,3 +18,5 @@
 \transclude{fcap-0005}
 
 \transclude{fcap-0006}
+
+\transclude{fcap-0007}

--- a/trees/fcap-0007.tree
+++ b/trees/fcap-0007.tree
@@ -1,0 +1,18 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+\tag{notes}
+
+\title{Reflections and square-normalized Clifford lifts}
+
+\p{This appendix records the reflection calculations that underlie the first Pin and Spin lift constructions. The sign convention is fixed first; the later cards then separate source theorems from the sharper square-witness statements used in the formalization.}
+
+\transclude{fcap-0008}
+\transclude{fcap-0009}
+\transclude{fcap-000A}
+\transclude{fcap-000B}
+\transclude{fcap-000C}
+\transclude{fcap-000D}
+\transclude{fcap-000E}

--- a/trees/fcap-0008.tree
+++ b/trees/fcap-0008.tree
@@ -1,0 +1,18 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Convention}
+\title{Quadratic-form sign \citet{I.1, (1.3)--(1.4), p. 8}{lawson2016spin}}
+
+\p{Lawson and Michelsohn write
+
+##{v^2=-q(v)1, \qquad vw+wv=-2q(v,w),}
+
+where #{2q(v,w)=q(v+w)-q(v)-q(w)}. Mathlib and TauCeti instead use a quadratic form #{Q} with
+
+##{\iota(v)^2=Q(v)1.}
+
+The conventions agree after setting #{Q=-q}. The orthogonal group and its reflections are unchanged by this global sign reversal. A source vector with #{q(v)=1} therefore has #{Q(v)=-1} in the formalization convention.}

--- a/trees/fcap-0009.tree
+++ b/trees/fcap-0009.tree
@@ -1,0 +1,19 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Definition}
+\title{Reflection in a nonisotropic vector \citet{I.2, (2.12), p. 14}{lawson2016spin}}
+\lean/tauceti{TauCeti.QuadraticMap.reflection}
+
+\p{Let #{F} be a field of characteristic different from #{2}, let #{Q} be a quadratic form on an #{F}-vector space #{V}, and write
+
+##{B_Q(x,y)=Q(x+y)-Q(x)-Q(y)}
+
+for its polar form. If #{Q(v)\ne0}, the reflection with normal vector #{v} is
+
+##{\rho_v(w)=w-\frac{B_Q(v,w)}{Q(v)}v.}
+
+It fixes #{v^\perp} pointwise, sends #{v} to #{-v}, and preserves #{Q}. Multiplying #{v} by a nonzero scalar does not change #{\rho_v}.}

--- a/trees/fcap-000A.tree
+++ b/trees/fcap-000A.tree
@@ -1,0 +1,32 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Lemma}
+\title{Twisted Clifford conjugation is a reflection \citet{I.2, Proposition 2.2 and (2.8), p. 13; (2.11)--(2.12), p. 14}{lawson2016spin}}
+
+\p{Let #{\alpha} denote the grading involution of #{\Cl(Q)}. For #{Q(v)\ne0}, the Clifford generator #{\iota(v)} is invertible with
+
+##{\iota(v)^{-1}=Q(v)^{-1}\iota(v).}
+
+Its twisted adjoint action on a generator is the reflection in \ref{fcap-0009}:
+
+##{\alpha(\iota(v))\,\iota(w)\,\iota(v)^{-1}=\iota(\rho_v(w)).}
+}
+
+\subtree{
+\taxon{Proof}
+\p{The Clifford relation gives
+
+##{\iota(v)\iota(w)+\iota(w)\iota(v)=B_Q(v,w).}
+
+Since #{\alpha(\iota(v))=-\iota(v)} and #{\iota(v)^2=Q(v)}, substitution yields
+
+##{-\iota(v)\iota(w)\frac{\iota(v)}{Q(v)}
+=\iota(w)-\frac{B_Q(v,w)}{Q(v)}\iota(v)
+=\iota(\rho_v(w)).}
+
+The ordinary adjoint differs by the leading minus sign; the twisted adjoint is the action that gives the reflection itself.}
+}

--- a/trees/fcap-000B.tree
+++ b/trees/fcap-000B.tree
@@ -1,0 +1,19 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Lemma}
+\title{Square-normalized Pin lift \citet{I.2, Definition 2.3 and (2.26), pp. 14, 18}{lawson2016spin}}
+\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mem_range_pinToOrthogonal_of_isSquare}
+
+\p{Let #{R} be a commutative ring, let #{Q} be a quadratic form on an #{R}-module #{M}, and suppose #{2} and #{Q(v)} are invertible. If there is a scalar #{c} such that
+
+##{c^2=-Q(v)^{-1},}
+
+then #{Q(cv)=-1}. The normalized Clifford generator #{\iota(cv)} belongs to the Pin group and its twisted adjoint action is #{\rho_v}, because #{\rho_{cv}=\rho_v}. Consequently
+
+##{\rho_v\in\operatorname{range}(\operatorname{pinToOrthogonal}).}
+
+Equivalently, the required hypothesis is that #{-Q(v)^{-1}} is a square. The conclusion is existential: it asserts that a Pin lift exists, not that a canonical square root has been chosen.}

--- a/trees/fcap-000C.tree
+++ b/trees/fcap-000C.tree
@@ -1,0 +1,35 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{Paired reflections have a product-square Spin lift}
+\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
+
+\p{Let #{R}, #{M}, and #{Q} be as in \ref{fcap-000B}. Suppose #{Q(v)}, #{Q(w)}, and #{2} are invertible. If there is a scalar #{c} such that
+
+##{c^2=Q(v)^{-1}Q(w)^{-1},}
+
+then
+
+##{Q(cv)Q(w)=1.}
+
+Set #{x=\iota(cv)\iota(w)}. The element #{x} is a product of invertible Clifford generators, and
+
+##{x^{*}x
+=\iota(w)\iota(cv)^2\iota(w)
+=Q(cv)Q(w)=1.}
+
+Thus #{x} is a unitary element of the Lipschitz group. It has even degree, so it belongs to the Spin group. Its twisted adjoint action is the ordered product of reflections, and therefore
+
+##{\rho_v\rho_w\in\operatorname{range}(\operatorname{spinToOrthogonal}).}
+}
+
+\subtree{
+\taxon{Proof}
+\p{The displayed square identity gives #{Q(cv)Q(w)=c^2Q(v)Q(w)=1}. Each generator is a Clifford unit and lies in the Lipschitz group, while the star calculation above establishes the unitary condition. The twisted adjoint is multiplicative on Clifford units, and scalar rescaling does not change a reflection. Hence the action of #{x} is #{\rho_{cv}\rho_w=\rho_v\rho_w}; its even degree supplies the remaining Spin condition.}
+}
+
+\p{Equations (2.24)--(2.26) in \citet{I.2, p. 18}{lawson2016spin} give the product descriptions and scaling invariance used here. The product-square condition is sharper than asking for separate normalizations of #{v} and #{w}; it is the formalization's algebraic bridge and is not stated as a separate theorem by Lawson and Michelsohn.}

--- a/trees/fcap-000D.tree
+++ b/trees/fcap-000D.tree
@@ -1,0 +1,18 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Example}
+\title{A Euclidean unit normal}
+
+\p{Let #{V=\mathbb{R}^n} with Euclidean inner product and use the formalization convention
+
+##{Q(x)=-\langle x,x\rangle.}
+
+For a unit vector #{v}, one has #{Q(v)=-1}; thus #{c=1} satisfies the square condition in \ref{fcap-000B}. The Clifford generator #{\iota(v)} is already Pin-normalized, and its action is the familiar hyperplane reflection
+
+##{\rho_v(w)=w-2\langle v,w\rangle v.}
+
+For orthonormal #{v,w}, the even product #{\iota(v)\iota(w)} lies in Spin and lifts the composition #{\rho_v\rho_w}.}

--- a/trees/fcap-000E.tree
+++ b/trees/fcap-000E.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Remark}
+\title{Source and formalization boundary}
+
+\p{Lawson and Michelsohn supply the twisted-adjoint reflection formula, the definitions of Pin and Spin, the description by products of normalized vectors, and the square-root obstruction to normalization. The square-witness statements in \ref{fcap-000B} and \ref{fcap-000C} package those ingredients over commutative rings and expose the precise hypotheses used by the formalization.}
+
+\p{Neither lift theorem proves a factorization into arbitrarily many reflections, surjectivity of the Pin or Spin action, a kernel computation, or a short exact sequence. Those conclusions require additional finite-dimensional, nondegeneracy, parity, and field hypotheses.}


### PR DESCRIPTION
## Summary

- rebuild the reverted SpinRep appendix as mathematics-first cards in the CA/TT style
- state the Lawson–Michelsohn sign convention and derive reflection by twisted Clifford conjugation
- prove the square-normalized Pin lift and product-square Spin lift used by merged TauCeti PR #2404
- include a Euclidean example and an explicit source/formalization boundary
- attach provider-aware TauCeti and Mathlib declaration badges

## Scholarly grounding

Lawson–Michelsohn, *Spin Geometry*, Chapter I, sections 1–2, equations (1.3)–(1.4), Proposition 2.2, Definition 2.3, and equations (2.8), (2.11)–(2.12), (2.24)–(2.26), printed pages 8, 13–14, and 18. Registered pdf-land source: `xxh3-128:7f1d9de3244d2a47751b1bbba67bab7a`.

## Verification

- full `just build` (1,115 XML documents)
- combined renderer/note `./lize.sh fcap-0001`
- nine-page PDF text, font, overflow, visual-card, and ten-link audit
- three independent grounding, formalization, and roadmap reviews

Targets `forest:fcap`. The unstable later Cartan-reduction cluster is intentionally outside this PR.