### PR TITLE
docs(fcap): complete the grounded SpinRep note suite [AGENT]

### DIFF
--- a/tex/forest.bib
+++ b/tex/forest.bib
@@ -48,6 +48,21 @@
   publisher={Elsevier}
 }
 
+@book{cartan1981theory,
+  title={The Theory of Spinors},
+  author={Cartan, Elie},
+  translator={Streater, Raymond F.},
+  year={1981},
+  publisher={Dover Publications}
+}
+
+@book{chevalley1954algebraic,
+  title={The Algebraic Theory of Spinors},
+  author={Chevalley, Claude},
+  year={1954},
+  publisher={Columbia University Press}
+}
+
 @article{dereli2010degenerate,
   title={Degenerate spin groups as semi-direct products},
   author={Dereli, Tekin and Ko{\c{c}}ak, {\c{S}}ahin and Limoncu, Murat},
@@ -135,6 +150,17 @@
   url={https://peeterjoot.com/archives/math2015/gabookII.pdf}
 }
 
+@article{kostant1997clifford,
+  title={Clifford Algebra Analogue of the Hopf--Koszul--Samelson Theorem},
+  author={Kostant, Bertram},
+  year={1997},
+  journal={Advances in Mathematics},
+  volume={125},
+  number={2},
+  pages={275--350},
+  doi={10.1006/aima.1997.1602}
+}
+
 @book{li2008invariant,
   title={Invariant algebras and geometric reasoning},
   author={Li, Hongbo},
@@ -162,6 +188,16 @@
   volume={58},
   year={2013},
   publisher={Springer}
+}
+
+@article{panyushev2001exterior,
+  title={The Exterior Algebra and `Spin' of an Orthogonal g-Module},
+  author={Panyushev, Dmitri I.},
+  year={2001},
+  journal={Transformation Groups},
+  volume={6},
+  number={1},
+  pages={51--77}
 }
 
 @book{perwass2009geometric,

--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -20,3 +20,5 @@
 \transclude{fcap-0006}
 
 \transclude{fcap-0007}
+
+\transclude{fcap-000F}

--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -22,3 +22,5 @@
 \transclude{fcap-0007}
 
 \transclude{fcap-000F}
+
+\transclude{fcap-000M}

--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \title{Formalized Clifford Algebra Programme}
 \meta{pdf}{true}
@@ -24,3 +25,5 @@
 \transclude{fcap-000F}
 
 \transclude{fcap-000M}
+
+\transclude{fcap-0010}

--- a/trees/fcap-0002.tree
+++ b/trees/fcap-0002.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{clifford}

--- a/trees/fcap-0002.tree
+++ b/trees/fcap-0002.tree
@@ -7,7 +7,7 @@
 
 \title{Coordinate representations}
 
-\p{A coordinate representation begins by choosing data that the abstract construction leaves open. For Clifford algebra, a basis of the generating module gives one route through the exterior algebra. The first two coordinate anchors of that route give later product and encoding work a named starting point rather than an implicit choice.}
+\p{A basis of the generating module gives coordinates on the exterior algebra, and the exterior equivalence transports those coordinates to the Clifford algebra. The empty and singleton coordinates fix the scalar and generator conventions. Orthogonality then controls how certain ordered products pass between the two algebras.}
 
 \transclude{fcap-0003}
 

--- a/trees/fcap-0003.tree
+++ b/trees/fcap-0003.tree
@@ -6,9 +6,8 @@
 
 \taxon{Definition}
 \title{Transported exterior-basis coordinates \citet{9.3.5}{wieser2024formalizing}}
-\lean{CliffordAlgebra.transportedExteriorBasis,CliffordAlgebra.equivExterior}
 
-\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and choose a basis #{b} indexed by a linearly ordered type. Write #{E_b(s)} for the exterior-basis vector indexed by a finite subset #{s}. For a quadratic form #{Q}, the linear equivalence #{\Cl(Q) \simeq \bigwedge_R M} gives a coordinate basis
+\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and choose a basis #{b} indexed by a linearly ordered type. Write #{E_b(s)} for the exterior-basis vector indexed by a finite subset #{s}. For a quadratic form #{Q}, the Mathlib linear equivalence \leanref{CliffordAlgebra.equivExterior} from #{\Cl(Q)} to #{\bigwedge_R M} gives a coordinate basis
 
 ##{B_{Q,b}(s) = \operatorname{equivExterior}(Q)^{-1}(E_b(s)).}
 

--- a/trees/fcap-0003.tree
+++ b/trees/fcap-0003.tree
@@ -1,18 +1,20 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 \tag{fcap}
 \tag{clifford}
 \tag{draft}
 
 \taxon{Definition}
 \title{Transported exterior-basis coordinates \citet{9.3.5}{wieser2024formalizing}}
-\lean{CliffordAlgebra.transportedExteriorBasis}
-\lean{CliffordAlgebra.equivExterior}
+\lean{CliffordAlgebra.transportedExteriorBasis,CliffordAlgebra.equivExterior}
 
 \p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and choose a basis #{b} indexed by a linearly ordered type. Write #{E_b(s)} for the exterior-basis vector indexed by a finite subset #{s}. For a quadratic form #{Q}, the linear equivalence #{\Cl(Q) \simeq \bigwedge_R M} gives a coordinate basis
 
 ##{B_{Q,b}(s) = \operatorname{equivExterior}(Q)^{-1}(E_b(s)).}
 
-This basis is transported through a linear equivalence. It does not say that the equivalence preserves multiplication or that Clifford multiplication becomes exterior multiplication. The basis-free construction is developed in \citek{wieser2022formalizing}, and the exterior equivalence is treated in \citet{9.3.5}{wieser2024formalizing}.}
+This basis is transported through a linear equivalence. It does not say that the equivalence preserves multiplication or that Clifford multiplication becomes exterior multiplication. The basis-free construction is developed in \citek{wieser2022formalizing}.}
+
+\p{The exterior equivalence is treated in \citet{9.3.5}{wieser2024formalizing}.}
 
 \p{Two calculations anchor the choice. The empty subset maps to the scalar unit,
 

--- a/trees/fcap-0003.tree
+++ b/trees/fcap-0003.tree
@@ -12,7 +12,7 @@
 
 ##{B_{Q,b}(s) = \operatorname{equivExterior}(Q)^{-1}(E_b(s)).}
 
-This basis is a choice transported through a linear equivalence. It does not say that the equivalence preserves multiplication or that Clifford multiplication becomes exterior multiplication. The basis-free formalization gives the surrounding context \citek{wieser2022formalizing}; the exterior-equivalence construction used here is treated in \citet{9.3.5}{wieser2024formalizing}. This note fixes the particular coordinate data needed for the next executable boundary.}
+This basis is transported through a linear equivalence. It does not say that the equivalence preserves multiplication or that Clifford multiplication becomes exterior multiplication. The basis-free construction is developed in \citek{wieser2022formalizing}, and the exterior equivalence is treated in \citet{9.3.5}{wieser2024formalizing}.}
 
 \p{Two calculations anchor the choice. The empty subset maps to the scalar unit,
 
@@ -22,6 +22,6 @@ and a singleton maps to the corresponding Clifford generator,
 
 ##{B_{Q,b}(\{i\}) = \iota_Q(b(i)).}
 
-The paired declarations name the basis and the exterior equivalence used to prove these two equalities. The claims are deliberately module-level: they say how the selected coordinates begin, not how arbitrary coordinates multiply.}
+These are module-level identities: they determine the first two coordinate types but do not determine multiplication of arbitrary coordinates.}
 
-\p{What remains is equally important. This note does not prove a formula for multi-element subsets, an algebra equivalence, an ordering or sign convention for blades, or an encoding into machine slots. Each requires its own representation and proof obligation before a symbolic or numerical implementation may rely on it.}
+\p{For subsets with several elements, a coordinate formula additionally needs an ordering convention and its attendant signs. No such convention is implicit in the transported basis.}

--- a/trees/fcap-0004.tree
+++ b/trees/fcap-0004.tree
@@ -18,4 +18,4 @@ This is the first point at which an orthogonality hypothesis changes the transpo
 
 \p{The change-of-form construction is the relevant mathematical background in \citet{8.4}{wieser2024formalizing}, and the Lean construction of #{\operatorname{equivExterior}} is described in \citet{9.3.5}{wieser2024formalizing}. The concrete geometric-product discussion in \citet{2.1.2}{wieser2024formalizing} motivates the role of orthogonality, but does not provide this note's formal interface.}
 
-\p{The paired theorem unfolds the two-generator change-of-form identity and applies the exact orthogonality equality for the associated form. No basis choice, finite ordered product, blade-product formula, sign convention, or executable encoding is used here. Those boundaries remain separate work.}
+\p{Thus orthogonality removes precisely the scalar correction in the two-generator change-of-form identity. No basis or reordering convention is needed.}

--- a/trees/fcap-0004.tree
+++ b/trees/fcap-0004.tree
@@ -7,9 +7,8 @@
 
 \taxon{Lemma}
 \title{Orthogonal pair transport \citet{8.4}{wieser2024formalizing}}
-\lean{CliffordAlgebra.equivExterior_ι_mul_ι_of_isOrtho}
 
-\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. Write #{T_Q} for the linear equivalence from #{\Cl(Q)} to the exterior algebra supplied by #{\operatorname{equivExterior}(Q)}. It is a module equivalence, not an algebra equivalence.}
+\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. Write #{T_Q} for the linear equivalence from #{\Cl(Q)} to the exterior algebra supplied by \leanref{CliffordAlgebra.equivExterior}. It is a module equivalence, not an algebra equivalence.}
 
 \p{For vectors #{m,n \in M}, the change-of-form calculation for #{T_Q(\iota_Q(m)\iota_Q(n))} has one extra scalar contribution, evaluated by the bilinear form associated to #{-Q}. If #{m} and #{n} are #{Q}-orthogonal, that contribution vanishes. The resulting two-generator calculation is
 

--- a/trees/fcap-0004.tree
+++ b/trees/fcap-0004.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{clifford}

--- a/trees/fcap-0005.tree
+++ b/trees/fcap-0005.tree
@@ -7,7 +7,6 @@
 
 \taxon{Lemma}
 \title{Vanishing list contraction \citet{8.4, (8.54)}{wieser2024formalizing}}
-\lean{CliffordAlgebra.contractLeft_list_prod_ι_of_forall_eq_zero,List.map,List.prod}
 
 \p{Let #{R} be a commutative ring, #{M} an #{R}-module, #{Q} a quadratic form on #{M}, and #{d : M \to R} a linear functional. For a list #{l} of generators, define an ordered product by
 

--- a/trees/fcap-0005.tree
+++ b/trees/fcap-0005.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{clifford}
@@ -6,9 +7,7 @@
 
 \taxon{Lemma}
 \title{Vanishing list contraction \citet{8.4, (8.54)}{wieser2024formalizing}}
-\lean{CliffordAlgebra.contractLeft_list_prod_ι_of_forall_eq_zero}
-\lean{List.map}
-\lean{List.prod}
+\lean{CliffordAlgebra.contractLeft_list_prod_ι_of_forall_eq_zero,List.map,List.prod}
 
 \p{Let #{R} be a commutative ring, #{M} an #{R}-module, #{Q} a quadratic form on #{M}, and #{d : M \to R} a linear functional. For a list #{l} of generators, define an ordered product by
 

--- a/trees/fcap-0005.tree
+++ b/trees/fcap-0005.tree
@@ -22,6 +22,4 @@ and write #{C_{Q,d}} for left contraction by #{d}. The condition #{\forall m\in 
 
 is the local rule in \citet{8.4, (8.54)}{wieser2024formalizing}. The hypothesis deletes the first summand, and the induction hypothesis deletes the second. This turns the recurrence into a finite-list vanishing criterion rather than a calculation for one fixed product.}
 
-\p{The paired declaration states this criterion for mapped lists and their ordered products. This card isolates its proof interface from later transport.}
-
-\p{The scope stops before ordered transport, change of form, bases, finite subsets, signs, coordinates, masks, PGA, and execution.}
+\p{The conclusion depends only on the ordered recurrence and pointwise vanishing of #{d} on the list. In particular, it is independent of a basis or any reordering convention.}

--- a/trees/fcap-0006.tree
+++ b/trees/fcap-0006.tree
@@ -20,6 +20,6 @@ The order of the list is unchanged. The equality concerns this product under the
 
 \p{The calculation proceeds from the head of the list. The one-generator change-of-form recurrence separates #{T_Q(P_Q(m::l))} into the zero-form generator #{\iota_0(m)} times the transported tail and a left-contraction correction. Pairwise orthogonality makes the associated dual vector vanish on every member of the tail. The criterion in \ref{fcap-0005} therefore kills the correction, and the induction hypothesis transports the tail.}
 
-\p{The contraction recurrence in \citet{8.4, (8.54)}{wieser2024formalizing}, the change-of-form recurrence in \citet{8.4, (8.55)}{wieser2024formalizing}, and the exterior-equivalence interface in \citet{9.3.5}{wieser2024formalizing} supply the ingredients. The pairwise-list induction is the FCAP formalization bridge; none of those source locations states this list theorem.}
+\p{The contraction recurrence in \citet{8.4, (8.54)}{wieser2024formalizing}, the change-of-form recurrence in \citet{8.4, (8.55)}{wieser2024formalizing}, and the exterior equivalence in \citet{9.3.5}{wieser2024formalizing} supply the local identities. Their induction over a pairwise-orthogonal list gives the displayed theorem; the source locations do not state that finite-list consequence separately.}
 
-\p{The paired declaration uses only Mathlib interfaces and the preceding vanishing-contraction theorem. The scope stops before reordering, finite subsets, ordered blades, coordinate signs, masks, PGA conventions, and executable representations.}
+\p{The order of the list is fixed throughout. Reordering would require an additional permutation-sign calculation and is not a consequence of this theorem.}

--- a/trees/fcap-0006.tree
+++ b/trees/fcap-0006.tree
@@ -7,13 +7,12 @@
 
 \taxon{Theorem}
 \title{Pairwise orthogonal list transport \citet{8.4, (8.55)}{wieser2024formalizing}}
-\lean{CliffordAlgebra.equivExterior_list_prod_ι_of_pairwise_isOrtho}
 
 \p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. For a list #{l} of vectors, write
 
 ##{P_Q([])=1, \qquad P_Q(m::l)=\iota_Q(m)P_Q(l),}
 
-and write #{T_Q} for the linear equivalence #{\operatorname{equivExterior}(Q)} from #{\Cl(Q)} to #{\bigwedge_R M}. In the corresponding zero-form product notation, suppose every earlier vector in #{l} is #{Q}-orthogonal to every later vector. Then
+and write #{T_Q} for the linear equivalence \leanref{CliffordAlgebra.equivExterior} from #{\Cl(Q)} to #{\bigwedge_R M}. In the corresponding zero-form product notation, suppose every earlier vector in #{l} is #{Q}-orthogonal to every later vector. Then
 
 ##{T_Q(P_Q(l))=P_0(l).}
 

--- a/trees/fcap-0006.tree
+++ b/trees/fcap-0006.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{clifford}

--- a/trees/fcap-0007.tree
+++ b/trees/fcap-0007.tree
@@ -7,7 +7,7 @@
 
 \title{Reflections and square-normalized Clifford lifts}
 
-\p{This appendix records the reflection calculations that underlie the first Pin and Spin lift constructions. The sign convention is fixed first; the later cards then separate source theorems from the sharper square-witness statements used in the formalization.}
+\p{A nonisotropic vector acts on the generating space by a reflection through twisted Clifford conjugation. Normalizing such vectors gives elements of Pin, while even products give elements of Spin. The cards first establish these local lifts and then pass from reflection generation to surjectivity of the Pin action.}
 
 \transclude{fcap-0008}
 \transclude{fcap-0009}
@@ -16,3 +16,4 @@
 \transclude{fcap-000C}
 \transclude{fcap-000D}
 \transclude{fcap-000E}
+\transclude{fcap-000U}

--- a/trees/fcap-0007.tree
+++ b/trees/fcap-0007.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -8,6 +9,8 @@
 \title{Reflections and square-normalized Clifford lifts}
 
 \p{A nonisotropic vector acts on the generating space by a reflection through twisted Clifford conjugation. Normalizing such vectors gives elements of Pin, while even products give elements of Spin. The cards first establish these local lifts and then pass from reflection generation to surjectivity of the Pin action.}
+
+\related{\ref{ca-0001}}
 
 \transclude{fcap-0008}
 \transclude{fcap-0009}

--- a/trees/fcap-0008.tree
+++ b/trees/fcap-0008.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-0008.tree
+++ b/trees/fcap-0008.tree
@@ -6,6 +6,7 @@
 
 \taxon{Convention}
 \title{Quadratic-form sign \citet{I.1, (1.3)--(1.4), p. 8}{lawson2016spin}}
+\lean{CliffordAlgebra.ι_sq_scalar}
 
 \p{Lawson and Michelsohn write
 
@@ -15,4 +16,4 @@ where #{2q(v,w)=q(v+w)-q(v)-q(w)}. Mathlib and TauCeti instead use a quadratic f
 
 ##{\iota(v)^2=Q(v)1.}
 
-The conventions agree after setting #{Q=-q}. The orthogonal group and its reflections are unchanged by this global sign reversal. A source vector with #{q(v)=1} therefore has #{Q(v)=-1} in the formalization convention.}
+The conventions agree after setting #{Q=-q}. The orthogonal group and its reflections are unchanged by this global sign reversal. A vector with #{q(v)=1} therefore has #{Q(v)=-1} in the convention used below.}

--- a/trees/fcap-0008.tree
+++ b/trees/fcap-0008.tree
@@ -7,7 +7,6 @@
 
 \taxon{Convention}
 \title{Quadratic-form sign \citet{I.1, (1.3)--(1.4), p. 8}{lawson2016spin}}
-\lean{CliffordAlgebra.ι_sq_scalar}
 
 \p{Lawson and Michelsohn write
 
@@ -17,4 +16,4 @@ where #{2q(v,w)=q(v+w)-q(v)-q(w)}. Mathlib and TauCeti instead use a quadratic f
 
 ##{\iota(v)^2=Q(v)1.}
 
-The conventions agree after setting #{Q=-q}. The orthogonal group and its reflections are unchanged by this global sign reversal. A vector with #{q(v)=1} therefore has #{Q(v)=-1} in the convention used below.}
+The conventions agree after setting #{Q=-q}. The orthogonal group and its reflections are unchanged by this global sign reversal. A vector with #{q(v)=1} therefore has #{Q(v)=-1} in the convention used below. Mathlib's generator-square rule \leanref{CliffordAlgebra.ι_sq_scalar} uses this #{Q}-convention.}

--- a/trees/fcap-0009.tree
+++ b/trees/fcap-0009.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000A.tree
+++ b/trees/fcap-000A.tree
@@ -6,6 +6,8 @@
 
 \taxon{Lemma}
 \title{Twisted Clifford conjugation is a reflection \citet{I.2, Proposition 2.2 and (2.8), p. 13; (2.11)--(2.12), p. 14}{lawson2016spin}}
+\lean{CliffordAlgebra.ι_sq_scalar}
+\lean{CliffordAlgebra.ι_mul_ι_add_swap}
 
 \p{Let #{\alpha} denote the grading involution of #{\Cl(Q)}. For #{Q(v)\ne0}, the Clifford generator #{\iota(v)} is invertible with
 

--- a/trees/fcap-000A.tree
+++ b/trees/fcap-000A.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -6,8 +7,7 @@
 
 \taxon{Lemma}
 \title{Twisted Clifford conjugation is a reflection \citet{I.2, Proposition 2.2 and (2.8), p. 13; (2.11)--(2.12), p. 14}{lawson2016spin}}
-\lean{CliffordAlgebra.ι_sq_scalar}
-\lean{CliffordAlgebra.ι_mul_ι_add_swap}
+\lean{CliffordAlgebra.ι_sq_scalar,CliffordAlgebra.ι_mul_ι_add_swap}
 
 \p{Let #{\alpha} denote the grading involution of #{\Cl(Q)}. For #{Q(v)\ne0}, the Clifford generator #{\iota(v)} is invertible with
 

--- a/trees/fcap-000A.tree
+++ b/trees/fcap-000A.tree
@@ -7,7 +7,6 @@
 
 \taxon{Lemma}
 \title{Twisted Clifford conjugation is a reflection \citet{I.2, Proposition 2.2 and (2.8), p. 13; (2.11)--(2.12), p. 14}{lawson2016spin}}
-\lean{CliffordAlgebra.ι_sq_scalar,CliffordAlgebra.ι_mul_ι_add_swap}
 
 \p{Let #{\alpha} denote the grading involution of #{\Cl(Q)}. For #{Q(v)\ne0}, the Clifford generator #{\iota(v)} is invertible with
 
@@ -20,7 +19,7 @@ Its twisted adjoint action on a generator is the reflection in \ref{fcap-0009}:
 
 \subtree{
 \taxon{Proof}
-\p{The Clifford relation gives
+\p{The generator-square rule \leanref{CliffordAlgebra.ι_sq_scalar} and the anticommutator rule \leanref{CliffordAlgebra.ι_mul_ι_add_swap} give
 
 ##{\iota(v)\iota(w)+\iota(w)\iota(v)=B_Q(v,w).}
 

--- a/trees/fcap-000B.tree
+++ b/trees/fcap-000B.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000C.tree
+++ b/trees/fcap-000C.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000C.tree
+++ b/trees/fcap-000C.tree
@@ -5,7 +5,7 @@
 \tag{clifford}
 
 \taxon{Theorem}
-\title{Paired reflections have a product-square Spin lift}
+\title{Paired reflections have a product-square Spin lift \citet{I.2, (2.24)--(2.26), p. 18}{lawson2016spin}}
 \lean/tauceti{TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
 
 \p{Let #{R}, #{M}, and #{Q} be as in \ref{fcap-000B}. Suppose #{Q(v)}, #{Q(w)}, and #{2} are invertible. If there is a scalar #{c} such that
@@ -32,4 +32,4 @@ Thus #{x} is a unitary element of the Lipschitz group. It has even degree, so it
 \p{The displayed square identity gives #{Q(cv)Q(w)=c^2Q(v)Q(w)=1}. Each generator is a Clifford unit and lies in the Lipschitz group, while the star calculation above establishes the unitary condition. The twisted adjoint is multiplicative on Clifford units, and scalar rescaling does not change a reflection. Hence the action of #{x} is #{\rho_{cv}\rho_w=\rho_v\rho_w}; its even degree supplies the remaining Spin condition.}
 }
 
-\p{Equations (2.24)--(2.26) in \citet{I.2, p. 18}{lawson2016spin} give the product descriptions and scaling invariance used here. The product-square condition is sharper than asking for separate normalizations of #{v} and #{w}; it is the formalization's algebraic bridge and is not stated as a separate theorem by Lawson and Michelsohn.}
+\p{Equations (2.24)--(2.26) give the product descriptions and scaling invariance used here. The product-square condition is sharper than asking for separate normalizations of #{v} and #{w}: one scalar normalizes the product even when neither vector has been normalized separately.}

--- a/trees/fcap-000D.tree
+++ b/trees/fcap-000D.tree
@@ -6,6 +6,8 @@
 
 \taxon{Example}
 \title{A Euclidean unit normal}
+\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mem_range_pinToOrthogonal_of_isSquare}
+\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
 
 \p{Let #{V=\mathbb{R}^n} with Euclidean inner product and use the formalization convention
 

--- a/trees/fcap-000D.tree
+++ b/trees/fcap-000D.tree
@@ -1,13 +1,13 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
 
 \taxon{Example}
-\title{A Euclidean unit normal}
-\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mem_range_pinToOrthogonal_of_isSquare}
-\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
+\title{A Euclidean unit normal \citet{I.2, (2.12), p. 14; (2.24)--(2.26), p. 18}{lawson2016spin}}
+\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mem_range_pinToOrthogonal_of_isSquare,TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
 
 \p{Let #{V=\mathbb{R}^n} with Euclidean inner product and use the formalization convention
 

--- a/trees/fcap-000D.tree
+++ b/trees/fcap-000D.tree
@@ -7,9 +7,8 @@
 
 \taxon{Example}
 \title{A Euclidean unit normal \citet{I.2, (2.12), p. 14; (2.24)--(2.26), p. 18}{lawson2016spin}}
-\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mem_range_pinToOrthogonal_of_isSquare,TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
 
-\p{Let #{V=\mathbb{R}^n} with Euclidean inner product and use the formalization convention
+\p{Let #{V=\mathbb{R}^n} with Euclidean inner product and use the sign convention
 
 ##{Q(x)=-\langle x,x\rangle.}
 
@@ -17,4 +16,4 @@ For a unit vector #{v}, one has #{Q(v)=-1}; thus #{c=1} satisfies the square con
 
 ##{\rho_v(w)=w-2\langle v,w\rangle v.}
 
-For orthonormal #{v,w}, the even product #{\iota(v)\iota(w)} lies in Spin and lifts the composition #{\rho_v\rho_w}.}
+For orthonormal #{v,w}, the even product #{\iota(v)\iota(w)} lies in Spin and lifts the composition #{\rho_v\rho_w}. This is the Euclidean specialization of the general Pin and paired-Spin lifting statements in \ref{fcap-000B} and \ref{fcap-000C}.}

--- a/trees/fcap-000E.tree
+++ b/trees/fcap-000E.tree
@@ -1,11 +1,12 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
 
 \taxon{Remark}
-\title{From individual lifts to generation}
+\title{From individual lifts to generation \citet{I.2, Proposition 2.2, Definition 2.3, and (2.24)--(2.26), pp. 13--18}{lawson2016spin}}
 
 \p{Lawson and Michelsohn supply the twisted-adjoint reflection formula, the definitions of Pin and Spin, the description by products of normalized vectors, and the square-root obstruction to normalization. The square-witness statements in \ref{fcap-000B} and \ref{fcap-000C} isolate the precise algebraic hypotheses under which one or two reflections lift.}
 

--- a/trees/fcap-000E.tree
+++ b/trees/fcap-000E.tree
@@ -5,8 +5,8 @@
 \tag{clifford}
 
 \taxon{Remark}
-\title{Source and formalization boundary}
+\title{From individual lifts to generation}
 
-\p{Lawson and Michelsohn supply the twisted-adjoint reflection formula, the definitions of Pin and Spin, the description by products of normalized vectors, and the square-root obstruction to normalization. The square-witness statements in \ref{fcap-000B} and \ref{fcap-000C} package those ingredients over commutative rings and expose the precise hypotheses used by the formalization.}
+\p{Lawson and Michelsohn supply the twisted-adjoint reflection formula, the definitions of Pin and Spin, the description by products of normalized vectors, and the square-root obstruction to normalization. The square-witness statements in \ref{fcap-000B} and \ref{fcap-000C} isolate the precise algebraic hypotheses under which one or two reflections lift.}
 
-\p{Neither lift theorem proves a factorization into arbitrarily many reflections, surjectivity of the Pin or Spin action, a kernel computation, or a short exact sequence. Those conclusions require additional finite-dimensional, nondegeneracy, parity, and field hypotheses.}
+\p{An individual lift does not by itself show that all orthogonal transformations lift. That global conclusion requires finite dimension, nondegeneracy, and the Cartan--Dieudonne factorization developed next.}

--- a/trees/fcap-000F.tree
+++ b/trees/fcap-000F.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000F.tree
+++ b/trees/fcap-000F.tree
@@ -1,0 +1,19 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+\tag{notes}
+
+\title{The exterior shadow of a Clifford algebra}
+
+\p{The Clifford relation lowers word length by two. Filtering by word length therefore separates a word from its contraction terms: the highest-degree part is alternating, and the associated graded algebra is the exterior algebra.}
+
+\related{\ref{ca-0001}}
+
+\transclude{fcap-000G}
+\transclude{fcap-000H}
+\transclude{fcap-000I}
+\transclude{fcap-000J}
+\transclude{fcap-000K}
+\transclude{fcap-000L}

--- a/trees/fcap-000G.tree
+++ b/trees/fcap-000G.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -6,8 +7,7 @@
 
 \taxon{Definition}
 \title{Word-length filtration \citet{II.1.2 and II.1.6, pp. 40--42}{chevalley1954algebraic}}
-\lean/tauceti{TauCeti.CliffordAlgebra.filtration}
-\lean/tauceti{TauCeti.CliffordAlgebra.filtration_mul}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtration,TauCeti.CliffordAlgebra.filtration_mul}
 
 \p{Let #{R} be a commutative ring, let #{M} be an #{R}-module, and let #{Q:M\to R} be a quadratic form. In the Clifford algebra #{\Cl(Q)}, define #{F_n\Cl(Q)} to be the #{R}-submodule spanned by all products of at most #{n} generators:
 

--- a/trees/fcap-000G.tree
+++ b/trees/fcap-000G.tree
@@ -1,0 +1,24 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Definition}
+\title{Word-length filtration \citet{II.1.2 and II.1.6, pp. 40--42}{chevalley1954algebraic}}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtration}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtration_mul}
+
+\p{Let #{R} be a commutative ring, let #{M} be an #{R}-module, and let #{Q:M\to R} be a quadratic form. In the Clifford algebra #{\Cl(Q)}, define #{F_n\Cl(Q)} to be the #{R}-submodule spanned by all products of at most #{n} generators:
+
+##{F_n\Cl(Q)=\operatorname{span}_R\left\{\iota(v_1)\cdots\iota(v_r):0\le r\le n\right\}.}
+
+The empty product gives #{F_0\Cl(Q)=R1}. Concatenating words makes the filtration multiplicative; in fact,
+
+##{F_i\Cl(Q)\,F_j\Cl(Q)=F_{i+j}\Cl(Q).}
+
+Thus multiplication descends to the successive quotients and makes
+
+##{\operatorname{gr}_F\Cl(Q)=\bigoplus_{n\ge0}F_n\Cl(Q)/F_{n-1}\Cl(Q)}
+
+a graded algebra, with #{F_{-1}\Cl(Q)=0}.}

--- a/trees/fcap-000H.tree
+++ b/trees/fcap-000H.tree
@@ -1,0 +1,26 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Lemma}
+\title{The leading symbol is exterior \citet{II.1.6, pp. 41--42}{chevalley1954algebraic}}
+\lean/tauceti{TauCeti.CliffordAlgebra.changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtrationLeadingTerm_apply_ιMulti}
+
+\p{Assume that #{2} is invertible in #{R}. For vectors #{v_1,\ldots,v_n\in M}, the Clifford relation replaces an interchange by its alternating term plus a scalar contraction. Each contraction removes two generators. Consequently
+
+##{\iota(v_1)\cdots\iota(v_n)
+\equiv v_1\wedge\cdots\wedge v_n\pmod{F_{n-2}},}
+
+where the right-hand side is read through the zero-form exterior model. In particular, the class of the Clifford word in #{F_n/F_{n-1}} depends alternately on the vectors and is the leading exterior symbol.}
+
+\subtree{
+\taxon{Proof}
+\p{Move a generator through the word using
+
+##{\iota(u)\iota(v)+\iota(v)\iota(u)=B_Q(u,v)1.}
+
+The swapped word contributes the alternating sign, whereas the polar term has two fewer generators. Iterating separates the fully alternating word from terms in #{F_{n-2}}. Equivalently, changing from #{Q} to the zero quadratic form changes a word only below its leading filtration degree.}
+}

--- a/trees/fcap-000H.tree
+++ b/trees/fcap-000H.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -6,8 +7,7 @@
 
 \taxon{Lemma}
 \title{The leading symbol is exterior \citet{II.1.6, pp. 41--42}{chevalley1954algebraic}}
-\lean/tauceti{TauCeti.CliffordAlgebra.changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration}
-\lean/tauceti{TauCeti.CliffordAlgebra.filtrationLeadingTerm_apply_ιMulti}
+\lean/tauceti{TauCeti.CliffordAlgebra.changeForm_prod_map_ι_sub_prod_map_ι_mem_filtration,TauCeti.CliffordAlgebra.filtrationLeadingTerm_apply_ιMulti}
 
 \p{Assume that #{2} is invertible in #{R}. For vectors #{v_1,\ldots,v_n\in M}, the Clifford relation replaces an interchange by its alternating term plus a scalar contraction. Each contraction removes two generators. Consequently
 

--- a/trees/fcap-000I.tree
+++ b/trees/fcap-000I.tree
@@ -1,13 +1,13 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
 
 \taxon{Theorem}
-\title{The graded pieces are exterior powers}
-\lean/tauceti{TauCeti.CliffordAlgebra.filtrationGradedPieceEquivExteriorPower}
-\lean/tauceti{TauCeti.CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm}
+\title{The graded pieces are exterior powers \citet{II.1.6, pp. 41--42}{chevalley1954algebraic}}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtrationGradedPieceEquivExteriorPower,TauCeti.CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm}
 
 \p{Let #{R}, #{M}, and #{Q} be as in \ref{fcap-000H}. For every #{n\ge0}, the leading-symbol map gives a canonical linear equivalence
 

--- a/trees/fcap-000I.tree
+++ b/trees/fcap-000I.tree
@@ -1,0 +1,18 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{The graded pieces are exterior powers}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtrationGradedPieceEquivExteriorPower}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtrationLeadingTerm_eq_filtrationGradedEquiv_symm}
+
+\p{Let #{R}, #{M}, and #{Q} be as in \ref{fcap-000H}. For every #{n\ge0}, the leading-symbol map gives a canonical linear equivalence
+
+##{F_n\Cl(Q)/F_{n-1}\Cl(Q)\simeq \bigwedge^n_R M.}
+
+At #{n=0} this is the scalar equivalence #{F_0/0\simeq R=\bigwedge^0_RM}. For #{n>0}, the inverse sends a decomposable exterior product to the class of the corresponding Clifford word.}
+
+\p{The point of the quotient is that every contraction term has already fallen into a lower filtration step. Alternation is therefore exact in the graded piece even though it is not exact in the Clifford algebra itself.}

--- a/trees/fcap-000J.tree
+++ b/trees/fcap-000J.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000J.tree
+++ b/trees/fcap-000J.tree
@@ -1,0 +1,17 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{PBW equivalence with the exterior algebra \citet{Proposition 2.6, pp. 33--34}{meinrenken2013clifford}}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtrationAssociatedGradedEquivExterior}
+
+\p{The equivalences of \ref{fcap-000I} respect multiplication of homogeneous classes. They assemble into a graded-algebra equivalence
+
+##{\operatorname{gr}_F\Cl(Q)\simeq_{\mathrm{grAlg}}\bigwedge_R M.}
+
+The class of a product of an #{i}-word and a #{j}-word is carried to the exterior product of their leading symbols in degree #{i+j}.}
+
+\p{This is a PBW theorem for the Clifford filtration. It does not make #{\Cl(Q)} and #{\bigwedge_RM} isomorphic as algebras. The quadratic form survives in the lower-degree contraction terms of Clifford multiplication; only the associated graded multiplication forgets it.}

--- a/trees/fcap-000K.tree
+++ b/trees/fcap-000K.tree
@@ -1,0 +1,17 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Example}
+\title{The degree-two symbol}
+\lean/tauceti{TauCeti.CliffordAlgebra.filtrationAssociatedGradedEquivExterior_apply_of_succ}
+
+\p{For #{u,v\in M}, write the Clifford product as
+
+##{\iota(u)\iota(v)
+=\frac12\bigl(\iota(u)\iota(v)-\iota(v)\iota(u)\bigr)
++\frac12B_Q(u,v)1.}
+
+The second summand belongs to #{F_0}. Hence the degree-two class of #{\iota(u)\iota(v)} is #{u\wedge v}. The surviving half-commutator is the Clifford bivector studied next; the scalar polar term is invisible to the leading symbol.}

--- a/trees/fcap-000K.tree
+++ b/trees/fcap-000K.tree
@@ -1,11 +1,12 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
 
 \taxon{Example}
-\title{The degree-two symbol}
+\title{The degree-two symbol \citet{II.1.6, pp. 41--42}{chevalley1954algebraic}}
 \lean/tauceti{TauCeti.CliffordAlgebra.filtrationAssociatedGradedEquivExterior_apply_of_succ}
 
 \p{For #{u,v\in M}, write the Clifford product as
@@ -14,4 +15,4 @@
 =\frac12\bigl(\iota(u)\iota(v)-\iota(v)\iota(u)\bigr)
 +\frac12B_Q(u,v)1.}
 
-The second summand belongs to #{F_0}. Hence the degree-two class of #{\iota(u)\iota(v)} is #{u\wedge v}. The surviving half-commutator is the Clifford bivector studied next; the scalar polar term is invisible to the leading symbol.}
+The second summand belongs to #{F_0}. Hence the degree-two class of #{\iota(u)\iota(v)} is #{u\wedge v}. This is the two-generator instance of Chevalley's leading-symbol calculation cited in the title. The surviving half-commutator is the Clifford bivector studied next; the scalar polar term is invisible to the leading symbol.}

--- a/trees/fcap-000L.tree
+++ b/trees/fcap-000L.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000L.tree
+++ b/trees/fcap-000L.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Remark}
+\title{Basis proof and quotient proof}
+
+\p{Chevalley's proof chooses a basis, proves that ordered Clifford monomials form a basis, and identifies the underlying vector space with the exterior algebra \citet{II.1.2 and II.1.6, pp. 40--42}{chevalley1954algebraic}. Panyushev uses the resulting stable filtration and exterior associated graded as standard representation-theoretic background \citet{Section 2, p. 7}{panyushev2001exterior}.}
+
+\p{The quotient construction above does not require those chosen coordinates. It builds each graded piece from the word-length submodule and its predecessor, handles degree zero separately, and then takes their direct sum. This is a change of packaging and generality, not a stronger claim about unfiltered Clifford multiplication.}

--- a/trees/fcap-000M.tree
+++ b/trees/fcap-000M.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000M.tree
+++ b/trees/fcap-000M.tree
@@ -1,0 +1,20 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+\tag{notes}
+
+\title{Bivectors and the orthogonal Lie algebra}
+
+\p{The second exterior power singled out by the PBW filtration has a second life inside the Clifford algebra. Its half-commutators are closed under the commutator bracket, and their action on generators is exactly the infinitesimal orthogonal action.}
+
+\related{\ref{ca-0001}}
+
+\transclude{fcap-000N}
+\transclude{fcap-000O}
+\transclude{fcap-000P}
+\transclude{fcap-000Q}
+\transclude{fcap-000R}
+\transclude{fcap-000S}
+\transclude{fcap-000T}

--- a/trees/fcap-000N.tree
+++ b/trees/fcap-000N.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -6,14 +7,15 @@
 
 \taxon{Convention}
 \title{Bivector normalizations \citet{Section 2.2.5, Proposition 2.5, p. 33}{meinrenken2013clifford}}
-\lean/tauceti{TauCeti.CliffordAlgebra.bivector_def}
-\lean/tauceti{TauCeti.CliffordAlgebra.bivector_lie_ι}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivector_def,TauCeti.CliffordAlgebra.bivector_lie_ι}
 
 \p{Meinrenken starts with a symmetric bilinear form #{B} and the relation
 
 ##{uv+vu=2B(u,v)1.}
 
-For the associated quadratic form #{Q(v)=B(v,v)}, the polar form used here is #{B_Q=2B}. Therefore Meinrenken's quantization formula and the half-commutator agree:
+For the associated quadratic form #{Q(v)=B(v,v)}, the polar form used here is #{B_Q=2B}.}
+
+\p{Meinrenken's quantization formula and the half-commutator agree:
 
 ##{q(u\wedge v)=uv-B(u,v)1
 =\frac12(uv-vu)=:\beta(u,v).}

--- a/trees/fcap-000N.tree
+++ b/trees/fcap-000N.tree
@@ -1,0 +1,27 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Convention}
+\title{Bivector normalizations \citet{Section 2.2.5, Proposition 2.5, p. 33}{meinrenken2013clifford}}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivector_def}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivector_lie_ι}
+
+\p{Meinrenken starts with a symmetric bilinear form #{B} and the relation
+
+##{uv+vu=2B(u,v)1.}
+
+For the associated quadratic form #{Q(v)=B(v,v)}, the polar form used here is #{B_Q=2B}. Therefore Meinrenken's quantization formula and the half-commutator agree:
+
+##{q(u\wedge v)=uv-B(u,v)1
+=\frac12(uv-vu)=:\beta(u,v).}
+
+The induced action on a vector is
+
+##{[\beta(u,v),x]
+=B_Q(v,x)u-B_Q(u,x)v
+=2\bigl(B(v,x)u-B(u,x)v\bigr).}
+
+This is Meinrenken's formula #{-2\iota_{B(x,-)}(u\wedge v)} and Kostant's formula #{-2\iota_x(u\wedge v)} in the corresponding contraction convention \citet{Section 2.4, (12) and Theorem 8, pp. 283, 286}{kostant1997clifford}. The factor of two belongs to the passage from #{B} to the unhalved polar form #{B_Q}; it is not an additional rescaling of #{\beta}.}

--- a/trees/fcap-000O.tree
+++ b/trees/fcap-000O.tree
@@ -1,13 +1,13 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
 
 \taxon{Definition}
-\title{Clifford bivector}
-\lean/tauceti{TauCeti.CliffordAlgebra.bivectorExterior}
-\lean/tauceti{TauCeti.CliffordAlgebra.equivExterior_bivectorExterior}
+\title{Clifford bivector \citet{Section 2.2.5, Proposition 2.5, p. 33}{meinrenken2013clifford}}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivectorExterior,TauCeti.CliffordAlgebra.equivExterior_bivectorExterior}
 
 \p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. The Clifford bivector of #{u,v\in M} is
 

--- a/trees/fcap-000O.tree
+++ b/trees/fcap-000O.tree
@@ -1,0 +1,25 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Definition}
+\title{Clifford bivector}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivectorExterior}
+\lean/tauceti{TauCeti.CliffordAlgebra.equivExterior_bivectorExterior}
+
+\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be an #{R}-module, and let #{Q} be a quadratic form on #{M}. The Clifford bivector of #{u,v\in M} is
+
+##{\beta_Q(u,v)=\frac12\bigl(\iota(u)\iota(v)-\iota(v)\iota(u)\bigr).}
+
+It is alternating in #{u} and #{v}, so it induces a linear map
+
+##{\beta_Q:\bigwedge_R^2M\longrightarrow\Cl(Q).}
+
+The exterior model is a left inverse on its image:
+
+##{\operatorname{equivExterior}_Q\bigl(\beta_Q(z)\bigr)=z
+\qquad (z\in\bigwedge_R^2M).}
+
+Hence #{\beta_Q} is injective.}

--- a/trees/fcap-000P.tree
+++ b/trees/fcap-000P.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000P.tree
+++ b/trees/fcap-000P.tree
@@ -1,0 +1,29 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Lemma}
+\title{A bivector acts by an infinitesimal rotation \citet{Section 2.2.10, Theorem 2.1, pp. 39--40}{meinrenken2013clifford}}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivector_lie_ι}
+
+\p{For #{u,v,x\in M}, the commutator of the bivector with a Clifford generator is
+
+##{[\beta_Q(u,v),\iota(x)]
+=\iota\left(B_Q(v,x)u-B_Q(u,x)v\right).}
+
+The endomorphism
+
+##{A_{u\wedge v}(x)=B_Q(v,x)u-B_Q(u,x)v}
+
+is skew-adjoint for #{B_Q}, since
+
+##{B_Q(A_{u\wedge v}x,y)+B_Q(x,A_{u\wedge v}y)=0.}
+
+Thus commutation by a degree-two Clifford element preserves the generating module and realizes the elementary infinitesimal orthogonal transformation attached to #{u\wedge v}.}
+
+\subtree{
+\taxon{Proof}
+\p{Expand the half-commutator and move #{\iota(x)} past #{\iota(u)} and #{\iota(v)} using the Clifford relation. The cubic terms cancel; the two polar terms combine to the displayed generator. Symmetry of #{B_Q} then makes the skew-adjointness equation cancel in pairs.}
+}

--- a/trees/fcap-000Q.tree
+++ b/trees/fcap-000Q.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -6,8 +7,7 @@
 
 \taxon{Theorem}
 \title{Exterior bivectors are the quadratic Clifford Lie algebra \citet{Section 2.2.10, Theorem 2.1, pp. 39--40}{meinrenken2013clifford}}
-\lean/tauceti{TauCeti.CliffordAlgebra.bivectorExteriorEquivQuadraticLieSubalgebra}
-\lean/tauceti{TauCeti.CliffordAlgebra.bivectorLieEquiv}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivectorExteriorEquivQuadraticLieSubalgebra,TauCeti.CliffordAlgebra.bivectorLieEquiv}
 
 \p{Let #{\mathfrak{cl}^{(2)}(Q)} be the submodule of #{\Cl(Q)} spanned by the elements #{\beta_Q(u,v)}. The commutator formula of \ref{fcap-000P}, together with the Jacobi identity, shows that this submodule is closed under commutators. Transporting its bracket across #{\beta_Q} gives a Lie algebra structure on #{\bigwedge_R^2M} and a Lie equivalence
 

--- a/trees/fcap-000Q.tree
+++ b/trees/fcap-000Q.tree
@@ -1,0 +1,20 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{Exterior bivectors are the quadratic Clifford Lie algebra \citet{Section 2.2.10, Theorem 2.1, pp. 39--40}{meinrenken2013clifford}}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivectorExteriorEquivQuadraticLieSubalgebra}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivectorLieEquiv}
+
+\p{Let #{\mathfrak{cl}^{(2)}(Q)} be the submodule of #{\Cl(Q)} spanned by the elements #{\beta_Q(u,v)}. The commutator formula of \ref{fcap-000P}, together with the Jacobi identity, shows that this submodule is closed under commutators. Transporting its bracket across #{\beta_Q} gives a Lie algebra structure on #{\bigwedge_R^2M} and a Lie equivalence
+
+##{\bigwedge_R^2M\simeq_{\mathrm{Lie}}\mathfrak{cl}^{(2)}(Q).}
+
+On a decomposable bivector the equivalence is exactly
+
+##{u\wedge v\longmapsto\frac12(uv-vu).}
+
+No choice of basis enters this identification.}

--- a/trees/fcap-000R.tree
+++ b/trees/fcap-000R.tree
@@ -1,0 +1,25 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{Quadratic elements realize the orthogonal Lie algebra \citet{Section 2.2.10, Proposition 2.12, p. 40}{meinrenken2013clifford}}
+\lean/tauceti{TauCeti.CliffordAlgebra.soEquivQuadratic}
+\lean/tauceti{TauCeti.CliffordAlgebra.soEquivQuadratic_lie_ι}
+
+\p{Let #{K} be a field of characteristic different from #{2}, let #{V} be finite-dimensional, and let #{Q} be nondegenerate. Write #{\mathfrak{so}(V,B_Q)} for the Lie algebra of endomorphisms skew-adjoint for the polar form. Then commutation on generators gives a Lie equivalence
+
+##{\mathfrak{so}(V,B_Q)\simeq_{\mathrm{Lie}}\mathfrak{cl}^{(2)}(Q).}
+
+If #{A\in\mathfrak{so}(V,B_Q)} corresponds to #{z_A\in\mathfrak{cl}^{(2)}(Q)}, then
+
+##{[z_A,\iota(x)]=\iota(Ax)\qquad(x\in V).}
+
+Combining this equivalence with \ref{fcap-000Q} gives the basis-free chain
+
+##{\bigwedge_K^2V\simeq_{\mathrm{Lie}}\mathfrak{so}(V,B_Q)
+\simeq_{\mathrm{Lie}}\mathfrak{cl}^{(2)}(Q).}
+
+Kostant identifies the same degree-two subspace with #{\operatorname{Lie}(\Spin(V))} and the first equivalence with the differential of the double cover \citet{Section 2.4, Theorem 8, pp. 286--287}{kostant1997clifford}.}

--- a/trees/fcap-000R.tree
+++ b/trees/fcap-000R.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -6,8 +7,7 @@
 
 \taxon{Theorem}
 \title{Quadratic elements realize the orthogonal Lie algebra \citet{Section 2.2.10, Proposition 2.12, p. 40}{meinrenken2013clifford}}
-\lean/tauceti{TauCeti.CliffordAlgebra.soEquivQuadratic}
-\lean/tauceti{TauCeti.CliffordAlgebra.soEquivQuadratic_lie_ι}
+\lean/tauceti{TauCeti.CliffordAlgebra.soEquivQuadratic,TauCeti.CliffordAlgebra.soEquivQuadratic_lie_ι}
 
 \p{Let #{K} be a field of characteristic different from #{2}, let #{V} be finite-dimensional, and let #{Q} be nondegenerate. Write #{\mathfrak{so}(V,B_Q)} for the Lie algebra of endomorphisms skew-adjoint for the polar form. Then commutation on generators gives a Lie equivalence
 

--- a/trees/fcap-000S.tree
+++ b/trees/fcap-000S.tree
@@ -1,13 +1,13 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
 
 \taxon{Example}
-\title{An elementary skew matrix}
-\lean/tauceti{TauCeti.CliffordAlgebra.bivectorEquivSo_apply_ιMulti}
-\lean/tauceti{TauCeti.CliffordAlgebra.bivectorEquivSo_apply_ιMulti_mulVec}
+\title{An elementary skew matrix \citet{Section 2.2.10, Proposition 2.12, p. 40}{meinrenken2013clifford}}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivectorEquivSo_apply_ιMulti,TauCeti.CliffordAlgebra.bivectorEquivSo_apply_ιMulti_mulVec}
 
 \p{Take #{V=R^n} with the standard sum-of-squares quadratic form, and let #{e_i,e_j} be distinct coordinate vectors. Under the standard-coordinate realization,
 
@@ -17,4 +17,4 @@ Thus its action on #{x=(x_k)} is
 
 ##{x\longmapsto 2x_j e_i-2x_i e_j.}
 
-The factor #{2} is the polar-form normalization from \ref{fcap-000N}: for the sum-of-squares form, #{B_Q(x,y)=2\sum_kx_ky_k}. Dividing the skew matrix by two would correspond to using the associated bilinear form #{B_Q/2} instead.}
+The factor #{2} is the polar-form normalization from \ref{fcap-000N}: for the sum-of-squares form, #{B_Q(x,y)=2\sum_kx_ky_k}. The displayed matrix is the standard-coordinate specialization of the basis-free isomorphism in Meinrenken's proposition. Dividing the skew matrix by two would correspond to using the associated bilinear form #{B_Q/2} instead.}

--- a/trees/fcap-000S.tree
+++ b/trees/fcap-000S.tree
@@ -1,0 +1,20 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Example}
+\title{An elementary skew matrix}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivectorEquivSo_apply_ιMulti}
+\lean/tauceti{TauCeti.CliffordAlgebra.bivectorEquivSo_apply_ιMulti_mulVec}
+
+\p{Take #{V=R^n} with the standard sum-of-squares quadratic form, and let #{e_i,e_j} be distinct coordinate vectors. Under the standard-coordinate realization,
+
+##{e_i\wedge e_j\longmapsto 2(E_{ij}-E_{ji}).}
+
+Thus its action on #{x=(x_k)} is
+
+##{x\longmapsto 2x_j e_i-2x_i e_j.}
+
+The factor #{2} is the polar-form normalization from \ref{fcap-000N}: for the sum-of-squares form, #{B_Q(x,y)=2\sum_kx_ky_k}. Dividing the skew matrix by two would correspond to using the associated bilinear form #{B_Q/2} instead.}

--- a/trees/fcap-000T.tree
+++ b/trees/fcap-000T.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000T.tree
+++ b/trees/fcap-000T.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Remark}
+\title{Infinitesimal and global Clifford symmetry}
+
+\p{The quadratic Clifford Lie algebra is the infinitesimal part of the same conjugation action that produces reflections. Kostant proves that #{\bigwedge^2V=\operatorname{Lie}(\Spin(V))}, that its map to #{\mathfrak{so}(V)} is the differential of #{\Spin(V)\to SO(V)}, and that its commutator action extends as the corresponding derivation of the exterior algebra \citet{Section 2.4, Theorem 8, pp. 286--287}{kostant1997clifford}. Chevalley obtains the same two-vector Lie algebra inside the Clifford group \citet{II.2.9, pp. 67--68}{chevalley1954algebraic}.}
+
+\p{The cards above identify the algebraic Lie layer. They do not assert a separately formalized differential of a Lie-group covering map. The next chapter instead reaches the global orthogonal group by finite products of reflections.}

--- a/trees/fcap-000T.tree
+++ b/trees/fcap-000T.tree
@@ -10,4 +10,4 @@
 
 \p{The quadratic Clifford Lie algebra is the infinitesimal part of the same conjugation action that produces reflections. Kostant proves that #{\bigwedge^2V=\operatorname{Lie}(\Spin(V))}, that its map to #{\mathfrak{so}(V)} is the differential of #{\Spin(V)\to SO(V)}, and that its commutator action extends as the corresponding derivation of the exterior algebra \citet{Section 2.4, Theorem 8, pp. 286--287}{kostant1997clifford}. Chevalley obtains the same two-vector Lie algebra inside the Clifford group \citet{II.2.9, pp. 67--68}{chevalley1954algebraic}.}
 
-\p{The cards above identify the algebraic Lie layer. They do not assert a separately formalized differential of a Lie-group covering map. The next chapter instead reaches the global orthogonal group by finite products of reflections.}
+\p{The cards above identify the algebraic Lie layer. They do not construct Lie-group structures or identify a differential of a Lie-group covering map. The next chapter instead reaches the global orthogonal group by finite products of reflections.}

--- a/trees/fcap-000U.tree
+++ b/trees/fcap-000U.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -10,6 +11,7 @@
 \p{One reflection can enlarge the fixed subspace of an orthogonal transformation. Iterating this correction proves that reflections generate the orthogonal group. Once each reflection has a Pin lift, generation becomes surjectivity.}
 
 \transclude{fcap-000V}
+\transclude{fcap-0018}
 \transclude{fcap-000W}
 \transclude{fcap-000X}
 \transclude{fcap-000Y}

--- a/trees/fcap-000U.tree
+++ b/trees/fcap-000U.tree
@@ -1,0 +1,16 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+\tag{notes}
+
+\title{Reflections generate the Pin cover}
+
+\p{One reflection can enlarge the fixed subspace of an orthogonal transformation. Iterating this correction proves that reflections generate the orthogonal group. Once each reflection has a Pin lift, generation becomes surjectivity.}
+
+\transclude{fcap-000V}
+\transclude{fcap-000W}
+\transclude{fcap-000X}
+\transclude{fcap-000Y}
+\transclude{fcap-000Z}

--- a/trees/fcap-000V.tree
+++ b/trees/fcap-000V.tree
@@ -1,0 +1,20 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Lemma}
+\title{One reflection enlarges the fixed subspace \citet{Section 10, pp. 10--12}{cartan1981theory}}
+\lean/tauceti{TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton}
+
+\p{Let #{K} be a separably closed field of characteristic different from #{2}, let #{Q} be a quadratic form on a #{K}-vector space #{V}, and let #{g\in O(V,Q)} fix a subspace #{W} pointwise. Suppose #{x\in W^{\perp}} and #{Q(x)\ne0}. Then there is an orthogonal transformation #{r} in the image of the Pin action such that
+
+##{rg\vert_{W+Kx}=\operatorname{id}.}
+
+The correction leaves the previously fixed space untouched and fixes one additional nonisotropic direction.}
+
+\subtree{
+\taxon{Proof}
+\p{Compare #{x} with #{g(x)}. When their difference is nonisotropic, reflection in that difference carries #{g(x)} to #{x}; because the difference is orthogonal to #{W}, the reflection fixes #{W}. The remaining case is handled by the complementary reflection used in the standard Cartan--Dieudonne step. Over a separably closed field the required reflection normalization has a square root, so \ref{fcap-000B} places the correction in the Pin image.}
+}

--- a/trees/fcap-000V.tree
+++ b/trees/fcap-000V.tree
@@ -1,20 +1,21 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
 
 \taxon{Lemma}
-\title{One reflection enlarges the fixed subspace \citet{Section 10, pp. 10--12}{cartan1981theory}}
-\lean/tauceti{TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton}
+\title{Fixed-subspace correction by reflections \citet{Section 10, pp. 10--12}{cartan1981theory}}
+\lean/tauceti{TauCeti.QuadraticMap.exists_mem_subgroup_mul_eqOn_sup_span_singleton_of_reflection_mem}
 
-\p{Let #{K} be a separably closed field of characteristic different from #{2}, let #{Q} be a quadratic form on a #{K}-vector space #{V}, and let #{g\in O(V,Q)} fix a subspace #{W} pointwise. Suppose #{x\in W^{\perp}} and #{Q(x)\ne0}. Then there is an orthogonal transformation #{r} in the image of the Pin action such that
+\p{Let #{K} be a field of characteristic different from #{2}, let #{Q} be a quadratic form on a #{K}-vector space #{V}, and let #{H\le O(V,Q)} contain every reflection in a nonisotropic vector. Suppose #{g\in O(V,Q)} fixes a subspace #{W} pointwise and #{x\in W^{\perp}} has #{Q(x)\ne0}. Then there is an element #{r\in H} such that
 
 ##{rg\vert_{W+Kx}=\operatorname{id}.}
 
-The correction leaves the previously fixed space untouched and fixes one additional nonisotropic direction.}
+The correction leaves the previously fixed space untouched and fixes one additional nonisotropic direction. It is either one reflection or a product of two reflections.}
 
 \subtree{
 \taxon{Proof}
-\p{Compare #{x} with #{g(x)}. When their difference is nonisotropic, reflection in that difference carries #{g(x)} to #{x}; because the difference is orthogonal to #{W}, the reflection fixes #{W}. The remaining case is handled by the complementary reflection used in the standard Cartan--Dieudonne step. Over a separably closed field the required reflection normalization has a square root, so \ref{fcap-000B} places the correction in the Pin image.}
+\p{Compare #{x} with #{g(x)}. When #{g(x)-x} is nonisotropic, reflection in that difference carries #{g(x)} to #{x}; because the difference is orthogonal to #{W}, the reflection fixes #{W}. In the exceptional case #{g(x)+x} is nonisotropic: reflection in this sum carries #{g(x)} to #{-x}, and reflection in #{x} supplies the second factor. Both factors fix #{W}, so their product gives the required correction.}
 }

--- a/trees/fcap-000W.tree
+++ b/trees/fcap-000W.tree
@@ -1,0 +1,20 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{Cartan--Dieudonne generation \citet{I.2, Theorem 2.7, p. 17}{lawson2016spin}}
+\lean/tauceti{TauCeti.QuadraticMap.subgroup_eq_top_of_reflection_mem}
+
+\p{Let #{K} be a field of characteristic different from #{2}, let #{V} be finite-dimensional, and let #{Q} be nondegenerate. Every orthogonal transformation is a product of at most #{\dim V} reflections in nonisotropic vectors. Equivalently, if a subgroup #{H\le O(V,Q)} contains every such reflection, then
+
+##{H=O(V,Q).}
+
+The parity of the number of reflections records the determinant.}
+
+\subtree{
+\taxon{Proof}
+\p{Begin with the zero fixed subspace. If the current fixed subspace is not all of #{V}, nondegeneracy supplies a nonisotropic vector in its orthogonal complement. The correction step of \ref{fcap-000V} increases the fixed-space dimension by one. Finite-dimensional induction eventually makes the corrected product the identity, expressing the original transformation as a product of reflections. Cartan gives this fixed-vector induction, including the isotropic-difference case, in \citet{Section 10, pp. 10--12}{cartan1981theory}.}
+}

--- a/trees/fcap-000W.tree
+++ b/trees/fcap-000W.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -8,13 +9,13 @@
 \title{Cartan--Dieudonne generation \citet{I.2, Theorem 2.7, p. 17}{lawson2016spin}}
 \lean/tauceti{TauCeti.QuadraticMap.subgroup_eq_top_of_reflection_mem}
 
-\p{Let #{K} be a field of characteristic different from #{2}, let #{V} be finite-dimensional, and let #{Q} be nondegenerate. Every orthogonal transformation is a product of at most #{\dim V} reflections in nonisotropic vectors. Equivalently, if a subgroup #{H\le O(V,Q)} contains every such reflection, then
+\p{Let #{K} be a field of characteristic different from #{2}, let #{V} be finite-dimensional, and let #{Q} be nondegenerate. Every orthogonal transformation is a product of reflections in nonisotropic vectors. Equivalently, if a subgroup #{H\le O(V,Q)} contains every such reflection, then
 
 ##{H=O(V,Q).}
 
-The parity of the number of reflections records the determinant.}
+The displayed subgroup-generation statement is the conclusion witnessed by the Lean annotation. It records neither a sharp bound on the number of reflection factors nor a parity formula for such a factorization.}
 
 \subtree{
 \taxon{Proof}
-\p{Begin with the zero fixed subspace. If the current fixed subspace is not all of #{V}, nondegeneracy supplies a nonisotropic vector in its orthogonal complement. The correction step of \ref{fcap-000V} increases the fixed-space dimension by one. Finite-dimensional induction eventually makes the corrected product the identity, expressing the original transformation as a product of reflections. Cartan gives this fixed-vector induction, including the isotropic-difference case, in \citet{Section 10, pp. 10--12}{cartan1981theory}.}
+\p{Begin with the zero fixed subspace, whose restricted polar form is nondegenerate. If the current nondegenerate fixed subspace is not all of #{V}, its orthogonal complement is nonzero and nondegenerate, hence contains a nonisotropic vector. The correction step of \ref{fcap-000V} enlarges the fixed subspace by that orthogonal line and preserves nondegeneracy. Finite-dimensional induction eventually makes the corrected product the identity, expressing the original transformation as a product of reflections. Cartan gives this fixed-vector induction, including the isotropic-difference case, in \citet{Section 10, pp. 10--12}{cartan1981theory}.}
 }

--- a/trees/fcap-000W.tree
+++ b/trees/fcap-000W.tree
@@ -13,7 +13,7 @@
 
 ##{H=O(V,Q).}
 
-The displayed subgroup-generation statement is the conclusion witnessed by the Lean annotation. It records neither a sharp bound on the number of reflection factors nor a parity formula for such a factorization.}
+This formulation asserts generation only; it records neither a sharp bound on the number of reflection factors nor a parity formula for such a factorization.}
 
 \subtree{
 \taxon{Proof}

--- a/trees/fcap-000X.tree
+++ b/trees/fcap-000X.tree
@@ -1,0 +1,18 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{Surjectivity of the Pin action \citet{I.2, Theorem 2.9, pp. 18--19}{lawson2016spin}}
+\lean/tauceti{TauCeti.CliffordAlgebra.pinToOrthogonal_surjective_of_isSquare}
+\lean/tauceti{TauCeti.CliffordAlgebra.pinToOrthogonal_surjective}
+
+\p{Let #{K}, #{V}, and #{Q} be as in \ref{fcap-000W}. Suppose every scalar #{-Q(v)^{-1}} attached to a nonisotropic vector is a square in #{K}. Then the twisted-adjoint homomorphism is surjective:
+
+##{\operatorname{pinToOrthogonal}:\Pin(V,Q)\twoheadrightarrow O(V,Q).}
+
+Indeed, \ref{fcap-000B} puts every reflection in its range, and \ref{fcap-000W} says that those reflections generate the target. In particular the conclusion holds over a separably closed field.}
+
+\p{Lawson and Michelsohn express the same obstruction by asking whether a nonzero vector can be rescaled to quadratic length #{\pm1}; see (2.26) and the discussion preceding Theorem 2.9.}

--- a/trees/fcap-000X.tree
+++ b/trees/fcap-000X.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
@@ -6,8 +7,7 @@
 
 \taxon{Theorem}
 \title{Surjectivity of the Pin action \citet{I.2, Theorem 2.9, pp. 18--19}{lawson2016spin}}
-\lean/tauceti{TauCeti.CliffordAlgebra.pinToOrthogonal_surjective_of_isSquare}
-\lean/tauceti{TauCeti.CliffordAlgebra.pinToOrthogonal_surjective}
+\lean/tauceti{TauCeti.CliffordAlgebra.pinToOrthogonal_surjective_of_isSquare,TauCeti.CliffordAlgebra.pinToOrthogonal_surjective}
 
 \p{Let #{K}, #{V}, and #{Q} be as in \ref{fcap-000W}. Suppose every scalar #{-Q(v)^{-1}} attached to a nonisotropic vector is a square in #{K}. Then the twisted-adjoint homomorphism is surjective:
 

--- a/trees/fcap-000Y.tree
+++ b/trees/fcap-000Y.tree
@@ -1,0 +1,19 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Example}
+\title{A planar rotation as two reflections}
+\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
+
+\p{In an oriented Euclidean plane, let #{u} and #{v} be unit normals whose directed angle is #{\frac{\theta}{2}}. Reflection in #{u^{\perp}} followed by reflection in #{v^{\perp}} is rotation through #{\theta}. With the convention #{Q=-\langle-,-\rangle}, both vectors have #{Q=-1}, and
+
+##{s=\iota(v)\iota(u)\in\Spin(V,Q)}
+
+lifts that rotation. In an oriented orthonormal basis #{e_1,e_2}, the familiar rotor form is
+
+##{\pm s=\cos\left(\frac{\theta}{2}\right)+\sin\left(\frac{\theta}{2}\right)\,\iota(e_1)\iota(e_2),}
+
+after choosing the central sign and the order convention for the two reflections. The half-angle appears because the Spin element acts by conjugation on vectors.}

--- a/trees/fcap-000Y.tree
+++ b/trees/fcap-000Y.tree
@@ -7,7 +7,6 @@
 
 \taxon{Example}
 \title{A planar rotation as two reflections \citet{I.2, (2.24)--(2.26), p. 18}{lawson2016spin}}
-\lean/tauceti{TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
 
 \p{In an oriented Euclidean plane, let #{u} and #{v} be unit normals whose directed angle is #{\frac{\theta}{2}}. Reflection in #{u^{\perp}} followed by reflection in #{v^{\perp}} is rotation through #{\theta}. With the convention #{Q=-\langle-,-\rangle}, both vectors have #{Q=-1}, and
 

--- a/trees/fcap-000Y.tree
+++ b/trees/fcap-000Y.tree
@@ -1,11 +1,12 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
 
 \taxon{Example}
-\title{A planar rotation as two reflections}
+\title{A planar rotation as two reflections \citet{I.2, (2.24)--(2.26), p. 18}{lawson2016spin}}
 \lean/tauceti{TauCeti.CliffordAlgebra.reflection_mul_reflection_mem_range_spinToOrthogonal_of_isSquare}
 
 \p{In an oriented Euclidean plane, let #{u} and #{v} be unit normals whose directed angle is #{\frac{\theta}{2}}. Reflection in #{u^{\perp}} followed by reflection in #{v^{\perp}} is rotation through #{\theta}. With the convention #{Q=-\langle-,-\rangle}, both vectors have #{Q=-1}, and
@@ -16,4 +17,4 @@ lifts that rotation. In an oriented orthonormal basis #{e_1,e_2}, the familiar r
 
 ##{\pm s=\cos\left(\frac{\theta}{2}\right)+\sin\left(\frac{\theta}{2}\right)\,\iota(e_1)\iota(e_2),}
 
-after choosing the central sign and the order convention for the two reflections. The half-angle appears because the Spin element acts by conjugation on vectors.}
+after choosing the central sign and the order convention for the two reflections. This is the two-dimensional specialization of the paired lift in \ref{fcap-000C}; the half-angle appears because the Spin element acts by conjugation on vectors.}

--- a/trees/fcap-000Z.tree
+++ b/trees/fcap-000Z.tree
@@ -1,4 +1,5 @@
 \import{spin-macros}
+\meta{agent-authored}{true}
 
 \tag{fcap}
 \tag{spin}

--- a/trees/fcap-000Z.tree
+++ b/trees/fcap-000Z.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Remark}
+\title{Boundary of the covering statement}
+
+\p{Surjectivity of #{\Pin(V,Q)\to O(V,Q)} uses reflection generation and the ability to normalize every reflecting vector. It does not compute the kernel, identify a short exact sequence, or introduce the spinor norm. Kostant's classical complex theorem has kernel #{\{\pm1\}} and identifies #{\Spin(V)} as a double cover of #{SO(V)} \citet{Section 2.3, Proposition 1, pp. 282--283}{kostant1997clifford}; those additional conclusions require their own hypotheses and arguments.}
+
+\p{Likewise, the even product in \ref{fcap-000Y} is a specific Spin lift. No general surjectivity assertion for the Spin action is used here.}

--- a/trees/fcap-0010.tree
+++ b/trees/fcap-0010.tree
@@ -1,0 +1,21 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+\tag{notes}
+
+\title{Hyperbolic recurrence and real signatures}
+
+\p{A positive and a negative generator form a hyperbolic plane. Adjoining that plane tensors the Clifford algebra with two-by-two real matrices. Iteration removes the common part of a real signature and isolates its one-sided remainder.}
+
+\related{\ref{ca-0001}}
+
+\transclude{fcap-0011}
+\transclude{fcap-0012}
+\transclude{fcap-0013}
+\transclude{fcap-0014}
+\transclude{fcap-0015}
+\transclude{fcap-0016}
+\transclude{fcap-0017}

--- a/trees/fcap-0011.tree
+++ b/trees/fcap-0011.tree
@@ -1,0 +1,22 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Convention}
+\title{Real signature and Clifford signs \citet{II.2.9, pp. 65--66}{chevalley1954algebraic}}
+\lean/tauceti{TauCeti.realCliffordForm,TauCeti.realCliffordForm_apply}
+
+\p{For #{p,q\ge0}, put
+
+##{Q_{p,q}(x)=\sum_{i<p}x_i^2-\sum_{p\le i<p+q}x_i^2}
+
+on #{\mathbb{R}^{p+q}}, and write #{\Cl_{p,q}} for #{\Cl(Q_{p,q})}. Thus the first #{p} Clifford generators square to #{+1}, and the last #{q} square to #{-1}. This agrees with Chevalley's convention for the quadratic form and with his positive/negative inertia indices.}
+
+\p{Lawson and Michelsohn use the same signature #{q_{r,s}} but impose #{v^2=-q_{r,s}(v)1} \citet{I.3, Proposition 3.1, p. 21}{lawson2016spin}. Therefore the algebras are related by the exact index swap
+
+##{\Cl_{p,q}=\Cl^{\mathrm{Lawson}}_{q,p}.}
+
+The recurrence below adds one index of each sign, so it is invariant under this swap.}

--- a/trees/fcap-0012.tree
+++ b/trees/fcap-0012.tree
@@ -1,0 +1,25 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Definition}
+\title{The hyperbolic plane \citet{I.4, Theorem 4.1 and (4.3), pp. 25--26}{lawson2016spin}}
+\lean/tauceti{TauCeti.realCliffordForm_one_one_apply,TauCeti.realBottSplitIsometry}
+
+\p{The real hyperbolic plane is
+
+##{H=(\mathbb{R}^2,Q_{1,1}),\qquad Q_{1,1}(s,t)=s^2-t^2.}
+
+Its coordinate generators #{e_+} and #{e_-} satisfy
+
+##{e_+^2=1,\qquad e_-^2=-1,\qquad e_+e_-=-e_-e_+.}
+
+For every signature, separating the last positive and negative coordinates gives an isometry
+
+##{(\mathbb{R}^{p+q+2},Q_{p+1,q+1})
+\simeq(\mathbb{R}^{p+q},Q_{p,q})\perp H.}
+
+The coordinate order is fixed: the retained #{p} positive and #{q} negative axes form the first factor, and the last positive and last negative axes form #{H}.}

--- a/trees/fcap-0013.tree
+++ b/trees/fcap-0013.tree
@@ -1,0 +1,47 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{The hyperbolic matrix recurrence \citet{I.4, Theorem 4.1, (4.3), pp. 25--26}{lawson2016spin}}
+\lean/tauceti{TauCeti.CliffordAlgebra.hyperbolicEquivTensor,TauCeti.realCliffordBottEquiv_ι}
+
+\p{For all #{p,q\ge0}, adjoining a hyperbolic plane gives an algebra equivalence
+
+##{\Cl_{p+1,q+1}\simeq_{\mathbb{R}\text{-alg}}
+\Cl_{p,q}\otimes_{\mathbb{R}}M_2(\mathbb{R}).}
+
+More generally, for any real quadratic module #{(M,Q)},
+
+##{\Cl(Q\perp Q_{1,1})\simeq
+\Cl(Q)\otimes_{\mathbb{R}}M_2(\mathbb{R}).}
+
+With
+
+##{\sigma_x=\begin{pmatrix}0&1\\1&0\end{pmatrix},}
+
+the equivalence sends a generator #{(m,(s,t))} to
+
+##{\iota_Q(m)\otimes\sigma_x
++1\otimes\begin{pmatrix}s&t\\-t&-s\end{pmatrix}.}
+
+The first summand squares to #{Q(m)}, the second to #{s^2-t^2}, and the two anticommute. The universal property therefore gives the forward algebra map. In the other direction, the original Clifford algebra and the matrix algebra act through commuting algebra maps on the hyperbolic Clifford algebra; their tensor lift is inverse to the forward map. The two composites are checked on Clifford generators and pure tensors, so no finite-dimensional hypothesis is used. Chevalley's split-matrix theorem and orthogonal-sum calculation supply the same structural mechanism \citet{II.2.1 and II.2.5, pp. 42--46}{chevalley1954algebraic}.}
+
+\p{Writing the displayed generator formula as #{f}, its universal extension is summarized by the commuting diagram
+
+\tikzfig{
+\begin{tikzcd}[column sep=large]
+M\oplus\mathbb{R}^{1,1}
+  \arrow[r,"\iota_{Q\perp Q_{1,1}}"]
+  \arrow[d,"f"']
+& \Cl(Q\perp Q_{1,1})
+  \arrow[d,"\Phi"] \\
+\Cl(Q)\otimes M_2(\mathbb{R})
+  \arrow[r,equal]
+& \Cl(Q)\otimes M_2(\mathbb{R}).
+\end{tikzcd}
+}
+}

--- a/trees/fcap-0014.tree
+++ b/trees/fcap-0014.tree
@@ -1,0 +1,28 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Lemma}
+\title{Finite hyperbolic reduction \citet{II.2.9, pp. 65--66}{chevalley1954algebraic}}
+\lean/tauceti{TauCeti.realCliffordBottIterEquiv,TauCeti.realCliffordSignatureReductionEquiv}
+
+\p{Iterating \ref{fcap-0013} #{n} times gives
+
+##{\Cl_{p+n,q+n}\simeq
+\Cl_{p,q}\otimes_{\mathbb{R}}M_{2^n}(\mathbb{R}).}
+
+Taking #{n=\min(p,q)} removes the common positive and negative part:
+
+##{\Cl_{p,q}\simeq
+\Cl_{p-n,q-n}\otimes_{\mathbb{R}}M_{2^n}(\mathbb{R}),
+\qquad n=\min(p,q).}
+
+Thus if #{p\le q}, the residual algebra is #{\Cl_{0,q-p}}; if #{q\le p}, it is #{\Cl_{p-q,0}}. The matrix factors combine through the Kronecker equivalence
+
+##{M_{2^a}(\mathbb{R})\otimes M_{2^b}(\mathbb{R})
+\simeq M_{2^{a+b}}(\mathbb{R}).}
+
+Chevalley describes the same reduction by splitting off a maximal hyperbolic part and a definite remainder.}

--- a/trees/fcap-0015.tree
+++ b/trees/fcap-0015.tree
@@ -1,0 +1,25 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Example}
+\title{The first four real Clifford algebras \citet{I.4, Theorem 4.3 and Tables I--II, pp. 27--29}{lawson2016spin}}
+\lean/tauceti{TauCeti.realCliffordOneZeroEquivProd,TauCeti.realCliffordZeroOneEquivComplex,TauCeti.realCliffordOneOneEquivMatrix}
+
+\p{The signature convention of \ref{fcap-0011} gives
+
+##{\Cl_{0,0}\simeq\mathbb{R},\qquad
+\Cl_{1,0}\simeq\mathbb{R}\times\mathbb{R},\qquad
+\Cl_{0,1}\simeq\mathbb{C},\qquad
+\Cl_{1,1}\simeq M_2(\mathbb{R}).}
+
+For #{\Cl_{1,1}}, the positive and negative generators may be represented by
+
+##{e_+\longmapsto\begin{pmatrix}1&0\\0&-1\end{pmatrix},
+\qquad
+e_-\longmapsto\begin{pmatrix}0&1\\-1&0\end{pmatrix}.}
+
+Their squares are #{+I} and #{-I}, and they anticommute. The last equivalence is also the case #{p=q=0} of \ref{fcap-0013}. The index swap in \ref{fcap-0011} explains why Lawson's one-generator table lists #{\mathbb{C}} and #{\mathbb{R}\times\mathbb{R}} in the opposite order.}

--- a/trees/fcap-0016.tree
+++ b/trees/fcap-0016.tree
@@ -1,0 +1,11 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Remark}
+\title{What the recurrence does not classify}
+
+\p{Hyperbolic reduction determines the matrix factor coming from matched positive and negative axes. It leaves a one-sided algebra #{\Cl_{r,0}} or #{\Cl_{0,r}}. Classifying those residual algebras and arranging them into the mod-eight table requires additional base cases and periodicity identifications; it is not a consequence of the single #{(1,1)} recurrence. Lawson and Michelsohn give the full classical table in \citet{I.4, Theorem 4.3 and Tables I--II, pp. 27--29}{lawson2016spin}.}

--- a/trees/fcap-0017.tree
+++ b/trees/fcap-0017.tree
@@ -1,0 +1,15 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Remark}
+\title{From Clifford algebras to spin modules}
+
+\p{The next mathematical step chooses complementary maximal isotropic subspaces #{W,W'} in a nondegenerate quadratic space. Clifford multiplication then acts on #{\bigwedge W} by exterior multiplication from #{W} and contraction from #{W'}, making #{\bigwedge W} a spin module. Chevalley constructs this model in \citet{II.2.1--II.2.2, pp. 42--44}{chevalley1954algebraic}.}
+
+\p{Panyushev writes #{\operatorname{Spin}(V)=\bigwedge W} and relates the full exterior algebra to the square of the spin module; for a hyperbolic module #{W\oplus W^*}, the result is an exterior algebra up to a one-dimensional weight twist \citet{Section 2, (2.1), Proposition 2.4, and Example 2.5(3), pp. 7--8}{panyushev2001exterior}. Kostant then lifts an orthogonal Lie representation into quadratic Clifford elements and lets those elements act on a spin module \citet{Sections 2.5 and 3.1, pp. 289, 294--297}{kostant1997clifford}.}
+
+\p{These representation-theoretic constructions are the horizon of the present notes. No polarization-dependent module, irreducibility theorem, character formula, or isotypic decomposition is asserted here.}

--- a/trees/fcap-0018.tree
+++ b/trees/fcap-0018.tree
@@ -1,0 +1,16 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Lemma}
+\title{Pin-range refinement of the correction \citet{Section 10, pp. 10--12}{cartan1981theory}; \citet{I.2, (2.26) and Theorem 2.9, pp. 18--19}{lawson2016spin}}
+\lean/tauceti{TauCeti.CliffordAlgebra.exists_mem_range_pinToOrthogonal_mul_eqOn_sup_span_singleton}
+
+\p{Under the hypotheses of \ref{fcap-000V}, suppose moreover that #{K} is separably closed and take #{H} to be the range of the Pin action. Every reflection factor used by the correction has a square-normalized Pin lift by \ref{fcap-000B}. The correcting element #{r} can therefore be chosen in
+
+##{\operatorname{range}(\operatorname{pinToOrthogonal}),}
+
+and still satisfies #{rg\vert_{W+Kx}=\operatorname{id}}. The statement concerns the correcting element in the Pin-action range; in the exceptional case it is the image of a product of two Pin lifts, not the image of a single reflecting vector.}

--- a/trees/refs/cartan1981theory.tree
+++ b/trees/refs/cartan1981theory.tree
@@ -1,0 +1,15 @@
+% ["forest"]
+\title{The theory of spinors}
+\date{1981}
+\author/literal{Elie Cartan}
+\taxon{Reference}
+
+\meta{bibtex}{\startverb
+@book{cartan1981theory,
+ title = {The Theory of Spinors},
+ author = {Cartan, Elie},
+ translator = {Streater, Raymond F.},
+ year = {1981},
+ publisher = {Dover Publications}
+}
+\stopverb}

--- a/trees/refs/chevalley1954algebraic.tree
+++ b/trees/refs/chevalley1954algebraic.tree
@@ -1,0 +1,14 @@
+% ["forest"]
+\title{The algebraic theory of spinors}
+\date{1954}
+\author/literal{Claude Chevalley}
+\taxon{Reference}
+
+\meta{bibtex}{\startverb
+@book{chevalley1954algebraic,
+ title = {The Algebraic Theory of Spinors},
+ author = {Chevalley, Claude},
+ year = {1954},
+ publisher = {Columbia University Press}
+}
+\stopverb}

--- a/trees/refs/kostant1997clifford.tree
+++ b/trees/refs/kostant1997clifford.tree
@@ -1,0 +1,18 @@
+% ["forest"]
+\title{Clifford algebra analogue of the Hopf--Koszul--Samelson theorem}
+\date{1997}
+\author/literal{Bertram Kostant}
+\taxon{Reference}
+
+\meta{bibtex}{\startverb
+@article{kostant1997clifford,
+ title = {Clifford Algebra Analogue of the Hopf--Koszul--Samelson Theorem},
+ author = {Kostant, Bertram},
+ year = {1997},
+ journal = {Advances in Mathematics},
+ volume = {125},
+ number = {2},
+ pages = {275--350},
+ doi = {10.1006/aima.1997.1602}
+}
+\stopverb}

--- a/trees/refs/panyushev2001exterior.tree
+++ b/trees/refs/panyushev2001exterior.tree
@@ -1,0 +1,17 @@
+% ["forest"]
+\title{The exterior algebra and Spin of an orthogonal g-module}
+\date{2001}
+\author/literal{Dmitri I. Panyushev}
+\taxon{Reference}
+
+\meta{bibtex}{\startverb
+@article{panyushev2001exterior,
+ title = {The Exterior Algebra and `Spin' of an Orthogonal g-Module},
+ author = {Panyushev, Dmitri I.},
+ year = {2001},
+ journal = {Transformation Groups},
+ volume = {6},
+ number = {1},
+ pages = {51--77}
+}
+\stopverb}


### PR DESCRIPTION
## Summary

- completes the grounded SpinRep appendix as four connected chapters: Clifford filtration/PBW, bivectors and the orthogonal Lie algebra, reflections and the Pin cover, and hyperbolic real recurrence
- rewrites the recent FCAP notes into mathematical Definition, Convention, Lemma, Theorem, Example, and Remark cards in the established CA/TT style
- grounds every mathematical card in registered scholarly sources and attaches Mathlib or TauCeti declaration markers wherever a matching formalization exists
- adds one vector commuting diagram for the hyperbolic recurrence and uses invisible `\related` links back to the protected CA root
- marks all 44 new or reworked FCAP trees as agent-authored without changing protected CA/TT trees

## Verification

- `just chk`
- full `just build` across 1,146 XML files
- 23-page PDF build and complete contact-sheet inspection
- 51 clickable Lean-badge annotations in the PDF, resolving to 46 unique targets: 37 TauCeti and 9 default-provider targets
- all 37 TauCeti declarations checked on upstream `main` and the live documentation resolver
- no overfull/underfull boxes, missing glyphs, or undefined references/citations in the final PDF pass
- browser QA of real theorem/example cards with the agent-authored watermark

## Renderer boundary

This content PR does not include renderer changes. Final evidence was rendered by temporarily overlaying exact heads from #84 (`e45721b960d7`) and #87 (`6d59456424d6`), then removing those files before push. The content tree builds without those overlays, but contextual taxon links and the visible web watermark require the corresponding renderer work.

## Explicit limits

- no protected CA/TT source was edited
- no complete Spin double-cover exact sequence, spin representation, irreducibility, character formula, or full real periodicity classification is claimed
- four inherited FCAP-local declarations still use the default Mathlib provider even though they are not Mathlib declarations; this PR preserves that existing metadata and does not invent a provider
- persistent duplicate-destination warnings from the generated multi-pass LaTeX document remain a renderer baseline; the final pass has no content overflow or undefined-reference warnings
