### PR TITLE
fix: make Lean marker lists responsive

### DIFF
--- a/assets/uts-overrides.xsl
+++ b/assets/uts-overrides.xsl
@@ -78,7 +78,7 @@
     </xsl:template>
 
     <xsl:template match="fr:meta[@name='lean']">
-        <span class="meta-lean">
+        <span class="meta-lean" tabindex="0" aria-label="Lean formalization links">
             <div class="meta-lean-list">
                 <xsl:call-template name="splitlean">
                     <xsl:with-param name="pText" select="." />
@@ -92,7 +92,7 @@
     </xsl:template>
 
     <xsl:template match="fr:meta[@name='lean-tauceti']">
-        <span class="meta-lean">
+        <span class="meta-lean" tabindex="0" aria-label="Lean formalization links">
             <div class="meta-lean-list">
                 <xsl:call-template name="splitlean">
                     <xsl:with-param name="pText" select="." />

--- a/bun/uts-style.css
+++ b/bun/uts-style.css
@@ -650,13 +650,11 @@ nav#toc li.active {
 } */
 
 .meta-lean {
-    display: block;
+    display: inline-block;
     float: right;
-    height: 4em;
-    width: 4vw;
     cursor: pointer;
     position: relative;
-    z-index: 1;
+    z-index: 2;
 }
 
 /* clearfix hack */
@@ -722,22 +720,47 @@ nav#toc li.active {
 }
 
 .meta-lean-list {
+    box-sizing: border-box;
     display: none;
     visibility: hidden;
+    width: max-content;
+    max-width: min(42rem, calc(100vw - 4rem));
+    margin-left: auto;
+    padding: 0.5rem;
+    border: 1px solid var(--uts-text-gentle);
+    border-radius: 5px;
+    background: var(--uts-background);
+    box-shadow: 0 0.25rem 0.75rem rgb(0 0 0 / 15%);
 }
 
-.meta-lean:hover .meta-lean-list {
+.meta-lean:hover .meta-lean-list,
+.meta-lean:focus-within .meta-lean-list {
     display: block;
     visibility: visible;
 }
 
-.meta-lean-list:hover {
+.meta-lean-list a {
     display: block;
-    visibility: visible;
+    float: none;
+    max-width: 100%;
+    margin: 0;
+    overflow-wrap: anywhere;
+    word-break: normal;
 }
 
-.meta-lean:hover .meta-lean-symbol {
-    visibility: hidden;
+.meta-lean-list a + a {
+    margin-top: 0.5rem;
+}
+
+.meta-lean:hover .meta-lean-symbol,
+.meta-lean:focus-within .meta-lean-symbol {
+    display: none;
+}
+
+/* AGENT-NOTE: Keep the expanded marker list in flow and clear card content below it. */
+details:has(> summary .meta-lean:hover) > summary + *,
+details:has(> summary .meta-lean:focus-within) > summary + * {
+    clear: both;
 }
 
 .related {


### PR DESCRIPTION
## Summary

- replace the fixed `4vw` Lean-marker hover target with a content-sized, viewport-bounded declaration list
- keep the expanded list in document flow so it does not cover the card body
- preserve exact Mathlib and TauCeti documentation links while adding keyboard-focus access

## Verification

- `xmllint --noout assets/uts-overrides.xsl`
- `just chk`
- full `just build` across 1,040 XML files
- real Chromium checks at 1440×900 and 390×844
- verified no horizontal overflow, no popup/body intersection, readable multi-line long declarations, preserved targets, and focus-triggered visibility

This PR targets `main` directly and contains only the general web renderer fix.