### PR TITLE
feat(render): separate inline Lean declaration references

### DIFF
--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -232,6 +232,13 @@
     <xsl:apply-templates />
     <!-- <xsl:text>}</xsl:text> -->
   </xsl:template>
+
+  <!-- AGENT-NOTE: Inline declaration links need paragraph-level TeX flexibility to avoid overfull boxes. -->
+  <xsl:template match="html:p[descendant::html:span[@class='lean-ref']]">
+    <xsl:text>\par{}\begingroup\sloppy{}</xsl:text>
+    <xsl:apply-templates />
+    <xsl:text>\par\endgroup</xsl:text>
+  </xsl:template>
   
   <xsl:template match="html:strong">
     <xsl:text>\textbf{</xsl:text>
@@ -360,6 +367,15 @@
     <xsl:text>}{</xsl:text>
     <xsl:apply-templates />
     <xsl:text>}</xsl:text>
+  </xsl:template>
+
+  <!-- AGENT-NOTE: Inline Lean references need URL-style breakpoints while preserving one clickable link. -->
+  <xsl:template match="html:span[@class='lean-ref']">
+    <xsl:text>\href{</xsl:text>
+    <xsl:value-of select="f:link/@href" />
+    <xsl:text>}{\leanref{</xsl:text>
+    <xsl:value-of select="f:link/html:code" />
+    <xsl:text>}}</xsl:text>
   </xsl:template>
   
   <xsl:template match="f:contextual-number">

--- a/tex/code.tex
+++ b/tex/code.tex
@@ -2,6 +2,16 @@
 \usepackage{fontspec}
 \newfontfamily\codefont{Noto Sans Mono}[Scale=MatchLowercase]
 
+% AGENT-NOTE: Lean references need Unicode-safe monospace text with URL-style line breaks.
+\DeclareRobustCommand{\leanref}[1]{%
+  \begingroup
+  \def\UrlFont{\codefont\footnotesize}%
+  \def\UrlBreakPenalty{0}%
+  \def\UrlBigBreakPenalty{0}%
+  \nolinkurl{#1}%
+  \endgroup
+}
+
 \definecolor{leanmarkerborder}{HTML}{7A7A72}
 \definecolor{leanmarkerbackground}{HTML}{F7F7F4}
 \DeclareRobustCommand{\leanmarker}[1]{%

--- a/trees/spin-macros.tree
+++ b/trees/spin-macros.tree
@@ -34,7 +34,7 @@
 
 \def\href[url][t]{[\t](\url)}
 \def\Mathlib{#{\textsf{Mathlib}}}
-\def\MathlibDoc[x]{[\x](https://leanprover-community.github.io/mathlib4_docs/find/#docs/\x)}
+\def\MathlibDoc[x]{[\x](https://leanprover-community.github.io/mathlib4_docs/find/#doc/\x)}
 
 \def\bu{\bullet}
 \def\ii{\item}
@@ -46,10 +46,13 @@
 \def\label[x]{}
 \def\leanok{}
 % AGENT-NOTE: Keep provider meta names aligned with the web and PDF XSL templates.
+% AGENT-NOTE: lean variants are card metadata; leanref variants are inline declaration links.
 % https://leanprover-community.github.io/mathlib4_docs/find/#doc/
 \def\lean[x]{\meta{lean}{\x}}
+\def\leanref[x]{\<html:span>[class]{lean-ref}{[\code{\x}](https://leanprover-community.github.io/mathlib4_docs/find/#doc/\x)}}
 % https://taucetiproject.github.io/TauCeti/docs/find/#doc/
 \def\lean/tauceti[x]{\meta{lean-tauceti}{\x}}
+\def\leanref/tauceti[x]{\<html:span>[class]{lean-ref}{[\code{\x}](https://taucetiproject.github.io/TauCeti/docs/find/#doc/\x)}}
 \def\uses[x]{}
 
 \def\cite[x]{\citek{\x}}


### PR DESCRIPTION
## Summary

- keep `\lean` and `\lean/tauceti` exclusively as card-level formalization metadata
- add `\leanref` and `\leanref/tauceti` for inline Mathlib and TauCeti declaration references
- render inline references as Unicode-safe, line-breakable, clickable code in PDF
- correct the legacy `\MathlibDoc` resolver fragment from `#docs/` to `#doc/`

## Verification

- `just chk`
- full `just build` across 1,041 XML files
- `xmllint --noout assets/latex.xsl`
- real Chromium desktop and 390 px mobile checks: zero horizontal overflow, natural inline wrapping, exact provider URLs
- one-page LuaLaTeX fixture: no overfull/underfull boxes, missing glyphs, or LaTeX errors
- PDF annotation audit: one Mathlib and two wrapped TauCeti link rectangles, all retaining their provider targets
- live resolver checks reach the exact Mathlib and TauCeti declaration pages

The renderer fixture and its generated artifacts were used only for verification and are not part of the PR.
