### PR TITLE
fix(build): publish the FGAP note PDF [AGENT]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -224,6 +224,8 @@ function lize {
     show_lize_result hopf-0001
     ./lize.sh ca-0001 # >/dev/null # 2>&1
     show_lize_result ca-0001
+    ./lize.sh fgap-0001 # >/dev/null # 2>&1
+    show_lize_result fgap-0001
     ./lize.sh fcap-0001 # >/dev/null # 2>&1
     show_lize_result fcap-0001
     ./lize.sh tt-0001 # >/dev/null # 2>&1


### PR DESCRIPTION
## Summary

- add `fgap-0001` to the CI LaTeX root set
- make the existing web PDF button resolve to a deployed PDF
- keep this follow-up isolated from the in-progress FCAP Pages run

## Verification

- `bash -n build.sh`
- `just chk`
- direct `./lize.sh fgap-0001` render
- 30-page PDF with 28 URL annotations and embedded fonts
- no fatal LaTeX errors or unresolved citations in the final log

This PR is authorized to land, but will remain unmerged until the current FCAP deployment finishes and is verified.
