### PR TITLE
fix(index): isolate agent-authored math drafts

### DIFF
--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -6,6 +6,8 @@
 
 \tag{notes}
 \tag{math}
+\tag{draft}
+\tag{agent-draft}
 \tag{fcap}
 \tag{clifford}
 

--- a/trees/fcap-0002.tree
+++ b/trees/fcap-0002.tree
@@ -3,7 +3,6 @@
 
 \tag{fcap}
 \tag{clifford}
-\tag{notes}
 \tag{draft}
 
 \title{Coordinate representations}

--- a/trees/fcap-0007.tree
+++ b/trees/fcap-0007.tree
@@ -4,7 +4,6 @@
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
-\tag{notes}
 
 \title{Reflections and square-normalized Clifford lifts}
 

--- a/trees/fcap-000F.tree
+++ b/trees/fcap-000F.tree
@@ -4,7 +4,6 @@
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
-\tag{notes}
 
 \title{The exterior shadow of a Clifford algebra}
 

--- a/trees/fcap-000M.tree
+++ b/trees/fcap-000M.tree
@@ -4,7 +4,6 @@
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
-\tag{notes}
 
 \title{Bivectors and the orthogonal Lie algebra}
 

--- a/trees/fcap-000U.tree
+++ b/trees/fcap-000U.tree
@@ -4,7 +4,6 @@
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
-\tag{notes}
 
 \title{Reflections generate the Pin cover}
 

--- a/trees/fcap-0010.tree
+++ b/trees/fcap-0010.tree
@@ -4,7 +4,6 @@
 \tag{fcap}
 \tag{spin}
 \tag{clifford}
-\tag{notes}
 
 \title{Hyperbolic recurrence and real signatures}
 

--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -7,6 +7,8 @@
 
 \tag{notes}
 \tag{math}
+\tag{draft}
+\tag{agent-draft}
 \tag{fgap}
 \tag{group-algebra}
 \tag{quaternion}

--- a/trees/fgap-0007.tree
+++ b/trees/fgap-0007.tree
@@ -5,7 +5,6 @@
 
 \title{Quaternion and order-three subgroups}
 
-\tag{notes}
 \tag{math}
 \tag{fgap}
 \tag{group-action}

--- a/trees/fgap-000E.tree
+++ b/trees/fgap-000E.tree
@@ -5,7 +5,6 @@
 
 \title{From the Hurwitz action to the binary tetrahedral group}
 
-\tag{notes}
 \tag{math}
 \tag{fgap}
 \tag{group}

--- a/trees/fgap-000M.tree
+++ b/trees/fgap-000M.tree
@@ -4,7 +4,6 @@
 
 \title{Finite tests for a topos layer}
 
-\tag{notes}
 \tag{math}
 \tag{fgap}
 \tag{group-algebra}

--- a/trees/fgap-000V.tree
+++ b/trees/fgap-000V.tree
@@ -4,7 +4,6 @@
 
 \title{Central involutions and complementary summands}
 
-\tag{notes}
 \tag{math}
 \tag{fgap}
 \tag{group-algebra}

--- a/trees/fgap-0019.tree
+++ b/trees/fgap-0019.tree
@@ -4,7 +4,6 @@
 
 \title{Quaternion and Hurwitz foundations}
 
-\tag{notes}
 \tag{math}
 \tag{fgap}
 \tag{quaternion}

--- a/trees/fgap-001A.tree
+++ b/trees/fgap-001A.tree
@@ -4,7 +4,6 @@
 
 \title{Appendix}
 
-\tag{notes}
 \tag{math}
 \tag{fgap}
 
@@ -12,3 +11,4 @@
 quaternionic and Group-Algebra spine.}
 
 \transclude{fgap-000M}
+\transclude{fgap-001F}

--- a/trees/fgap-001C.tree
+++ b/trees/fgap-001C.tree
@@ -4,7 +4,6 @@
 
 \title{Real blocks of the quaternion Group Algebra}
 
-\tag{notes}
 \tag{math}
 \tag{fgap}
 \tag{group-algebra}

--- a/trees/fgap-001F.tree
+++ b/trees/fgap-001F.tree
@@ -5,7 +5,6 @@
 \title{Models and routes from binary tetrahedral structure}
 \meta{pdf}{true}
 
-\tag{notes}
 \tag{math}
 \tag{fgap}
 \tag{group-algebra}

--- a/trees/index.tree
+++ b/trees/index.tree
@@ -13,6 +13,8 @@
 
 \transclude{uts-000U}
 
+\transclude{uts-016Q}
+
 \scope{
   \put\transclude/expanded{false}
   \transclude{uts-000V}
@@ -24,6 +26,5 @@
 }
 
 \transclude{uts-0168}
-
 
 

--- a/trees/uts-016Q.tree
+++ b/trees/uts-016Q.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Math notes (agent drafts)}
+
+\scope{
+  \put\transclude/expanded{false}
+  \query\datalog{
+    ?X -:
+      {\rel/has-tag ?X '{math}}
+      {\rel/has-tag ?X '{notes}}
+      {\rel/has-tag ?X '{agent-draft}}
+  }
+}


### PR DESCRIPTION
## Summary

- add a dedicated `Math notes (agent drafts)` index under Home
- classify only `fgap-0001` and `fcap-0001` as agent-draft roots
- remove root-note classification from all FGAP/FCAP component trees
- keep components in their project storylines, including placing `fgap-001F` in the FGAP appendix
- exclude the two draft roots from `Math notes (partially complete)` through the existing `draft` status contract

## Classification contract

- `\meta{agent-authored}{true}` remains provenance for the visible watermark
- `\tag{agent-draft}` selects the two project roots for the new index
- `\tag{notes}` remains only on those two roots; descendants are nursery trees reached through their storyline

## Verification

- `just chk`
- full `just build`
- XPath assertions: old math index has no FGAP/FCAP root; new index has exactly `fcap-0001` and `fgap-0001`
- source reachability audit: every reclassified component has an inbound storyline transclusion
- Chromium desktop QA: both project roots render as collapsed cards under the new section
