### PR TITLE
fix(index): keep agent drafts in their own section

### DIFF
--- a/trees/uts-000V.tree
+++ b/trees/uts-000V.tree
@@ -6,5 +6,6 @@
         {\rel/has-tag ?X '{math}}
         {\rel/has-tag ?X '{notes}}
         {\rel/has-tag ?X '{draft}}
+        # {\rel/has-tag ?X '{agent-draft}}
     }
 }


### PR DESCRIPTION
## Summary

Exclude `agent-draft` roots from the legacy `Math notes (early drafts)` query.

This completes the #94 classification contract: `Math notes (agent drafts)` is the sole query transcluding `fgap-0001` and `fcap-0001`.

## Verification

- `just chk`
- full `just build` (1,149 XML files)
- XPath assertions:
  - `uts-000U` contains no FGAP/FCAP direct roots
  - `uts-000V` contains no FGAP/FCAP direct roots
  - `uts-016Q` contains exactly `fcap-0001`, `fgap-0001`
