### PR TITLE
fix(index): keep provenance off the draft index

### DIFF
--- a/trees/uts-016Q.tree
+++ b/trees/uts-016Q.tree
@@ -1,5 +1,4 @@
 \import{macros}
-\meta{agent-authored}{true}
 
 \title{Math notes (agent drafts)}
 


### PR DESCRIPTION
## Summary

Remove `agent-authored` provenance metadata from the organizational `Math notes (agent drafts)` index.

The FCAP and FGAP project roots retain their provenance badges. The index itself contains no agent-authored mathematical content.

## Verification

- `just chk`
- full `just build` (1,149 XML files)
- Chromium QA: index has no watermark; both collapsed child roots retain theirs
