### PR TITLE
fix(notes): refine agent draft presentation

### DIFF
--- a/bun/uts-style.css
+++ b/bun/uts-style.css
@@ -152,6 +152,14 @@ section:has(> details > summary > header .agent-authored-watermark)
     padding-inline-end: 6rem;
 }
 
+section:has(> details > summary > header .agent-authored-watermark)
+    > details
+    > summary
+    > header
+    .link-buttons {
+    margin-inline-end: 7.5rem;
+}
+
 .agent-authored-watermark {
     position: absolute;
     inset-block-start: 0;
@@ -197,6 +205,14 @@ section:has(> details > summary > header .agent-authored-watermark)
         > header {
         min-height: 4rem;
         padding-inline-end: 4.5rem;
+    }
+
+    section:has(> details > summary > header .agent-authored-watermark)
+        > details
+        > summary
+        > header
+        .link-buttons {
+        margin-inline-end: 6rem;
     }
 
     .agent-authored-watermark {
@@ -730,12 +746,12 @@ nav#toc li.active {
     z-index: 2;
 }
 
-/* clearfix hack */
-/* header h1::after {
+/* AGENT-NOTE: Floated note controls must contribute to heading height, or they overlap the first child card. */
+summary header h1:has(.link-button, .meta-lean)::after {
     content: "";
     clear: both;
     display: table;
-} */
+}
 
 .link-buttons {
     cursor: pointer;

--- a/trees/fcap-0001.tree
+++ b/trees/fcap-0001.tree
@@ -14,7 +14,16 @@
 \author{utensil}
 \date{2026-08-02}
 
-\p{These notes collect the mathematical work paired with FCAP.}
+\p{These are the accompanying mathematical notes for the experimental research
+project \href{https://github.com/utensil/fcap}{FCAP}. FCAP is read “F-cap,” and
+studies whether Lean can serve both as a formal language for the abstract and
+concrete mathematics of Clifford algebras and as an implementation language
+for efficient symbolic and numerical computation. It is also a coined acronym
+for “Formalized Clifford Algebra Programme.”}
+
+\p{FCAP's formalization is still at an early spike-test stage. The current
+storyline follows that agent-led spike test through coordinate representations
+and orthogonal-product transport.}
 
 \transclude{fcap-0002}
 
@@ -22,10 +31,4 @@
 
 \transclude{fcap-0006}
 
-\transclude{fcap-0007}
-
-\transclude{fcap-000F}
-
-\transclude{fcap-000M}
-
-\transclude{fcap-0010}
+\transclude{fcap-0019}

--- a/trees/fcap-0019.tree
+++ b/trees/fcap-0019.tree
@@ -1,0 +1,22 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{clifford}
+\tag{draft}
+
+\title{Appendix}
+
+\p{This appendix records supporting mathematics produced by agent formalization
+work on the \href{https://github.com/TauCetiProject/TauCetiRoadmap/tree/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations}{spin-representation roadmap}
+of \href{https://github.com/TauCetiProject/TauCeti}{Tau Ceti}. It covers
+reflections and Clifford lifts, the exterior shadow of a Clifford algebra,
+bivectors and the orthogonal Lie algebra, and real-signature recurrences.}
+
+\transclude{fcap-0007}
+
+\transclude{fcap-000F}
+
+\transclude{fcap-000M}
+
+\transclude{fcap-0010}

--- a/trees/fgap-0001.tree
+++ b/trees/fgap-0001.tree
@@ -1,4 +1,4 @@
-\import{macros}
+\import{spin-macros}
 
 \meta{agent-authored}{true}
 
@@ -16,11 +16,24 @@
 \author{utensil}
 \date{2026-07-28}
 
-\p{These notes are about mathematical structures suggested by questions in
-physics beyond the Standard Model. They do not propose a physical theory. We
-begin with Hamilton's Quaternions and the quaternionic realization of the
-binary tetrahedral group, because they give a small and explicit route into
-finite real Group Algebras.}
+\p{These are the accompanying mathematical notes for the experimental research
+project \href{https://github.com/utensil/fgap}{FGAP}. FGAP is read “F-gap,” for
+the foundational gap between established mathematical tools and open questions
+about physical structures, especially beyond the Standard Model. It is also a
+coined acronym for “Foundational Group Algebras (for) Physics.”}
+
+\p{The project studies mathematical structures that may help us understand
+physical structures more deeply. It does not construct or claim a physical
+theory. The current storyline has been strongly shaped by agent exploration of
+one spike-test slice of that research domain. It follows the project's
+\href{https://github.com/utensil/fgap/blob/main/README.md#approach}{approach}:
+turn a structural hypothesis into a small, source-grounded vertical slice, then
+use explicit calculations and formalization to expose its assumptions.}
+
+\p{This slice begins with Hamilton's Quaternions and the quaternionic
+realization of the binary tetrahedral group, because they give a small and
+explicit route into finite real Group Algebras. For the human-curated storyline
+of the notes, see \ref{spin-0010}.}
 
 \p{For the mathematics, we follow the Hurwitz-unit treatment in
 \citet{ch. 11}{voight2021quaternion}. We keep the mathematics and the

--- a/trees/index.tree
+++ b/trees/index.tree
@@ -13,12 +13,12 @@
 
 \transclude{uts-000U}
 
-\transclude{uts-016Q}
-
 \scope{
   \put\transclude/expanded{false}
   \transclude{uts-000V}
 }
+
+\transclude{uts-016Q}
 
 \scope{
   \put\transclude/expanded{false}
@@ -26,5 +26,4 @@
 }
 
 \transclude{uts-0168}
-
 

--- a/trees/spin-0010.tree
+++ b/trees/spin-0010.tree
@@ -16,7 +16,7 @@
 
 % cox1997ideals gathmann2013commutative
 
-\note{notes on group algebras}{
+\note{Notes on group algebras}{
 
 \transclude{spin-0011}
 


### PR DESCRIPTION
## Summary

- place **Math notes (agent drafts)** below the human-authored early-drafts section on Home
- keep the `uts-016Q` source control clear of its first child card and reserve balanced space between PDF controls and provenance watermarks
- introduce FCAP and FGAP consistently as accompanying notes for their linked experimental research projects
- make FCAP's own coordinate and orthogonal-product spike test its main storyline, matching FGAP's project-local vertical-slice arrangement
- collect the Tau Ceti SpinRep-derived FCAP material in an explicit appendix with links to the roadmap and Tau Ceti
- explain how the FGAP agent-explored slice follows the README Approach section and link the human-curated **Notes on group algebras** storyline

## Verification

- `just chk`
- full `just build` (1,150 XML files)
- desktop Chromium QA at 1440×900
- mobile Chromium QA at 390×844
- verified source control clears the first card at both widths
- verified 18.45 px horizontal clearance between PDF controls and provenance watermarks at both widths
- verified `uts-016Q` itself remains unbadged
- verified Home orders early drafts before agent drafts
- verified FCAP order: coordinate representations, contraction lemma, ordered transport, then Appendix
- verified Tau Ceti, SpinRep roadmap, FGAP Approach, and `spin-0010` links in Chromium and PDF annotations
- rendered FCAP (24 pages) and FGAP (34 pages) PDFs without fatal LaTeX errors

This PR targets `main` directly and is intentionally human-gated. It must not be landed without explicit approval.