### PR TITLE
fix(index): collapse agent draft notes

### DIFF
--- a/trees/index.tree
+++ b/trees/index.tree
@@ -18,7 +18,10 @@
   \transclude{uts-000V}
 }
 
-\transclude{uts-016Q}
+\scope{
+  \put\transclude/expanded{false}
+  \transclude{uts-016Q}
+}
 
 \scope{
   \put\transclude/expanded{false}
@@ -26,4 +29,3 @@
 }
 
 \transclude{uts-0168}
-


### PR DESCRIPTION
## Summary

Collapse **Math notes (agent drafts)** on Home, matching **Math notes (early drafts)**. Keep **Math notes (partially complete)** expanded.

## Verification

- `just chk`
- full `just build` across 1,150 XML files
- Chromium DOM audit:
  - partially complete: open, 5 child notes
  - early drafts: collapsed, 4 child notes
  - agent drafts: collapsed, 2 child notes
- rendered desktop preview

This PR targets `main` directly and is intentionally human-gated. It must not be landed without explicit approval.
