### PR TITLE
docs(fcap): complete the Spin surjectivity chapter [AGENT]

### DIFF
--- a/trees/fcap-0007.tree
+++ b/trees/fcap-0007.tree
@@ -7,7 +7,7 @@
 
 \title{Reflections and square-normalized Clifford lifts}
 
-\p{A nonisotropic vector acts on the generating space by a reflection through twisted Clifford conjugation. Normalizing such vectors gives elements of Pin, while even products give elements of Spin. The cards first establish these local lifts and then pass from reflection generation to surjectivity of the Pin action.}
+\p{A nonisotropic vector acts on the generating space by a reflection through twisted Clifford conjugation. Normalizing such vectors gives elements of Pin, while determinant parity detects the even products that belong to Spin. The cards pass from local lifts to reflection generation, Pin surjectivity, and finally Spin surjectivity onto the special orthogonal group.}
 
 \related{\ref{ca-0001}}
 

--- a/trees/fcap-000U.tree
+++ b/trees/fcap-000U.tree
@@ -5,13 +5,15 @@
 \tag{spin}
 \tag{clifford}
 
-\title{Reflections generate the Pin cover}
+\title{From reflection generation to Pin and Spin}
 
-\p{One reflection can enlarge the fixed subspace of an orthogonal transformation. Iterating this correction proves that reflections generate the orthogonal group. Once each reflection has a Pin lift, generation becomes surjectivity.}
+\p{One reflection can enlarge the fixed subspace of an orthogonal transformation. Iterating this correction proves that reflections generate the orthogonal group. Once each reflection has a Pin lift, generation gives the Pin cover; determinant parity then restricts that cover to Spin over the special orthogonal group.}
 
 \transclude{fcap-000V}
 \transclude{fcap-0018}
 \transclude{fcap-000W}
 \transclude{fcap-000X}
 \transclude{fcap-000Y}
+\transclude{fcap-001A}
+\transclude{fcap-001B}
 \transclude{fcap-000Z}

--- a/trees/fcap-000Z.tree
+++ b/trees/fcap-000Z.tree
@@ -8,6 +8,6 @@
 \taxon{Remark}
 \title{Boundary of the covering statement}
 
-\p{Surjectivity of #{\Pin(V,Q)\to O(V,Q)} uses reflection generation and the ability to normalize every reflecting vector. It does not compute the kernel, identify a short exact sequence, or introduce the spinor norm. Kostant's classical complex theorem has kernel #{\{\pm1\}} and identifies #{\Spin(V)} as a double cover of #{SO(V)} \citet{Section 2.3, Proposition 1, pp. 282--283}{kostant1997clifford}; those additional conclusions require their own hypotheses and arguments.}
+\p{Surjectivity of #{\Pin(V,Q)\to O(V,Q)} and #{\Spin(V,Q)\to SO(V,Q)} uses reflection generation, normalization of the reflecting vectors, and determinant parity. Kostant's classical complex theorem continues by identifying the kernel #{\{\pm1\}} and hence a double cover of #{SO(V)} \citet{Section 2.3, Proposition 1, pp. 282--283}{kostant1997clifford}. A kernel calculation, its exact sequence, and the spinor norm lie beyond the present argument.}
 
-\p{Likewise, the even product in \ref{fcap-000Y} is a specific Spin lift. No general surjectivity assertion for the Spin action is used here.}
+\p{The homomorphisms above are algebraic. Lie-group structures, connected components, and the differential of the Spin action require additional arguments.}

--- a/trees/fcap-0015.tree
+++ b/trees/fcap-0015.tree
@@ -6,17 +6,25 @@
 \tag{clifford}
 
 \taxon{Example}
-\title{The first four real Clifford algebras \citet{I.4, Theorem 4.3 and Tables I--II, pp. 27--29}{lawson2016spin}}
-\lean/tauceti{TauCeti.realCliffordOneZeroEquivProd,TauCeti.realCliffordZeroOneEquivComplex,TauCeti.realCliffordOneOneEquivMatrix}
+\title{Four real Clifford base entries \citet{I.4, Theorem 4.3 and Tables I--II, pp. 27--29}{lawson2016spin}}
+\lean/tauceti{TauCeti.realCliffordOneZeroEquivProd,TauCeti.realCliffordZeroOneEquivComplex,TauCeti.realCliffordZeroTwoEquivQuaternion,TauCeti.realCliffordOneOneEquivMatrix}
 
-\p{The signature convention of \ref{fcap-0011} gives
+\p{With #{\Cl_{0,0}\simeq\mathbb{R}} as the scalar anchor, the signature convention of \ref{fcap-0011} gives four nontrivial base entries:
 
-##{\Cl_{0,0}\simeq\mathbb{R},\qquad
-\Cl_{1,0}\simeq\mathbb{R}\times\mathbb{R},\qquad
-\Cl_{0,1}\simeq\mathbb{C},\qquad
-\Cl_{1,1}\simeq M_2(\mathbb{R}).}
+##{\begin{aligned}
+\Cl_{0,0}&\simeq\mathbb{R}, &
+\Cl_{1,0}&\simeq\mathbb{R}\times\mathbb{R}, &
+\Cl_{0,1}&\simeq\mathbb{C},\\
+\Cl_{0,2}&\simeq\mathbb{H}, &
+\Cl_{1,1}&\simeq M_2(\mathbb{R}).
+\end{aligned}}
 
-For #{\Cl_{1,1}}, the positive and negative generators may be represented by
+For #{\Cl_{0,2}}, the two negative generators map to the quaternion units
+#{i} and #{j}; their product maps to #{k}. Thus they square to #{-1} and
+anticommute, as required by the Clifford relations. The exact generator map is
+recorded by \leanref/tauceti{TauCeti.realCliffordZeroTwoEquivQuaternion_ι}.}
+
+\p{For #{\Cl_{1,1}}, the positive and negative generators may be represented by
 
 ##{e_+\longmapsto\begin{pmatrix}1&0\\0&-1\end{pmatrix},
 \qquad

--- a/trees/fcap-0019.tree
+++ b/trees/fcap-0019.tree
@@ -11,7 +11,8 @@
 work on the \href{https://github.com/TauCetiProject/TauCetiRoadmap/tree/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations}{spin-representation roadmap}
 of \href{https://github.com/TauCetiProject/TauCeti}{Tau Ceti}. It covers
 reflections and Clifford lifts, the exterior shadow of a Clifford algebra,
-bivectors and the orthogonal Lie algebra, and real-signature recurrences.}
+bivectors and the orthogonal Lie algebra, the Spin cover of the special
+orthogonal group, and real-signature recurrences.}
 
 \transclude{fcap-0007}
 

--- a/trees/fcap-001A.tree
+++ b/trees/fcap-001A.tree
@@ -1,0 +1,25 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Lemma}
+\title{Determinant parity detects the even lift \citet{I.2, Theorems 2.7 and 2.9, pp. 17--19}{lawson2016spin}}
+\lean/tauceti{TauCeti.QuadraticMap.det_reflection,TauCeti.CliffordAlgebra.mem_even_of_det_pinToOrthogonal_eq_one}
+
+\p{Let #{R} be a commutative ring in which #{2} is invertible, let #{M} be a finite free #{R}-module, and let #{Q} be a quadratic form on #{M}. A reflection in a vector of invertible quadratic value has determinant #{-1}. Therefore a product of #{r} such reflections has determinant
+
+##{(-1)^r.}
+
+In particular, every product of an even number of reflections belongs to #{SO(M,Q)}.}
+
+\p{Lawson--Michelsohn state this parity argument for quadratic vector spaces over a field. The finite-free commutative-ring statement above is the formalized extension: its determinant calculation uses freeness and finiteness, while invertibility of #{2} identifies the fixed part of the grading involution with the even subalgebra.}
+
+\p{The Clifford lift remembers this parity. If #{p\in\Pin(M,Q)} and its orthogonal action has determinant #{1}, then #{p} lies in the even Clifford subalgebra. Hence #{p} is a Spin element. Thus any Pin lift of a special orthogonal transformation is automatically even.}
+
+\subtree{
+\taxon{Proof}
+\p{Multiplicativity of the determinant gives the first assertion from #{\det(\rho_v)=-1}. For the second, the grading involution of a Lipschitz element is its determinant sign times that element. If the determinant is #{1}, the involution fixes the Pin element. Because #{2} is invertible, the fixed submodule of the grading involution is precisely the even Clifford subalgebra.}
+}

--- a/trees/fcap-001B.tree
+++ b/trees/fcap-001B.tree
@@ -1,0 +1,31 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{Surjectivity of the Spin action \citet{I.2, Theorem 2.9, pp. 18--19}{lawson2016spin}}
+\lean/tauceti{TauCeti.CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_isSquare,TauCeti.CliffordAlgebra.spinToSpecialOrthogonal_surjective}
+
+\p{Let #{K} be a field of characteristic different from #{2}, let #{V} be finite-dimensional, and let #{Q} be nondegenerate. Suppose that for every nonisotropic #{v\in V}, the scalar #{-Q(v)^{-1}} is a square in #{K}. Then the twisted-adjoint action restricts to a surjection
+
+##{\Spin(V,Q)\twoheadrightarrow SO(V,Q).}
+
+The underlying homomorphism is \leanref/tauceti{TauCeti.CliffordAlgebra.spinToSpecialOrthogonal}, and its action on vectors is the usual Spin action by \leanref/tauceti{TauCeti.CliffordAlgebra.coe_spinToSpecialOrthogonal_apply}.}
+
+\p{Indeed, the square-normalization hypothesis and Cartan--Dieudonne generation give the Pin surjection of \ref{fcap-000X}. It lifts an element of #{SO(V,Q)} to Pin; the lift has determinant #{1}, so \ref{fcap-001A} shows that it is even and therefore lies in Spin. The restriction square
+
+\tikzfig{
+\begin{tikzcd}[column sep=large, row sep=large]
+\Spin(V,Q) \arrow[r,hook] \arrow[d,two heads,"\operatorname{spinToSpecialOrthogonal}"']
+  & \Pin(V,Q) \arrow[d,two heads,"\operatorname{pinToOrthogonal}"] \\
+SO(V,Q) \arrow[r,hook]
+  & O(V,Q)
+\end{tikzcd}
+}
+
+commutes because both vertical maps are induced by the same twisted Clifford conjugation. Over a separably closed field the square condition is automatic, so nondegeneracy and finite dimension suffice. The general restriction principle from a surjective Pin action is \leanref/tauceti{TauCeti.CliffordAlgebra.spinToSpecialOrthogonal_surjective_of_pinToOrthogonal_surjective}.}
+
+\p{The square condition belongs to the algebraic normalization argument. For a positive-definite real geometric form #{q}, the Clifford convention is #{Q=-q}; hence #{-Q(v)^{-1}>0} for every nonzero #{v}, so the reflecting vectors can be normalized over #{\mathbb{R}}. This observation does not assert the square condition for arbitrary real signatures.}


### PR DESCRIPTION
## Summary

- add the determinant-parity bridge from Pin to Spin
- state the surjectivity of the Spin action onto the special orthogonal group, with a commutative restriction square
- restore the quaternion entry `Cl_{0,2} ≃ H` in the real-signature base examples
- update the appendix and chapter boundaries to end before the kernel, exact sequence, spinor norm, components, and differential

The mathematical claims are grounded in Lawson--Michelsohn and Kostant, with current TauCeti whole-card badges and inline declaration links.

## Current rendered placement

Forest #102 makes LaTeX derive the same contextual paths structurally while displayed equations retain a separate local counter. Both renderers place the new cards in **Appendix §4.1.8**:

- **Lemma 4.1.8.6**, “Determinant parity detects the even lift” (`fcap-001A`)
- **Theorem 4.1.8.7**, “Surjectivity of the Spin action” (`fcap-001B`)
- **Remark 4.1.8.8**, updated boundary of the covering statement (`fcap-000Z`)

**Real-signature example**

- Appendix §4.4, **Example 4.4.5**, expanded “Four real Clifford base entries” (`fcap-0015`)

Tree-file count: **7 changed = 2 new + 5 modified**. The two new note trees are `fcap-001A.tree` and `fcap-001B.tree`; the five modified trees are `fcap-0007.tree`, `fcap-000U.tree`, `fcap-000Z.tree`, `fcap-0015.tree`, and `fcap-0019.tree`.

## Verification

- `just chk`
- full `just build` (1,152 XML files)
- `fcap-0001.pdf` (26 pages)
- desktop and mobile HTML inspection
- PDF text, overflow, and link-annotation audit
- all 49 unique Lean declarations in the FCAP suite resolve in the PDF
- all TauCeti declarations checked against current TauCeti `main` and the live documentation resolver

No protected `tt-*` or `ca-*` tree is changed.