### PR TITLE
fix(pdf): separate card and equation counters

### DIFF
--- a/tex/mdframed.tex
+++ b/tex/mdframed.tex
@@ -170,8 +170,9 @@
 \numberwithin{equation}{subsection}
 \theoremstyle{definition}
 % \declaretheorem[style=thmblackbox,name=Definition,numberwithin=subsection]{definition}
-\declaretheorem[style=thmbluebox,name=Theorem,numberwithin=subsection, numberlike=equation]{theorem}
-\declaretheorem[style=thmbluebox,name=Theorem,numberwithin=subsection, numberlike=equation]{theoremx} % theorem not in dep graph
+% AGENT-NOTE: Mathematical cards share the theorem counter; displayed equations use their own counter.
+\declaretheorem[style=thmbluebox,name=Theorem,numberwithin=subsection]{theorem}
+\declaretheorem[style=thmbluebox,name=Theorem,sibling=theorem]{theoremx} % theorem not in dep graph
 \declaretheorem[style=thmbluebox,name=Lemma,sibling=theorem]{lemma}
 \declaretheorem[style=thmbluebox,name=Lemma,sibling=theorem]{lemmax} % lemma not in dep graph
 \declaretheorem[style=thmbluebox,name=Corollary,sibling=theorem]{corollary}


### PR DESCRIPTION
## Summary

- give theorem-like mathematical cards their own subsection-local counter
- retain a separate subsection-local counter for displayed equations
- keep theorem, lemma, definition, convention, notation, example, and remark cards in one continuous card sequence

This corrects an accidental PDF-only coupling. Web numbering already treats cards and formulas separately.

## Evidence

- `just chk`
- full `just build` over 1,151 XML files
- two-pass CA, TT, and FCAP PDF builds
- PDF label audit: cards are continuous within each subsection, equations count independently
- focused visual inspection of FCAP Appendix §2.1
- no LaTeX fatal errors

The change is isolated to `tex/mdframed.tex`.