### PR TITLE
fix(pdf): match Forester contextual numbering

### DIFF
--- a/assets/article.xsl
+++ b/assets/article.xsl
@@ -56,26 +56,30 @@
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and not(@numbered='false')]/f:frontmatter/f:title">
-    <xsl:text>\section{</xsl:text>
-    <xsl:call-template name="section-title" />
+    <xsl:call-template name="set-contextual-section-number" />
+    <xsl:text>\section*{</xsl:text>
+    <xsl:call-template name="contextual-section-title" />
     <xsl:text>}</xsl:text>
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and not(@numbered='false')]/f:frontmatter/f:title">
-    <xsl:text>\subsection{</xsl:text>
-    <xsl:call-template name="section-title" />
+    <xsl:call-template name="set-contextual-section-number" />
+    <xsl:text>\subsection*{</xsl:text>
+    <xsl:call-template name="contextual-section-title" />
     <xsl:text>}</xsl:text>
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and not(@numbered='false')]/f:frontmatter/f:title">
-    <xsl:text>\subsubsection{</xsl:text>
-    <xsl:call-template name="section-title" />
+    <xsl:call-template name="set-contextual-section-number" />
+    <xsl:text>\subsubsection*{</xsl:text>
+    <xsl:call-template name="contextual-section-title" />
     <xsl:text>}</xsl:text>
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and not(@numbered='false')]/f:frontmatter/f:title">
-    <xsl:text>\subsubsubsection{</xsl:text>
-    <xsl:call-template name="section-title" />
+    <xsl:call-template name="set-contextual-section-number" />
+    <xsl:text>\subsubsubsection*{</xsl:text>
+    <xsl:call-template name="contextual-section-title" />
     <xsl:text>}</xsl:text>
   </xsl:template>
 
@@ -104,6 +108,14 @@
   </xsl:template>
 
   <!-- AGENT-NOTE: Untyped note trees still carry Lean metadata and need a PDF-visible marker row. -->
+  <xsl:template name="set-contextual-section-number">
+    <xsl:text>\setforestsectionnumber{</xsl:text>
+    <xsl:call-template name="contextual-section-number">
+      <xsl:with-param name="tree" select="../.." />
+    </xsl:call-template>
+    <xsl:text>}\setforestsectioncurrentlabel</xsl:text>
+  </xsl:template>
+
   <xsl:template name="section-title">
     <xsl:apply-templates />
     <xsl:call-template name="lean-marker-metadata">

--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -89,6 +89,12 @@
   
   <!-- use mdframed begin -->
   <xsl:template match="f:tree[f:frontmatter/f:taxon[not(text()='Proof' or (ancestor::f:backmatter))]]">
+    <!-- AGENT-NOTE: PDF card headings must use the same contextual tree path as the web renderer. -->
+    <xsl:text>\setforestcontextualnumber{</xsl:text>
+    <xsl:call-template name="contextual-number">
+      <xsl:with-param name="tree" select="." />
+    </xsl:call-template>
+    <xsl:text>}</xsl:text>
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="f:frontmatter/f:taxon" />
     <xsl:text>}</xsl:text>
@@ -101,7 +107,7 @@
       <xsl:text>}]</xsl:text>
     </xsl:if>
     <xsl:if test="f:frontmatter/f:display-uri[not(contains(text(), '#'))]">
-      <xsl:text>\label{</xsl:text>
+      <xsl:text>\setforestcurrentlabel\label{</xsl:text>
       <xsl:value-of select="f:frontmatter/f:display-uri" />
       <xsl:text>}</xsl:text>
     </xsl:if>
@@ -109,6 +115,73 @@
     <xsl:text>\end{</xsl:text>
     <xsl:apply-templates select="f:frontmatter/f:taxon" />
     <xsl:text>}</xsl:text>
+  </xsl:template>
+
+  <xsl:template name="contextual-number">
+    <xsl:param name="tree" />
+    <xsl:variable name="parent" select="$tree/ancestor::f:tree[1]" />
+    <xsl:variable name="prefix">
+      <xsl:if test="$parent">
+        <xsl:call-template name="contextual-number">
+          <xsl:with-param name="tree" select="$parent" />
+        </xsl:call-template>
+      </xsl:if>
+    </xsl:variable>
+    <xsl:variable name="explicitly-unnumbered" select="boolean($tree/ancestor-or-self::f:tree[@numbered='false' or @toc='false'])" />
+    <xsl:variable name="implicitly-unnumbered" select="count($tree/../f:tree) = 1 and not(count($tree/f:mainmatter/f:tree) &gt; 1) and not($tree/ancestor::f:tree[f:frontmatter/f:display-uri = /f:tree/f:frontmatter/f:display-uri])" />
+    <xsl:if test="$tree/f:frontmatter/f:number != '' or ($tree/ancestor::f:tree and not($tree/ancestor::f:backmatter) and not($explicitly-unnumbered) and not($implicitly-unnumbered))">
+      <xsl:if test="string($prefix) != ''">
+        <xsl:value-of select="$prefix" />
+        <xsl:text>.</xsl:text>
+      </xsl:if>
+      <xsl:choose>
+        <xsl:when test="$tree/f:frontmatter/f:number != ''">
+          <xsl:value-of select="$tree/f:frontmatter/f:number" />
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="count($tree/preceding-sibling::f:tree[not(@toc='false' or @numbered='false')]) + 1" />
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
+  <xsl:template name="contextual-section-title">
+    <xsl:param name="frontmatter" select=".." />
+    <xsl:variable name="tree" select="$frontmatter/.." />
+    <xsl:choose>
+      <xsl:when test="count($tree/f:mainmatter/f:tree) = 1 and not($tree/ancestor::f:tree[f:frontmatter/f:display-uri = /f:tree/f:frontmatter/f:display-uri])">
+        <xsl:call-template name="contextual-number">
+          <xsl:with-param name="tree" select="$tree/f:mainmatter/f:tree[1]" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="contextual-number">
+          <xsl:with-param name="tree" select="$tree" />
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
+    <xsl:text>\quad{}</xsl:text>
+    <xsl:apply-templates select="$frontmatter/f:title/node()" />
+    <xsl:call-template name="lean-marker-metadata">
+      <xsl:with-param name="frontmatter" select="$frontmatter" />
+      <xsl:with-param name="continuation" select="true()" />
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template name="contextual-section-number">
+    <xsl:param name="tree" />
+    <xsl:choose>
+      <xsl:when test="count($tree/f:mainmatter/f:tree) = 1 and not($tree/ancestor::f:tree[f:frontmatter/f:display-uri = /f:tree/f:frontmatter/f:display-uri])">
+        <xsl:call-template name="contextual-number">
+          <xsl:with-param name="tree" select="$tree/f:mainmatter/f:tree[1]" />
+        </xsl:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:call-template name="contextual-number">
+          <xsl:with-param name="tree" select="$tree" />
+        </xsl:call-template>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <xsl:template name="lean-marker-metadata">

--- a/tex/mdframed.tex
+++ b/tex/mdframed.tex
@@ -8,8 +8,24 @@
 
 % Keep theorem headings ragged and breakable between atomic inline markers.
 \newcommand{\foresttheoremhead}{%
-	\parbox[t]{\linewidth}{\raggedright\NAME\ \NUMBER\ \NOTE}%
+	\parbox[t]{\linewidth}{\raggedright\NAME\ \foresttheoremnumber{\NUMBER}\ \NOTE}%
 }
+
+% The LaTeX renderer supplies Forester's contextual number before each card.
+\newcommand{\forestcontextualnumber}{}
+\newcommand{\setforestcontextualnumber}[1]{\renewcommand{\forestcontextualnumber}{#1}}
+\newcommand{\foresttheoremnumber}[1]{%
+	\if\relax\detokenize\expandafter{\forestcontextualnumber}\relax#1\else\forestcontextualnumber\fi%
+}
+\makeatletter
+\newcommand{\setforestcurrentlabel}{\protected@edef\@currentlabel{\forestcontextualnumber}}
+\newcommand{\forestsectionnumber}{}
+\newcommand{\setforestsectionnumber}[1]{%
+	\renewcommand{\forestsectionnumber}{#1}%
+	\setcounter{equation}{0}%
+}
+\newcommand{\setforestsectioncurrentlabel}{\protected@edef\@currentlabel{\forestsectionnumber}}
+\makeatother
 
 \theoremstyle{definition}
 \mdfdefinestyle{mdbluebox}{%
@@ -167,7 +183,7 @@
 	headpunct={\\[3pt]},
 ]{def}
 
-\numberwithin{equation}{subsection}
+\renewcommand{\theequation}{\forestsectionnumber.\arabic{equation}}
 \theoremstyle{definition}
 % \declaretheorem[style=thmblackbox,name=Definition,numberwithin=subsection]{definition}
 % AGENT-NOTE: Mathematical cards share the theorem counter; displayed equations use their own counter.


### PR DESCRIPTION
## Summary

- render PDF section paths from Forester contextual tree numbering
- render mathematical-card headings and labels with those same paths
- preserve a separate per-section equation counter
- make internal PDF references use the contextual card paths

The web renderer remains the numbering contract. This PR makes the PDF consume the same tree structure instead of independently flattening it through LaTeX section and theorem counters.

## Evidence

- `xmllint` on both changed XSL stylesheets
- `just chk`
- full `just build` over 1,151 XML files
- two-pass CA, TT, and FCAP PDF builds
- web/PDF sample equality for FCAP sections `1`, `4`, `4.1`, card `4.1.1`, and nested card `4.1.8.1`
- PDF internal-reference audit
- focused visual inspection of FCAP Appendix §4.1
- no LaTeX fatal errors