### PR TITLE
fix(pdf): derive numbering from LaTeX structure

### DIFF
--- a/assets/article.xsl
+++ b/assets/article.xsl
@@ -56,31 +56,27 @@
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and not(@numbered='false')]/f:frontmatter/f:title">
-    <xsl:call-template name="set-contextual-section-number" />
-    <xsl:text>\section*{</xsl:text>
-    <xsl:call-template name="contextual-section-title" />
-    <xsl:text>}</xsl:text>
+    <xsl:text>\section{</xsl:text>
+    <xsl:call-template name="section-title" />
+    <xsl:text>}\forestsetformulasection{section}</xsl:text>
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and not(@numbered='false')]/f:frontmatter/f:title">
-    <xsl:call-template name="set-contextual-section-number" />
-    <xsl:text>\subsection*{</xsl:text>
-    <xsl:call-template name="contextual-section-title" />
-    <xsl:text>}</xsl:text>
+    <xsl:text>\subsection{</xsl:text>
+    <xsl:call-template name="section-title" />
+    <xsl:text>}\forestsetformulasection{subsection}</xsl:text>
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and not(@numbered='false')]/f:frontmatter/f:title">
-    <xsl:call-template name="set-contextual-section-number" />
-    <xsl:text>\subsubsection*{</xsl:text>
-    <xsl:call-template name="contextual-section-title" />
-    <xsl:text>}</xsl:text>
+    <xsl:text>\subsubsection{</xsl:text>
+    <xsl:call-template name="section-title" />
+    <xsl:text>}\forestsetformulasection{subsubsection}</xsl:text>
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and not(@numbered='false')]/f:frontmatter/f:title">
-    <xsl:call-template name="set-contextual-section-number" />
-    <xsl:text>\subsubsubsection*{</xsl:text>
-    <xsl:call-template name="contextual-section-title" />
-    <xsl:text>}</xsl:text>
+    <xsl:text>\subsubsubsection{</xsl:text>
+    <xsl:call-template name="section-title" />
+    <xsl:text>}\forestsetformulasection{paragraph}</xsl:text>
   </xsl:template>
 
   <xsl:template match="/f:tree/f:mainmatter/f:tree[not(f:frontmatter/f:taxon) and (@numbered='false')]/f:frontmatter/f:title">
@@ -108,14 +104,6 @@
   </xsl:template>
 
   <!-- AGENT-NOTE: Untyped note trees still carry Lean metadata and need a PDF-visible marker row. -->
-  <xsl:template name="set-contextual-section-number">
-    <xsl:text>\setforestsectionnumber{</xsl:text>
-    <xsl:call-template name="contextual-section-number">
-      <xsl:with-param name="tree" select="../.." />
-    </xsl:call-template>
-    <xsl:text>}\setforestsectioncurrentlabel</xsl:text>
-  </xsl:template>
-
   <xsl:template name="section-title">
     <xsl:apply-templates />
     <xsl:call-template name="lean-marker-metadata">

--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -89,12 +89,8 @@
   
   <!-- use mdframed begin -->
   <xsl:template match="f:tree[f:frontmatter/f:taxon[not(text()='Proof' or (ancestor::f:backmatter))]]">
-    <!-- AGENT-NOTE: PDF card headings must use the same contextual tree path as the web renderer. -->
-    <xsl:text>\setforestcontextualnumber{</xsl:text>
-    <xsl:call-template name="contextual-number">
-      <xsl:with-param name="tree" select="." />
-    </xsl:call-template>
-    <xsl:text>}</xsl:text>
+    <!-- AGENT-NOTE: Cards advance LaTeX's structural counter at their Forester depth. -->
+    <xsl:call-template name="step-card-counter" />
     <xsl:text>\begin{</xsl:text>
     <xsl:apply-templates select="f:frontmatter/f:taxon" />
     <xsl:text>}</xsl:text>
@@ -107,7 +103,9 @@
       <xsl:text>}]</xsl:text>
     </xsl:if>
     <xsl:if test="f:frontmatter/f:display-uri[not(contains(text(), '#'))]">
-      <xsl:text>\setforestcurrentlabel\label{</xsl:text>
+      <xsl:text>\forestcardlabel{</xsl:text>
+      <xsl:apply-templates select="f:frontmatter/f:taxon" />
+      <xsl:text>}{</xsl:text>
       <xsl:value-of select="f:frontmatter/f:display-uri" />
       <xsl:text>}</xsl:text>
     </xsl:if>
@@ -117,71 +115,16 @@
     <xsl:text>}</xsl:text>
   </xsl:template>
 
-  <xsl:template name="contextual-number">
-    <xsl:param name="tree" />
-    <xsl:variable name="parent" select="$tree/ancestor::f:tree[1]" />
-    <xsl:variable name="prefix">
-      <xsl:if test="$parent">
-        <xsl:call-template name="contextual-number">
-          <xsl:with-param name="tree" select="$parent" />
-        </xsl:call-template>
-      </xsl:if>
-    </xsl:variable>
-    <xsl:variable name="explicitly-unnumbered" select="boolean($tree/ancestor-or-self::f:tree[@numbered='false' or @toc='false'])" />
-    <xsl:variable name="implicitly-unnumbered" select="count($tree/../f:tree) = 1 and not(count($tree/f:mainmatter/f:tree) &gt; 1) and not($tree/ancestor::f:tree[f:frontmatter/f:display-uri = /f:tree/f:frontmatter/f:display-uri])" />
-    <xsl:if test="$tree/f:frontmatter/f:number != '' or ($tree/ancestor::f:tree and not($tree/ancestor::f:backmatter) and not($explicitly-unnumbered) and not($implicitly-unnumbered))">
-      <xsl:if test="string($prefix) != ''">
-        <xsl:value-of select="$prefix" />
-        <xsl:text>.</xsl:text>
-      </xsl:if>
-      <xsl:choose>
-        <xsl:when test="$tree/f:frontmatter/f:number != ''">
-          <xsl:value-of select="$tree/f:frontmatter/f:number" />
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="count($tree/preceding-sibling::f:tree[not(@toc='false' or @numbered='false')]) + 1" />
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:if>
-  </xsl:template>
-
-  <xsl:template name="contextual-section-title">
-    <xsl:param name="frontmatter" select=".." />
-    <xsl:variable name="tree" select="$frontmatter/.." />
+  <xsl:template name="step-card-counter">
+    <xsl:variable name="depth" select="count(ancestor::f:tree)" />
+    <xsl:text>\foreststepcard{</xsl:text>
     <xsl:choose>
-      <xsl:when test="count($tree/f:mainmatter/f:tree) = 1 and not($tree/ancestor::f:tree[f:frontmatter/f:display-uri = /f:tree/f:frontmatter/f:display-uri])">
-        <xsl:call-template name="contextual-number">
-          <xsl:with-param name="tree" select="$tree/f:mainmatter/f:tree[1]" />
-        </xsl:call-template>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:call-template name="contextual-number">
-          <xsl:with-param name="tree" select="$tree" />
-        </xsl:call-template>
-      </xsl:otherwise>
+      <xsl:when test="$depth = 1">section</xsl:when>
+      <xsl:when test="$depth = 2">subsection</xsl:when>
+      <xsl:when test="$depth = 3">subsubsection</xsl:when>
+      <xsl:otherwise>paragraph</xsl:otherwise>
     </xsl:choose>
-    <xsl:text>\quad{}</xsl:text>
-    <xsl:apply-templates select="$frontmatter/f:title/node()" />
-    <xsl:call-template name="lean-marker-metadata">
-      <xsl:with-param name="frontmatter" select="$frontmatter" />
-      <xsl:with-param name="continuation" select="true()" />
-    </xsl:call-template>
-  </xsl:template>
-
-  <xsl:template name="contextual-section-number">
-    <xsl:param name="tree" />
-    <xsl:choose>
-      <xsl:when test="count($tree/f:mainmatter/f:tree) = 1 and not($tree/ancestor::f:tree[f:frontmatter/f:display-uri = /f:tree/f:frontmatter/f:display-uri])">
-        <xsl:call-template name="contextual-number">
-          <xsl:with-param name="tree" select="$tree/f:mainmatter/f:tree[1]" />
-        </xsl:call-template>
-      </xsl:when>
-      <xsl:otherwise>
-        <xsl:call-template name="contextual-number">
-          <xsl:with-param name="tree" select="$tree" />
-        </xsl:call-template>
-      </xsl:otherwise>
-    </xsl:choose>
+    <xsl:text>}</xsl:text>
   </xsl:template>
 
   <xsl:template name="lean-marker-metadata">

--- a/tex/mdframed.tex
+++ b/tex/mdframed.tex
@@ -8,23 +8,25 @@
 
 % Keep theorem headings ragged and breakable between atomic inline markers.
 \newcommand{\foresttheoremhead}{%
-	\parbox[t]{\linewidth}{\raggedright\NAME\ \foresttheoremnumber{\NUMBER}\ \NOTE}%
+	\parbox[t]{\linewidth}{\raggedright\NAME\ \forestcurrentnumber\ \NOTE}%
 }
 
-% The LaTeX renderer supplies Forester's contextual number before each card.
-\newcommand{\forestcontextualnumber}{}
-\newcommand{\setforestcontextualnumber}[1]{\renewcommand{\forestcontextualnumber}{#1}}
-\newcommand{\foresttheoremnumber}[1]{%
-	\if\relax\detokenize\expandafter{\forestcontextualnumber}\relax#1\else\forestcontextualnumber\fi%
-}
+% Cards advance the same structural counters as section-like trees at their depth.
+\newcommand{\forestcurrentnumber}{}
 \makeatletter
-\newcommand{\setforestcurrentlabel}{\protected@edef\@currentlabel{\forestcontextualnumber}}
-\newcommand{\forestsectionnumber}{}
-\newcommand{\setforestsectionnumber}[1]{%
-	\renewcommand{\forestsectionnumber}{#1}%
+\newcommand{\foreststepcard}[1]{%
+	\refstepcounter{#1}%
+	\protected@edef\forestcurrentnumber{\csname the#1\endcsname}%
+}
+\newcommand{\forestcardlabel}[2]{%
+	\protected@edef\@currentlabel{\forestcurrentnumber}%
+	\label[#1]{#2}%
+}
+\newcommand{\forestformulaprefix}{}
+\newcommand{\forestsetformulasection}[1]{%
+	\protected@edef\forestformulaprefix{\csname the#1\endcsname}%
 	\setcounter{equation}{0}%
 }
-\newcommand{\setforestsectioncurrentlabel}{\protected@edef\@currentlabel{\forestsectionnumber}}
 \makeatother
 
 \theoremstyle{definition}
@@ -183,34 +185,43 @@
 	headpunct={\\[3pt]},
 ]{def}
 
-\renewcommand{\theequation}{\forestsectionnumber.\arabic{equation}}
+\renewcommand{\theequation}{%
+	\if\relax\detokenize\expandafter{\forestformulaprefix}\relax
+		\arabic{equation}%
+	\else
+		\forestformulaprefix.\arabic{equation}%
+	\fi
+}
+\renewcommand{\theHequation}{%
+	\theHsection.\theHsubsection.\theHsubsubsection.\theHparagraph.\arabic{equation}%
+}
 \theoremstyle{definition}
 % \declaretheorem[style=thmblackbox,name=Definition,numberwithin=subsection]{definition}
 % AGENT-NOTE: Mathematical cards share the theorem counter; displayed equations use their own counter.
-\declaretheorem[style=thmbluebox,name=Theorem,numberwithin=subsection]{theorem}
-\declaretheorem[style=thmbluebox,name=Theorem,sibling=theorem]{theoremx} % theorem not in dep graph
-\declaretheorem[style=thmbluebox,name=Lemma,sibling=theorem]{lemma}
-\declaretheorem[style=thmbluebox,name=Lemma,sibling=theorem]{lemmax} % lemma not in dep graph
-\declaretheorem[style=thmbluebox,name=Corollary,sibling=theorem]{corollary}
-\declaretheorem[style=thmbluebox,name=Proposition,sibling=theorem]{proposition}
+\declaretheorem[style=thmbluebox,name=Theorem,numbered=no]{theorem}
+\declaretheorem[style=thmbluebox,name=Theorem,numbered=no]{theoremx} % theorem not in dep graph
+\declaretheorem[style=thmbluebox,name=Lemma,numbered=no]{lemma}
+\declaretheorem[style=thmbluebox,name=Lemma,numbered=no]{lemmax} % lemma not in dep graph
+\declaretheorem[style=thmbluebox,name=Corollary,numbered=no]{corollary}
+\declaretheorem[style=thmbluebox,name=Proposition,numbered=no]{proposition}
 
 \theoremstyle{definition}
 % \newtheorem{claim}[theorem]{Claim}
 % \newtheorem{definition}[theorem]{Definition}
-\declaretheorem[style=def,name=Definition,sibling=theorem]{definition}
-\declaretheorem[style=def,name=Convention,sibling=theorem]{convention}
-\declaretheorem[style=def,name=Notation,sibling=theorem]{notation}
+\declaretheorem[style=def,name=Definition,numbered=no]{definition}
+\declaretheorem[style=def,name=Convention,numbered=no]{convention}
+\declaretheorem[style=def,name=Notation,numbered=no]{notation}
 % \newtheorem{fact}[theorem]{Fact}
 % \newtheorem{abuse}[theorem]{Abuse of Notation}
 
-\declaretheorem[style=thmredbox,name=Example,sibling=theorem]{example}
+\declaretheorem[style=thmredbox,name=Example,numbered=no]{example}
 
 \theoremstyle{theorem}
 % \declaretheorem[name=Question,sibling=theorem,style=thmblackbox]{ques}
 % \declaretheorem[name=Exercise,sibling=theorem,style=thmblackbox]{exercise}
 
-\declaretheorem[name=Remark,sibling=theorem,style=thmgreenbox]{remark}
-\declaretheorem[name=Remark,sibling=theorem,style=thmgreenbox*]{remark*}
+\declaretheorem[name=Remark,numbered=no,style=thmgreenbox]{remark}
+\declaretheorem[name=Remark,numbered=no,style=thmgreenbox*]{remark*}
 % \declaretheorem[name=Step,style=thmgreenbox]{step} % only used in Lebesgue int
 
 \crefname{notation}{notation}{notations}


### PR DESCRIPTION
## Summary

- remove #101 textual contextual-number injection
- emit ordinary numbered LaTeX section commands
- make cards advance the LaTeX structural counter at their Forester depth
- keep theorem taxon labels and internal references semantic
- keep displayed equations on a separate local counter

The generated TeX contains no literal display numbering and remains reusable in other compositions.

## Evidence

- XSL validation and `just chk`
- full 1,151-file build
- two-pass CA, TT, and FCAP PDF builds
- exact web/PDF section, card, equation, and internal-reference checks
- generated-TeX audit: ordinary section/theorem environments, no injected contextual-number strings
- no LaTeX fatal or duplicate-destination errors