### PR TITLE
docs(connes): correct EJZK source route and provenance

### DIFF
--- a/trees/connes-0002.tree
+++ b/trees/connes-0002.tree
@@ -11,8 +11,10 @@
 \p{The public theorem is
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Main.lean#L17-L25}{\code{Connes.theoremA}}.
 Its sole mathematical parameter is
-#{\operatorname{HasKazhdanPropertyT}(\mathrm{EL}_3(\mathbb F_2[t]))}, represented by
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L23-L39}{\code{PaperPropertyT.elementaryGroup} and \code{EJZKInput}}.
+#{\operatorname{HasKazhdanPropertyT}(\mathrm{EL}_3(\mathbb F_2[t]))}.
+The corresponding Lean boundary consists of
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L23-L39}{\code{PaperPropertyT.elementaryGroup}}
+and \code{EJZKInput}.
 All spectral, factor, ICC, and nonisomorphism certificates downstream of that
 parameter are constructed in the project. This is completeness for the
 load-bearing content of Zhou's Theorem A under the project's definitions, not
@@ -20,17 +22,22 @@ a claim that every expository sentence of \citek{zhou2026icc} has been encoded.}
 
 \p{The dependency boundary is deliberately narrow:}
 
-\tikzfig{\begin{tikzcd}[column sep=large]
-{\mathrm{EL}_3(\mathbb F_2[t])\text{ has (T)}}
-  \arrow[r, "\mathrm{transport}"] &
-{\mathrm{SL}_3(\mathbb F_2[t])\text{ has (T)}}
-  \arrow[r, "\mathrm{certificates}"] &
-{\Gamma_1,\Gamma_2\text{ satisfy Theorem A}}
-\end{tikzcd}}
+\tikzfig{\begin{tikzpicture}[
+  node distance=8mm,
+  every node/.style={draw, rounded corners=2pt, align=center,
+    text width=31mm, minimum height=10mm},
+  every path/.style={-{Stealth[length=2mm]}, thick}
+]
+\node (el) {$\mathrm{EL}_3(\mathbb F_2[t])$\\has property (T)};
+\node[right=of el] (sl) {$\mathrm{SL}_3(\mathbb F_2[t])$\\has property (T)};
+\node[right=of sl] (groups) {$\Gamma_1,\Gamma_2$\\satisfy Theorem A};
+\draw (el) -- node[draw=none, above, text width=18mm] {transport} (sl);
+\draw (sl) -- node[draw=none, above, text width=20mm] {certificates} (groups);
+\end{tikzpicture}}
 
-\p{The solution import graph contains no \code{axiom}, \code{opaque},
-\code{sorry}, or \code{admit}. \code{#print axioms Connes.theoremA} reports
-only \code{propext}, \code{Classical.choice}, and \code{Quot.sound}, the usual
+\p{The solution import graph contains no axiom, opaque declaration, sorry, or
+admit. Lean's axiom report for \code{Connes.theoremA} contains only
+\code{propext}, \code{Classical.choice}, and \code{Quot.sound}, the usual
 Lean foundations used by the imported library. The one \code{sorry} in an
 independent Comparator challenge is outside the theorem's import graph.}
 \related{\ref{connes-0001}}

--- a/trees/connes-0003.tree
+++ b/trees/connes-0003.tree
@@ -8,9 +8,9 @@
 \title{Qualitative property (T) interface}
 \lean/connes{Connes.HasKazhdanPropertyT,Connes.HasRelativePropertyT}
 
-\p{For a countable discrete group #{G}, a unitary representation #{\pi} has
-\newvocab{almost-invariant unit vectors} when every finite #{K\subset G} and
-every #{\varepsilon>0} admit a unit vector #{\xi} with
+\p{Let #{G} be a countable discrete group. A unitary representation #{\pi} has
+\newvocab{almost-invariant unit vectors} if every finite #{K\subset G} and
+every #{\varepsilon>0} admit a unit vector #{\xi} satisfying
 
 ##{\lVert \pi(g)\xi-\xi\rVert<\varepsilon\qquad(g\in K).}
 

--- a/trees/connes-0007.tree
+++ b/trees/connes-0007.tree
@@ -31,10 +31,16 @@ dense, and conjugation therefore matches the two von Neumann closures. The
 final concrete objects are
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section3/FactorClosure.lean#L578-L697}{\code{paperSpatialUnitary}, \code{paperSpatialWitness}, and \code{paperGroupFactors_isomorphic}}.
 This is the operator-algebra interface behind the construction in
-\citet{Section 3}{zhou2026icc}. The repository records
-\citek{openai2026tenadvances} only as provenance for generic infrastructure
-adapted into local definitions; the mathematical conclusion and every witness
-field used here are proved in the Connes source.}
+\citet{Section 3}{zhou2026icc}. Chapter 4 of
+\citek{openai2026tenadvances} is an independent binary-carry construction and
+mathematical context; it is not the source of these Lean declarations. Adapted
+Lean infrastructure is traced separately to the pinned
+\href{https://github.com/openai/ten-proofs/tree/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6}{\code{openai/ten-proofs} snapshot},
+through the Connes project's
+\href{https://github.com/utensil/connes-rigidity/blob/main/docs/PROVENANCE.md}{provenance ledger}
+and \href{https://github.com/utensil/connes-rigidity/blob/main/docs/PORT_MAP.md}{port map}.
+The mathematical conclusion and every witness field used here are proved in
+the Connes source.}
 
 \p{\strong{Design adaptation: the consumer is closure membership.}
 Mapping a convenient generating family is only an intermediate result.

--- a/trees/connes-000A.tree
+++ b/trees/connes-000A.tree
@@ -41,7 +41,11 @@ isolation” makes \code{#print axioms} meaningful and lets semantic review trac
 each conjunct to the file where its mathematics occurs.}
 
 \p{These lessons concern proof structure rather than the mathematical claims
-of \citek{zhou2026icc} or \citek{openai2026tenadvances}. They are reusable in
+of \citek{zhou2026icc} or the independent binary-carry construction in Chapter
+4 of \citek{openai2026tenadvances}. The latter is mathematical context, not code
+provenance. Where the implementation adapts prior Lean infrastructure, the
+source is the pinned \code{openai/ten-proofs} snapshot recorded in the Connes
+project's provenance ledger and port map. The lessons are reusable in
 formalizations where a linear paper proof crosses topology, analysis, finite
 computation, and algebraic transport.}
 

--- a/trees/connes-000B.tree
+++ b/trees/connes-000B.tree
@@ -10,34 +10,51 @@
 \lean/connes{Connes.PaperPropertyT.elementaryGroup,Connes.HasKazhdanPropertyT,Connes.spectral_criterion_unconditional}
 \lean{SimpleGraph.lapMatrix,SimpleGraph.posSemidef_lapMatrix}
 
-\p{The only remaining substantive premise is
-#{\operatorname{HasKazhdanPropertyT}(\mathrm{EL}_3(\mathbb F_2[t]))}. The
-recommended source-faithful route specializes the earlier #{A_2} proof and
-the root-graded treatment in \citet{Theorem 1.1, Sections 2--5 and 7.2--7.4,
-Appendix A}{ershov2017rootgraded}, rather than formalizing the full general
-root-system theorem. The central estimate is \strong{24--28 thousand new Lean
-lines}; retain \strong{18--35 thousand} as the uncertainty envelope. This is
-about #{0.8}--#{1.5} times the current 22,962-line project and
-\strong{two to four times the present proof-search and engineering effort}.
-Confidence is medium, with about 50 percent uncertainty.}
+\p{The only remaining substantive premise is property (T) for
+#{\mathrm{EL}_3(\mathbb F_2[t])}. The
+primary source-faithful route is the exact elementary-group theorem
+\citet{Theorem 1.1, p. 1; Section 5.4, pp. 25--29; Section 6.1, pp.
+34--35}{ershov2010noncommutative}, specialized to #{R=\mathbb F_2[t]} and
+#{n=3}. The later root-graded treatment
+\citet{Theorem 1.1, p. 3; Sections 2--5 and 7.2--7.4; Appendix
+A}{ershov2017rootgraded} supplies broader supporting language. Our internal
+engineering estimate remains \strong{24--28 thousand new Lean lines}, with an
+internal uncertainty envelope of \strong{18--35 thousand}. This is about
+#{0.8}--#{1.5} times the current 22,962-line project and, by our internal
+estimate, \strong{two to four times its present proof-search and engineering
+effort}. The changed source route reallocates work within the original range;
+it does not independently calibrate a new total. The literature supports the
+route and its decomposition, not these LOC or effort figures.}
 
 \p{The six implementation layers, with overlapping uncertainty ranges, are:}
 
 \ol{
   \li{quantitative Kazhdan subsets, constants, and relative ratios, with a
-  bridge to the current qualitative predicate: \strong{2--3.5 thousand
-  lines};}
-  \li{six concrete #{A_2} root homomorphisms and their Steinberg commutator
-  relations: \strong{2.5--4.5 thousand};}
-  \li{fixed-space angles, codistance, and the class-two nilpotent estimate:
-  \strong{5--9 thousand};}
-  \li{the weighted six-vertex magic-graph spectral estimate:
-  \strong{2--3.5 thousand};}
-  \li{six quantitative relative-property-(T) specializations for the root
-  pairs: \strong{4.5--8 thousand}; and}
+  bridge to the current qualitative predicate; our internal allocation is
+  \strong{2--3.5 thousand lines};}
+  \li{the six additive root-subgroup embeddings and the direct #{A_2}
+  commutator relations; our internal allocation is \strong{2--4 thousand}.
+  A Steinberg-group detour is optional, not required for this direct
+  matrix-group specialization;}
+  \li{fixed-space angles, codistance, and the class-two nilpotent estimate;
+  our internal allocation is \strong{5--9 thousand};}
+  \li{the unweighted standard-Laplacian boundary case on six vertices. This is
+  Section 5.4 of \citek{ershov2010noncommutative}. Our internal allocation is
+  \strong{1.5--3 thousand}; the weighted criterion in Section 5.5 is a separate
+  generalization;}
+  \li{the packaged relative-ratio estimate for the union of all six root
+  subgroups in \citet{Proposition 6.1, p. 34}{ershov2010noncommutative}; our
+  internal allocation is \strong{3--5.5 thousand}. Six repeated Lean
+  instantiations would be an implementation choice, not six mathematical
+  inputs; and}
   \li{assembly plus the exact qualitative export theorem for
-  \code{PaperPropertyT.elementaryGroup}: \strong{1.5--3 thousand}.}
+  the elementary-group property-(T) boundary; our internal allocation is
+  \strong{1.5--3 thousand}.}
 }
+
+\p{These internal allocations overlap, and their subtotal excludes integration
+adapters, proof-search retries, and pin-specific repair risk. It therefore is
+not an arithmetic derivation of the 18--35 thousand-line envelope.}
 
 \p{The existing analytic shell is not part of the missing estimate.
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/PositiveSpectralMeasure.lean#L2255-L2268}{\code{PositiveSpectralMeasure.spectral_criterion_unconditional}}
@@ -47,54 +64,62 @@ the quantitative root-subgroup, fixed-space, graph, and detector mathematics
 listed above; it should reuse that shell rather than construct another PVM
 layer.}
 
-\p{The pinned Connes project uses Mathlib
-\code{905b95818eb32af7874a58b427f50c1711a5e96c} with Lean
-\code{v4.32.2}. Mathlib supplies the graph Laplacian and its positivity theorem,
-marked above as \code{SimpleGraph.lapMatrix} and
-\code{SimpleGraph.posSemidef_lapMatrix}, but not the
+\p{The pinned Connes project uses Mathlib revision
+\href{https://github.com/leanprover-community/mathlib4/commit/905b95818eb32af7874a58b427f50c1711a5e96c}{\code{905b958}} with Lean 4.32.2.
+Mathlib supplies the graph Laplacian and its positivity theorem, exposed by
+the declaration links above, but not the
 Ershov--Jaikin-Zapirain graph-of-groups criterion, Kazhdan ratios, root
-gradings, codistance, or the magic graph argument. The relative-property-(T)
-estimates are calibrated by
-\citet{Theorem 2.2 and Lemmas 2.3--2.7}{kassabov2005universal} and by the
-earlier quantitative development in \citet{Sections 2--6 and Appendix
+gradings, codistance, or the graph argument. Kassabov's
+\citet{Theorem 2.2 and Lemmas 2.3--2.7, pp. 11--18}{kassabov2005universal}
+concern a free associative integer ring and require quotient transport before
+application to #{\mathbb F_2[t]}. For calibration over an arbitrary finitely
+generated ring and module, the cleaner reference is
+\citet{Appendix Theorem A.1, p. 110}{ershov2017rootgraded}. The direct route is
+the earlier quantitative development in \citet{Sections 2--6 and Appendix
 A}{ershov2010noncommutative}.}
 
-\p{TauCeti at the referenced revision
-\code{cc6ce758421ce3a0731ff62667b7771cfc4aa3da} uses Mathlib
-\code{de5ce8a9a66a4aa68a9bdbb35b63a06d34d9ca11} and Lean
-\code{v4.34.0-rc1}. Its
+\p{TauCeti at revision
+\href{https://github.com/TauCetiProject/TauCeti/commit/cc6ce758421ce3a0731ff62667b7771cfc4aa3da}{\code{cc6ce75}}
+uses Mathlib \href{https://github.com/leanprover-community/mathlib4/commit/de5ce8a9a66a4aa68a9bdbb35b63a06d34d9ca11}{\code{de5ce8a}}
+and Lean 4.34.0-rc1. Its
 \href{https://github.com/TauCetiProject/TauCeti/blob/cc6ce758421ce3a0731ff62667b7771cfc4aa3da/TauCeti/LowDimTopology/Plumbing/DiagonalDominance.lean#L73-L74}{diagonal-dominance proof}
 consumes the same Mathlib Laplacian facts, but its source and roadmap
 contain no direct property-(T), Kazhdan, codistance, root-graded, or magic-graph
 lane. It is therefore not a drop-in dependency for this boundary. Moving the
-Connes development immediately to that pin would add an estimated
-\strong{2--5 thousand lines of migration and pin-repair work}, not reduce the
-mathematical estimate.}
+Connes development immediately to that pin would add, by our internal
+engineering estimate, \strong{2--5 thousand lines of migration and pin-repair
+work}; it would not reduce the mathematical estimate.}
 
-\p{Bounded elementary generation is not presently shorter. Nica's theorem
-gives
+\p{Bounded elementary generation is not presently shorter. Nica's
+\citet{Theorem 2, p. 2}{nica2019bounded} gives
 
 ##{\nu_3=\frac{3\cdot3^2-3}{2}+29=41,}
 
-but its proof invokes the Kornblum--Artin theorem for irreducibles in
-polynomial arithmetic progressions \citet{Theorems 2--3}{nica2019bounded}.
-That input is absent from the pinned Mathlib revision. A self-contained
-Nica--Kassabov route is estimated at \strong{20--45 thousand lines} and
-\strong{three to six times the current engineering effort}, with about
-70 percent uncertainty. Assuming Kornblum--Artin reduces it to roughly
-\strong{8--15 thousand lines}, but merely moves the external boundary. A
-reusable formalization of the generic EJK theorem is at least
-\strong{45--90 thousand lines} and is unnecessary for Zhou's application.}
+and its proof invokes the Kornblum--Artin theorem for irreducibles in
+polynomial arithmetic progressions, stated as
+\citet{Theorem 3, p. 2}{nica2019bounded}. That input is absent from the pinned
+Mathlib revision. Our internal estimate for a self-contained Nica--Kassabov
+route is \strong{20--45 thousand lines} and \strong{three to six times the
+current engineering effort}, with roughly 70 percent internal uncertainty.
+Assuming Kornblum--Artin gives our internal estimate of \strong{8--15 thousand
+lines}, but merely moves the external boundary. Our internal estimate for a
+reusable formalization of the generic EJK theorem is \strong{45--90 thousand
+lines}; that generality is unnecessary for Zhou's application.}
 
-\p{The literature anchors for the estimate are Zhou's exact invocation
-\citet{Proposition 4.1, pp. 8--10}{zhou2026icc}; the general theorem,
-quantitative language, graph criterion, strong grading, #{A_2} specialization,
-and Appendix relative theorem in \citet{Theorem 1.1, Sections 2--5 and
-7.2--7.4, Appendix A}{ershov2017rootgraded}; the shorter magic-graph assembly
-in \citet{Sections 2--6 and Appendix A}{ershov2010noncommutative}; Kassabov's
-relative estimates cited above; and Nica's exact-ring alternative. The OpenAI
-volume \citek{openai2026tenadvances} is retained only as provenance for generic
-formalization components adapted locally, not as mathematical authority for
-the EJZK theorem.}
+\p{The literature anchors for the route decomposition are Zhou's exact
+invocation \citet{Proposition 4.1, pp. 8--10}{zhou2026icc}; the exact
+elementary-group theorem, unweighted boundary graph, and packaged six-root
+estimate in \citet{Theorem 1.1, p. 1; Section 5.4, pp. 25--29; Proposition
+6.1, pp. 34--35}{ershov2010noncommutative}; the broader root-graded theorem and
+arbitrary-ring relative estimate in \citet{Theorem 1.1, p. 3; Appendix Theorem
+A.1, p. 110}{ershov2017rootgraded}; Kassabov's free-associative-ring estimates;
+and Nica's exact-ring alternative. None states our LOC or effort ranges.
+Chapter 4 of \citek{openai2026tenadvances} is independent binary-carry
+mathematical context, not code provenance and not authority for the EJZK
+theorem. Adapted Lean infrastructure is traced instead to the pinned
+\href{https://github.com/openai/ten-proofs/tree/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6}{\code{openai/ten-proofs} snapshot}
+and the Connes project's
+\href{https://github.com/utensil/connes-rigidity/blob/main/docs/PROVENANCE.md}{provenance ledger}
+and \href{https://github.com/utensil/connes-rigidity/blob/main/docs/PORT_MAP.md}{port map}.}
 
 \related{\ref{connes-0001}}


### PR DESCRIPTION
## Summary

This stacked correction:

- separates the OpenAI volume’s independent Chapter 4 binary-carry mathematics from code provenance in the pinned `openai/ten-proofs` snapshot and the Connes project’s public provenance ledger;
- makes Ershov–Jaikin-Zapirain 2010 Theorem 1.1 and Sections 5.4 and 6.1 the primary exact route to property (T) for `EL₃(𝔽₂[t])`, while treating EJK 2017 as broader supporting machinery;
- corrects the boundary graph to the unweighted standard-Laplacian case, separating the weighted Section 5.5 criterion;
- uses Proposition 6.1’s packaged relative-ratio estimate for the union of the six root subgroups;
- records six additive root-subgroup embeddings and direct A₂ commutator relations without requiring a Steinberg detour;
- qualifies Kassabov’s free-associative-integer-ring estimates and points to EJK Appendix Theorem A.1 for arbitrary finitely generated rings and modules;
- records Nica’s exact `ν₃ = 41` bound and its Kornblum–Artin dependency;
- labels every LOC and effort range as an internal engineering estimate, not a literature claim;
- reflows the corrected citations, revision links, and dependency diagram without overfull boxes.

Public bibliographic citations and theorem/page references remain intact.

## Validation

- `just chk`
- `TEXINPUTS="$PWD/tex:" opam exec -- forester build`
- `./lize.sh connes-0001`
- 15-page article inspected as page images; no overfull boxes, unresolved citations, or unresolved references
- all 12 Connes trees contain the agent-authored marker; `connes-0001` appears in generated `uts-016Q`
- exact author and committer identity verified

This PR is stacked on `terra/connes-formalization-notes`; it must not be merged independently before its base.
