### PR TITLE
fix(pdf): externalize out-of-tree references

### DIFF
--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -371,7 +371,17 @@
         <xsl:text>\href{</xsl:text>
         <xsl:value-of select="@uri" />
         <xsl:text>}{</xsl:text>
-        <xsl:apply-templates />
+        <xsl:choose>
+          <!-- A contextual number is meaningful only when its target is in this PDF. -->
+          <xsl:when test="f:contextual-number">
+            <xsl:text>[</xsl:text>
+            <xsl:value-of select="@display-uri" />
+            <xsl:text>]</xsl:text>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates />
+          </xsl:otherwise>
+        </xsl:choose>
         <xsl:text>}</xsl:text>
       </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
The PDF renderer treated contextual references outside the transclusion tree as if their section labels existed in the current document. The link itself was external, but its text still used an internal `\ref*`, producing an undefined reference.

For an out-of-tree local link carrying a contextual number, render the linked note identifier instead. In-tree references and custom link text keep their existing paths.

Validation:

- the generated TeX changes only the `spin-0010` link
- internal-reference, citation, and hyperlink counts are unchanged
- the 44-page FGAP PDF rebuild has no undefined references
- page 1 shows `[spin-0010]` linked to the published note
