### PR TITLE
chore: remove resolved Forester 5.x upgrade banner

### DIFF
--- a/assets/uts-layout.xsl
+++ b/assets/uts-layout.xsl
@@ -89,9 +89,6 @@
                 </header>
 
                 <div id="grid-wrapper">
-                    <blockquote>
-                        NOTE: This site has just upgraded to Forester 5.x and is still having some style and functionality <span class="link external"><a href="https://github.com/utensil/forest/issues/9">issues</a></span>, we will fix them ASAP.
-                    </blockquote>
                     <article>
                         <xsl:apply-templates select="fr:tree" />
                     </article>


### PR DESCRIPTION
Closes #9

The Forester 5.x migration is now verified on current main:
- full `just build` succeeds; 1,190 redirect stubs are restored to XSL-converted HTML on a repeat build
- the known two bare-domain link diagnostics are false positives; the target returns HTTP 200
- the remaining upstream #182 XML argument-consistency edge case is not exercised by this forest; the prior content-node failure is covered by the HTML `\placeholder` migration

This PR intentionally removes only the obsolete banner; it does not change the Forester pin.