### PR TITLE
fix: restore visible browser demos [AGENT]

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -70,7 +70,10 @@ function prep_wasm {
     if [ -n "$CI" ] || [ -n "$UTS_DEV" ]; then
         if [ "$needs_build" = "true" ]; then
             echo "Building WASM package for $lib_name..."
-            (cd "lib/$lib_path" && bunx wasm-pack -v build --target web --release . --out-dir pkg || echo -e "\033[0;31mwasm-pack build failed\033[0m")
+            if ! (cd "lib/$lib_path" && bunx wasm-pack -v build --target web --release --no-opt . --out-dir pkg); then
+                echo -e "\033[0;31mwasm-pack build failed for $lib_name\033[0m" >&2
+                return 1
+            fi
             [ -d "lib/$lib_path/pkg" ] && echo "$hash" > "$hash_file"
         else
             echo "Using cached WASM package for $lib_name"
@@ -79,19 +82,24 @@ function prep_wasm {
         echo "🟡 Skipping wasm-pack build for $lib_name, some notes that used Rust and WASM might not work as epected."
     fi
 
-    cp "lib/$lib_path"/pkg/*.wasm output/forest/
+    if ! compgen -G "lib/$lib_path/pkg/*.wasm" > /dev/null; then
+        echo "Missing WASM output for $lib_name" >&2
+        return 1
+    fi
+
+    cp "lib/$lib_path"/pkg/*.wasm output/forest/ || return 1
 }
 
 function bun_build {
     # don't run `bun install` for `dev.sh`
     if [ -z "$UTS_DEV" ]; then
-        bun install --frozen-lockfile
+        bun install --frozen-lockfile || return 1
     fi
 
     mkdir -p output/forest
-    prep_wasm wgputoy https://github.com/compute-toys/wgpu-compute-toy.git 60d0bec4bd912a54d5049f2c28c1bd6a0916e5ec
-    prep_wasm egglog https://github.com/egraphs-good/egglog.git 8d9b10ec712106b21d10b7bf45d10c0f9d1d09c7 egglog/web-demo
-    prep_wasm rhaiscript https://github.com/rhaiscript/playground 9fa80661bc9eb69363ac86879826dcd8ccb604af
+    prep_wasm wgputoy https://github.com/utensil/wgpu-compute-toy.git dd2dfbe5a686090ece17672de4e430a7980bd2d9 || return 1
+    prep_wasm egglog https://github.com/egraphs-good/egglog.git 8d9b10ec712106b21d10b7bf45d10c0f9d1d09c7 egglog/web-demo || return 1
+    prep_wasm rhaiscript https://github.com/rhaiscript/playground 9fa80661bc9eb69363ac86879826dcd8ccb604af || return 1
     # failed:
     # prep_wasm nalgebra https://github.com/dimforge/nalgebra
 
@@ -100,7 +108,7 @@ function bun_build {
         # if the file extension is .css
         if [[ $FILE == *".css" ]]; then
             echo "🚀 lightningcss"
-            just css "bun/$FILE"
+            just css "bun/$FILE" || return 1
             # check result
             # EXIT_CODE=$?
             # if [ $EXIT_CODE -ne 0 ]; then
@@ -108,7 +116,7 @@ function bun_build {
             #     exit $EXIT_CODE
             # fi
         elif [[ $FILE == *".ts" || $FILE == *".tsx" || $FILE == *".jsx" ]]; then
-            just js "bun/$FILE"
+            just js "bun/$FILE" || return 1
             # bun build bun/$FILE --outdir output
         fi
     done
@@ -229,16 +237,16 @@ function write_root_redirect() {
 function build {
     mkdir -p build
     echo "⭐ Rebuilding bun"
-    bun_build
+    if ! bun_build; then
+        echo -e "\033[0;31mError: browser asset build failed.\033[0m" >&2
+        return 1
+    fi
     backup_xml_files
     backup_html_before_forester
     echo "⭐ Rebuilding forest"
-    just forest
-    show_result
-
-    if [ $? -ne 0 ]; then
+    if ! just forest; then
         echo -e "\033[0;31mError: Forest build failed.\033[0m"
-        exit 1
+        return 1
     fi
 
     restore_html_after_forester
@@ -250,12 +258,10 @@ function build {
     #     echo -e "\033[0;31mError: index.xml not found in output directory. Forest build likely failed.\033[0m"
     #     exit 1
     # fi
-    just assets
+    just assets || return 1
     # if the env var UTS_DEV is not set
     # if [ -z "$UTS_DEV" ]; then
-    convert_xml_files true
-    # fi
-    show_result
+    convert_xml_files true || return 1
     #   build_ssr
     #   show_result
     # echo "Open build/forester.log to see the log."
@@ -280,7 +286,9 @@ function lize {
     #   show_lize_result uts-0001
 }
 
-time build
+if ! build; then
+    exit 1
+fi
 echo
 
 #if environment variable CI or LIZE is set

--- a/bun/demo-output.ts
+++ b/bun/demo-output.ts
@@ -1,0 +1,48 @@
+type DemoResult = readonly [label: string, value: string]
+
+function outputFor(name: string): HTMLElement | null {
+    return document.querySelector(`[data-demo-output="${name}"]`)
+}
+
+export function renderDemoResults(
+    name: string,
+    results: readonly DemoResult[],
+): void {
+    const output = outputFor(name)
+    if (!output) {
+        return
+    }
+
+    output.classList.remove('demo-output--error')
+
+    const title = document.createElement('p')
+    title.className = 'demo-output__title'
+    title.textContent = 'Computed locally'
+
+    const list = document.createElement('dl')
+    list.className = 'demo-output__results'
+    for (const [label, value] of results) {
+        const term = document.createElement('dt')
+        term.textContent = label
+        const definition = document.createElement('dd')
+        definition.textContent = value
+        list.append(term, definition)
+    }
+
+    output.replaceChildren(title, list)
+}
+
+export function renderDemoError(name: string, error: unknown): void {
+    const output = outputFor(name)
+    if (!output) {
+        return
+    }
+
+    output.classList.add('demo-output--error')
+    const title = document.createElement('p')
+    title.className = 'demo-output__title'
+    title.textContent = 'This browser-side computation could not run.'
+    const detail = document.createElement('code')
+    detail.textContent = error instanceof Error ? error.message : String(error)
+    output.replaceChildren(title, detail)
+}

--- a/bun/hello-egglog.ts
+++ b/bun/hello-egglog.ts
@@ -1,14 +1,16 @@
-import init, { start, run_program } from '../lib/egglog/web-demo/pkg'
+import init, { run_program } from '../lib/egglog/web-demo/pkg'
+import { renderDemoError, renderDemoResults } from './demo-output'
 
-await init()
+try {
+    await init()
 
-function log(level, str) {
-    // console.log(str);
-}
+    function log(_level: unknown, _str: unknown) {
+        // console.log(str);
+    }
 
-window.log = log
+    window.log = log
 
-const result = run_program(`(function fib (i64) i64)
+    const result = run_program(`(function fib (i64) i64)
 (set (fib 0) 0)
 (set (fib 1) 1)
 
@@ -20,4 +22,9 @@ const result = run_program(`(function fib (i64) i64)
 
 (check (= (fib 7) 13))`)
 
-console.log(result)
+    console.log(result)
+    renderDemoResults('egglog', [['Fibonacci check', 'fib(7) = 13']])
+} catch (error) {
+    console.error(error)
+    renderDemoError('egglog', error)
+}

--- a/bun/hello-ginac.ts
+++ b/bun/hello-ginac.ts
@@ -1,12 +1,13 @@
 import { getFactory, initGiNaC } from 'ginac-wasm'
 // bun add ginac-wasm
 import ginac_wasm from 'ginac-wasm/dist/ginac.wasm'
+import { renderDemoError, renderDemoResults } from './demo-output'
 ;(async () => {
-    const GiNaC = await initGiNaC(`/forest/${ginac_wasm}`)
-    const g = getFactory()
+    try {
+        const GiNaC = await initGiNaC(`/forest/${ginac_wasm}`)
+        const g = getFactory()
 
-    console.log(
-        GiNaC([
+        const expressions = GiNaC([
             // 2 * 3 = 6
             g.mul(g.numeric('2'), g.numeric('3')),
             // x + 2x = 3x
@@ -15,28 +16,38 @@ import ginac_wasm from 'ginac-wasm/dist/ginac.wasm'
             g.diff(g.mul(g.numeric('2'), g.sin(g.symbol('x'))), g.symbol('x')),
             // internal parser of GiNaC
             g.parse('x^3 + 3*x + 1'),
-        ]),
-    )
+        ])
+        console.log(expressions)
 
-    console.log(
-        GiNaC([
-            g.numeric('2'),
-            g.numeric('3'),
-            // reference first and second items from the array => 2*3 = 6
-            g.mul(g.ref(0), g.ref(1)),
-        ]),
-    )
+        console.log(
+            GiNaC([
+                g.numeric('2'),
+                g.numeric('3'),
+                // reference first and second items from the array => 2*3 = 6
+                g.mul(g.ref(0), g.ref(1)),
+            ]),
+        )
 
-    // besides the string output format,
-    // it can also generate traversable json structures
-    console.dir(
-        GiNaC(
-            [
-                // 2*sin(x)
-                g.mul(g.numeric('2'), g.sin(g.symbol('x'))),
-            ],
-            { json: true },
-        ),
-        { depth: null },
-    )
+        // Besides the string output format, GiNaC can generate traversable JSON.
+        console.dir(
+            GiNaC(
+                [
+                    // 2*sin(x)
+                    g.mul(g.numeric('2'), g.sin(g.symbol('x'))),
+                ],
+                { json: true },
+            ),
+            { depth: null },
+        )
+
+        renderDemoResults('ginac', [
+            ['2 × 3', expressions[0]?.string ?? 'no result'],
+            ['x + 2x', expressions[1]?.string ?? 'no result'],
+            ['d/dx (2 sin(x))', expressions[2]?.string ?? 'no result'],
+            ['parse(x³ + 3x + 1)', expressions[3]?.string ?? 'no result'],
+        ])
+    } catch (error) {
+        console.error(error)
+        renderDemoError('ginac', error)
+    }
 })()

--- a/bun/uts-style.css
+++ b/bun/uts-style.css
@@ -1046,6 +1046,43 @@ code.highlight.grace-loading {
     }
 }
 
+.wgputoy.wgputoy-error {
+    color: inherit;
+    display: grid;
+    place-items: center;
+    padding: 1rem;
+    text-align: center;
+}
+
+.demo-output {
+    border: 1px solid var(--uts-text-gentle);
+    color: inherit;
+    margin: 1rem auto;
+    max-width: var(--uts-canvas-width);
+    padding: 0.75rem 1rem;
+}
+
+.demo-output__title {
+    font-weight: bold;
+    margin: 0 0 0.5rem;
+}
+
+.demo-output__results {
+    display: grid;
+    gap: 0.25rem 1rem;
+    grid-template-columns: max-content 1fr;
+    margin: 0;
+}
+
+.demo-output__results dd {
+    font-family: var(--mono);
+    margin: 0;
+}
+
+.demo-output--error code {
+    white-space: pre-wrap;
+}
+
 .shadertoywithcode {
     details {
         cursor: pointer;

--- a/bun/uwal.ts
+++ b/bun/uwal.ts
@@ -2,8 +2,12 @@
 
 // based on https://github.com/UstymUkhman/uwal/blob/main/src/lessons/fundamentals/index.js
 import { UWAL } from 'uwal'
+import { renderDemoError, renderDemoResults } from './demo-output'
 
-const uwal_compute = async (input, shader) => {
+const uwalCompute = async (
+    input: Float32Array,
+    shader: string,
+): Promise<number[]> => {
     // Run computations on the GPU:
     {
         // const input = new Float32Array([1, 3, 5]);
@@ -46,10 +50,9 @@ const uwal_compute = async (input, shader) => {
 
         await resultBuffer.mapAsync(GPUMapMode.READ)
         const result = new Float32Array(resultBuffer.getMappedRange())
-
-        return result
-
-        // resultBuffer.unmap();
+        const values = Array.from(result)
+        resultBuffer.unmap()
+        return values
     }
 }
 
@@ -66,5 +69,14 @@ fn compute(@builtin(global_invocation_id) id: vec3u)
 }
 `
 
-const result = await uwal_compute(input, shader)
-console.log(result)
+try {
+    const result = await uwalCompute(input, shader)
+    console.log(result)
+    renderDemoResults('uwal', [
+        ['Input', '[1, 3, 5]'],
+        ['GPU output', `[${result.join(', ')}]`],
+    ])
+} catch (error) {
+    console.error(error)
+    renderDemoError('uwal', error)
+}

--- a/bun/wgputoy.ts
+++ b/bun/wgputoy.ts
@@ -1,14 +1,18 @@
-import init, { create_renderer, WgpuToyRenderer } from '../lib/wgputoy/pkg'
+import init, { create_renderer } from '../lib/wgputoy/pkg'
 
 interface CustomUniforms {
     [key: string]: number
 }
 
-await init()
+const initialized = init()
 
-const embeded_wgputoys = document.querySelectorAll('.wgputoy')
+function showError(element: Element, message: string): void {
+    element.classList.remove('lazy-loading')
+    element.classList.add('wgputoy-error')
+    element.textContent = message
+}
 
-for (const element of embeded_wgputoys) {
+async function startToy(element: Element): Promise<void> {
     const canvas = document.createElement('canvas')
     canvas.id = `wgputoy-${Math.random().toString(36).substring(7)}`
 
@@ -21,85 +25,100 @@ for (const element of embeded_wgputoys) {
     element.innerHTML = ''
     element.classList.add('lazy-loading')
 
-    const handleMouseOver = async (event: MouseEvent) => {
-        element.removeEventListener('mouseover', handleMouseOver)
+    try {
+        if (!('gpu' in navigator)) {
+            showError(element, 'This browser does not support WebGPU.')
+            return
+        }
+
+        await initialized
         element.classList.remove('lazy-loading')
         element.appendChild(canvas)
-        if (canvas?.getContext('webgpu') && 'gpu' in navigator) {
-            const context = canvas.getContext('webgpu')
-            const presentationFormat = navigator.gpu.getPreferredCanvasFormat()
-            const adapter = await navigator.gpu.requestAdapter()
-            if (adapter) {
-                const device = await adapter.requestDevice()
 
-                if (device) {
-                    context.configure({
-                        device,
-                        format: presentationFormat,
-                    })
+        const context = canvas.getContext('webgpu')
+        if (!context) {
+            showError(element, 'WebGPU is unavailable for this canvas.')
+            return
+        }
 
-                    const width = element.clientWidth
-                    const height = element.clientHeight
+        const presentationFormat = navigator.gpu.getPreferredCanvasFormat()
+        const adapter = await navigator.gpu.requestAdapter()
+        if (!adapter) {
+            showError(element, 'No WebGPU adapter is available.')
+            return
+        }
 
-                    // console.log(width, height);
+        const device = await adapter.requestDevice()
+        context.configure({ device, format: presentationFormat })
 
-                    const renderer = await create_renderer(
-                        width,
-                        height,
-                        canvas.id,
-                    )
-                    renderer.on_success = () => {}
-                    renderer.on_error = (error) => {
-                        console.error(error)
-                    }
+        const renderer = await create_renderer(
+            element.clientWidth,
+            element.clientHeight,
+            canvas.id,
+        )
+        renderer.on_success = () => {}
+        renderer.on_error = (error) => {
+            console.error(error)
+            showError(element, `WebGPU shader error: ${error}`)
+        }
 
-                    // console.log(renderer);
+        shader = shader.replace(
+            '@group(0) @binding(5) var<uniform> custom: Custom;',
+            '',
+        )
 
-                    shader = shader.replace(
-                        '@group(0) @binding(5) var<uniform> custom: Custom;',
-                        '',
-                    )
+        if (Object.keys(custom).length > 0) {
+            renderer.set_custom_floats(
+                Object.keys(custom),
+                Float32Array.from(Object.values(custom)),
+            )
+        }
 
-                    // if custom has more than 0 keys
-                    if (Object.keys(custom).length > 0) {
-                        renderer.set_custom_floats(
-                            Object.keys(custom),
-                            Float32Array.from(Object.values(custom)),
-                        )
-                    }
+        const processedShader = await renderer.preprocess(shader)
+        if (!processedShader) {
+            showError(element, 'WebGPU shader preprocessing failed.')
+            return
+        }
 
-                    renderer.preprocess(shader).then((s) => {
-                        if (s) {
-                            let start: number | undefined
-                            let last = 0
-                            renderer.compile(s)
-                            // renderer.render();
+        let start: number | undefined
+        let last = 0
+        renderer.compile(processedShader)
 
-                            const step = (timestamp: DOMHighResTimeStamp) => {
-                                if (start === undefined) {
-                                    start = timestamp
-                                }
-                                const elapsed = timestamp - start
+        const step = (timestamp: DOMHighResTimeStamp) => {
+            if (start === undefined) {
+                start = timestamp
+            }
+            const elapsed = timestamp - start
+            renderer.set_time_elapsed(elapsed / 1000.0)
+            renderer.set_time_delta((elapsed - last) / 1000.0)
+            last = elapsed
+            renderer.render()
+            requestAnimationFrame(step)
+        }
 
-                                renderer.set_time_elapsed(elapsed / 1000.0)
-                                renderer.set_time_delta(
-                                    (elapsed - last) / 1000.0,
-                                )
+        requestAnimationFrame(step)
+    } catch (error) {
+        console.error(error)
+        showError(
+            element,
+            `WebGPU renderer failed: ${error instanceof Error ? error.message : String(error)}`,
+        )
+    }
+}
 
-                                last = elapsed
-
-                                renderer.render()
-
-                                requestAnimationFrame(step)
-                            }
-
-                            requestAnimationFrame(step)
-                        }
-                    })
-                }
+const embeddedWgputoys = document.querySelectorAll('.wgputoy')
+const observer = new IntersectionObserver(
+    (entries) => {
+        for (const entry of entries) {
+            if (entry.isIntersecting) {
+                observer.unobserve(entry.target)
+                void startToy(entry.target)
             }
         }
-    }
+    },
+    { rootMargin: '200px' },
+)
 
-    element.addEventListener('mouseover', handleMouseOver)
+for (const element of embeddedWgputoys) {
+    observer.observe(element)
 }

--- a/bun_build.ts
+++ b/bun_build.ts
@@ -65,6 +65,7 @@ if (!result.success) {
         // Bun will pretty print the message object
         console.error(message)
     }
+    process.exitCode = 1
 } else {
     // Copy WASM assets for aliased packages — bun doesn't auto-copy npm WASM files.
     // These must come from the same dist/ tree as the aliased JS entry.

--- a/justfile
+++ b/justfile
@@ -52,7 +52,7 @@ glsl SOURCE:
 css SOURCE:
     # ln -s {{justfile_directory()}}/assets/images bun/images || true
     bun build --target=browser --minify --outfile=output/forest/{{file_name(SOURCE)}} {{SOURCE}}
-    rm bun/images
+    rm -f bun/images
     # blocks on
     # - [fix: Use correct MIME type for CSS files in Bun.build outputs](https://github.com/oven-sh/bun/pull/21849)
     # - [Allow relative assets in CSS that don't exist · Issue #22725 · oven-sh/bun](https://github.com/oven-sh/bun/issues/22725)

--- a/trees/uts-001H.tree
+++ b/trees/uts-001H.tree
@@ -6,7 +6,8 @@
 \note{test GiNaC (WASM)}{
 \loadjs{hello-ginac.js}
 
-\p{For now, open the console to see the output.
-}
+\p{This example evaluates symbolic expressions locally in the browser.}
+
+\<html:div>[class]{demo-output}[data-demo-output]{ginac}[aria-live]{polite}{Computing symbolic expressions…}
 
 }

--- a/trees/uts-001I.tree
+++ b/trees/uts-001I.tree
@@ -5,6 +5,6 @@
 
 \note{test egglog}{
 \loadjs{hello-egglog.js}
-\p{For now, open the console to see the output.
-}
+\p{This example runs a local egglog fixed-point computation in the browser.}
+\<html:div>[class]{demo-output}[data-demo-output]{egglog}[aria-live]{polite}{Computing Fibonacci…}
 }

--- a/trees/uts-001J.tree
+++ b/trees/uts-001J.tree
@@ -5,6 +5,6 @@
 
 \note{test uwal}{
 \loadjs{uwal.js}
-\p{For now, open the console to see the output.
-}
+\p{This example doubles a small vector with a local WebGPU compute shader.}
+\<html:div>[class]{demo-output}[data-demo-output]{uwal}[aria-live]{polite}{Running the GPU computation…}
 }

--- a/verify-forester-output.sh
+++ b/verify-forester-output.sh
@@ -35,6 +35,13 @@ if [ ! -f "$output_dir/forester.js" ]; then
     exit 1
 fi
 
+for runtime_asset in wgputoy.js wgputoy_bg.wasm; do
+    if [ ! -s "$output_dir/$runtime_asset" ]; then
+        echo "Publish output must include the required $runtime_asset runtime" >&2
+        exit 1
+    fi
+done
+
 if [ -e "$output_dir/min.js" ]; then
     echo "Publish output must not include Forester's unused native bundle" >&2
     exit 1


### PR DESCRIPTION
## Summary

- build and publish the WgpuToy runtime from the exact isolated fork commit that compiles with the locked WebGPU API
- fail the build when WASM or Bun bundling fails, and require the WgpuToy JS/WASM assets in the publish-output contract
- replace console-only demo results with accessible in-page GiNaC, egglog, and UWAL output, and make WebGPU failures visible

## Verification

- full isolated `CI=1 ./build.sh` (1,190 converted page pairs and all existing PDF fixtures)
- `./verify-forester-output.sh output/forest spin-0001 hopf-0001 ca-0001 fgap-0001 fcap-0001 tt-0001 uts-000C`
- `bunx biome check` for changed Bun sources and `bash -n` for changed shell scripts
- browser acceptance on B/C/H/I/J: WebGPU canvases loaded from emitted runtime assets; visible results include `fib(7) = 13` and `[2, 6, 10]`