### PR TITLE
docs(connes): organize formalization boundaries

### DIFF
--- a/trees/connes-0001.tree
+++ b/trees/connes-0001.tree
@@ -83,7 +83,9 @@ transfer principles. The nonroutine points are where the paper suppresses an
 interface that Lean must make explicit. The tensor calculation becomes a
 square-span certificate in \ref{connes-000C}. Generator identities are upgraded
 to completed von Neumann algebras through the spatial witness of
-\ref{connes-0007}. Quantitative spectral detection is separated from the exact
+\ref{connes-0007}; that bridge now separates measurable crossed-product
+transport, continuous-coefficient closure, and the concrete nonadditive fiber
+shear. Quantitative spectral detection is separated from the exact
 qualitative boundary in \ref{connes-0003} and \ref{connes-0004}. The ICC proof
 uses the three-case criterion in \ref{connes-0006}, and nonisomorphism follows
 the quotient twist in \ref{connes-0008}. The assembly in \ref{connes-0002}

--- a/trees/connes-0001.tree
+++ b/trees/connes-0001.tree
@@ -65,7 +65,8 @@ separate port at the construction and theorem nodes.}
 
 \p{The mathematical weight is uneven. The characteristic-two construction in
 \ref{connes-000C} is concrete algebra and supplies every later carrier. The
-factor lane in \ref{connes-0007} is heavy operator algebra: compact duals, Haar
+factor lane in \ref{connes-0007}, \ref{connes-000D}, and \ref{connes-000E} is
+heavy operator algebra: compact duals, Haar
 measure, Fourier transforms, von Neumann closures, and trace transport. The
 property-(T) lane in \ref{connes-0003}, \ref{connes-0004}, and
 \ref{connes-0005} is heavy harmonic and representation theory: spectral
@@ -83,14 +84,16 @@ transfer principles. The nonroutine points are where the paper suppresses an
 interface that Lean must make explicit. The tensor calculation becomes a
 square-span certificate in \ref{connes-000C}. Generator identities are upgraded
 to completed von Neumann algebras through the spatial witness of
-\ref{connes-0007}; that bridge now separates measurable crossed-product
-transport, continuous-coefficient closure, and the concrete nonadditive fiber
-shear. Quantitative spectral detection is separated from the exact
-qualitative boundary in \ref{connes-0003} and \ref{connes-0004}. The ICC proof
+\ref{connes-0007}, \ref{connes-000D}, and \ref{connes-000E}; that bridge
+separates measurable crossed-product transport, continuous-coefficient closure,
+and the concrete nonadditive fiber shear. Quantitative spectral detection is
+separated from the exact qualitative boundary in \ref{connes-0003} and
+\ref{connes-0004}. The ICC proof
 uses the three-case criterion in \ref{connes-0006}, and nonisomorphism follows
-the quotient twist in \ref{connes-0008}. The assembly in \ref{connes-0002}
+the quotient twist in \ref{connes-000H}. The assembly in \ref{connes-0002}
 accepts proved propositions, not a record that already contains its conclusion.
-The broader lessons are collected in \ref{connes-000A}.}
+The broader lessons are collected in \ref{connes-000A}, \ref{connes-000F},
+and \ref{connes-000J}.}
 
 \p{The code has two architectural layers. Reusable group theory, linear
 algebra, topology, measure theory, and operator algebra live in a foundation
@@ -112,7 +115,8 @@ quotient automorphism induced by a hypothetical group isomorphism; and tying
 the factor target to the concrete Fourier shear and completed von Neumann
 closures. The final interface remains proposition-valued. Its assembly and
 trust boundary are detailed in \ref{connes-0002} and \ref{connes-0009}; the
-remaining EJZK work is scoped in \ref{connes-000B}.}
+remaining EJZK work is scoped in \ref{connes-000B}, \ref{connes-000G}, and
+\ref{connes-000I}.}
 
 \p{The notes use their own section numbers for a continuous reading order.
 Sections 2--7 correspond respectively to Zhou's Sections 2--7; that
@@ -140,6 +144,8 @@ are local to this development.}
 \subtree{
   \title{Factor equivalence by Fourier shear (Zhou §3)}
   \transclude{connes-0007}
+  \transclude{connes-000D}
+  \transclude{connes-000E}
 }
 
 \subtree{
@@ -157,6 +163,7 @@ are local to this development.}
 \subtree{
   \title{Nonisomorphism by characteristic modules (Zhou §6)}
   \transclude{connes-0008}
+  \transclude{connes-000H}
 }
 
 \subtree{
@@ -168,9 +175,13 @@ are local to this development.}
 \subtree{
   \title{Formalization adaptations}
   \transclude{connes-000A}
+  \transclude{connes-000F}
+  \transclude{connes-000J}
 }
 
 \subtree{
   \title{EJZK formalization outlook}
   \transclude{connes-000B}
+  \transclude{connes-000G}
+  \transclude{connes-000I}
 }

--- a/trees/connes-0007.tree
+++ b/trees/connes-0007.tree
@@ -7,7 +7,7 @@
 \tag{von-neumann-algebra}
 \taxon{Theorem}
 \title{Spatial implementation of the factor equivalence}
-\lean/connes{Connes.FactorWitness.SpatialWitness,Connes.FactorWitness.tracialEquiv_of_spatialWitness,Connes.PaperFactorClosure.paperGroupFactors_isomorphic}
+\lean/connes{Connes.CrossedProduct.EquivariantHaarHomeomorph,Connes.CrossedProduct.vonNeumannClosure_crossedGeneratorSetOfContinuousCoefficients_eq,Connes.CrossedProduct.continuousCrossedClosure_mem_iff,Connes.PaperCrossedHaar.paperHaarHomeomorph,Connes.PaperFactorClosure.paperGroupFactors_isomorphic}
 
 \p{The group von Neumann algebra #{L(G)} is represented on #{\ell^2(G)} as
 the von Neumann closure of the left regular operators. Its canonical trace is
@@ -25,16 +25,50 @@ and obtains trace preservation from the vacuum equation. Thus no operator-
 algebra conclusion is stored as an unexplained premise.}
 
 \p{For Zhou's groups, the concrete unitary is a composite of the two Fourier
-models and the fiber shear. The difficult closure statement is kept separate:
-the images of continuous crossed-product generators agree, their spans are
-dense, and conjugation therefore matches the two von Neumann closures. The
-final concrete objects are
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section3/FactorClosure.lean#L578-L697}{\code{paperSpatialUnitary}, \code{paperSpatialWitness}, and \code{paperGroupFactors_isomorphic}}.
-This is the operator-algebra interface behind the construction in
-\citet{Section 3}{zhou2026icc}. Chapter 4 of
-\citek{openai2026tenadvances} is an independent binary-carry construction and
-mathematical context; it is not the source of these Lean declarations. Adapted
-Lean infrastructure is traced separately to the pinned
+models and the fiber shear. Proposition 3.2 proves that the shear is a
+Haar-measure-preserving homeomorphism and strictly conjugates the two actions.
+Remark 3.3 emphasizes the decisive point: its quadratic correction is generally
+not additive, so the shear need not be a compact-group automorphism. Proposition
+3.4 then uses only the induced equivariant measure-space isomorphism after
+Fourier transform
+\citet{Proposition 3.2, Remark 3.3, and Proposition 3.4}{zhou2026icc}. The
+independent crossed-product discussion in
+\citet{Chapter 4, Section 2.3, equation (2.1)}{openai2026tenadvances}
+corroborates this general mechanism: the crossed product depends on the Haar
+probability space and its action, not on preservation of the compact-group law.}
+
+\p{The Lean boundary mirrors that distinction. The concrete
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Paper/Section3/CrossedHaar.lean#L108-L141}{\code{paperFiberShearHomeomorph} and \code{paperHaarHomeomorph}}
+package continuity, measure preservation, and action equivariance, but contain
+no additive-homomorphism field. Forgetting the topology gives the existing
+measurable \code{paperHaarEquiv}. At the foundation layer,
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L141-L162}{\code{EquivariantHaarHomeomorph}}
+records exactly this stronger witness and projects it to the measurable
+transport interface. The extra topology is an implementation aid for the
+continuous-coefficient argument, not a replacement for the paper's
+measure-theoretic statement.}
+
+\p{The closure proof has a separate job. Coordinate characters have norm-dense
+linear span in the continuous functions by Stone--Weierstrass. Since continuous
+coefficients act continuously as crossed-product multipliers, the generic
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L215-L375}{continuous-coefficient closure theorem}
+upgrades that density to equality of the generated von Neumann closures. The
+homeomorphism then transports continuous coefficients by pullback and yields
+the closure-membership equivalence
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L377-L460}{\code{continuousCrossedClosure_mem_iff}}.
+This does \em{not} assert that continuous functions are norm-dense in
+#{L^\infty}; instead it compares the particular von Neumann closures generated
+before and after adjoining all continuous coefficients.}
+
+\p{The paper-facing file now applies those two generic theorems once to each
+action, then composes the Fourier models with the shear. The final objects are
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Paper/Section3/FactorClosure.lean#L276-L404}{\code{paperSpatialUnitary}, \code{paperSpatialWitness}, and \code{paperGroupFactors_isomorphic}}.
+The refactor removes parallel action-one/action-two closure plumbing while
+leaving the Proposition 3.4 endpoint and Zhou's section order unchanged.}
+
+\p{Chapter 4 of \citek{openai2026tenadvances} develops an independent
+binary-carry construction and is mathematical context, not the source of these
+Lean declarations. Adapted Lean infrastructure is traced separately to the pinned
 \href{https://github.com/openai/ten-proofs/tree/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6}{\code{openai/ten-proofs} snapshot},
 through the Connes project's
 \href{https://github.com/utensil/connes-rigidity/blob/main/docs/PROVENANCE.md}{provenance ledger}
@@ -48,3 +82,11 @@ The group-factor consumer needs an equivalence of membership in the completed
 von Neumann algebras. Keeping that biconditional as the witness field prevents
 a dense-span argument from being silently replaced by a statement about an
 algebraic subalgebra.}
+
+\p{\strong{Design adaptation: separate mathematical sufficiency from formal
+convenience.} A measurable equivariant isomorphism suffices for the abstract
+crossed-product identification. The available concrete shear is also a
+homeomorphism, and that stronger fact makes pullback preserve continuous
+coefficients. The formalization uses the topological witness for the density
+bridge and immediately forgets it when invoking the measurable transport. This
+keeps the proof efficient without falsely requiring an additive equivalence.}

--- a/trees/connes-0007.tree
+++ b/trees/connes-0007.tree
@@ -7,7 +7,7 @@
 \tag{von-neumann-algebra}
 \taxon{Theorem}
 \title{Spatial implementation of the factor equivalence}
-\lean/connes{Connes.CrossedProduct.EquivariantHaarHomeomorph,Connes.CrossedProduct.vonNeumannClosure_crossedGeneratorSetOfContinuousCoefficients_eq,Connes.CrossedProduct.continuousCrossedClosure_mem_iff,Connes.PaperCrossedHaar.paperHaarHomeomorph,Connes.PaperFactorClosure.paperGroupFactors_isomorphic}
+\lean/connes{Connes.FactorWitness.SpatialWitness,Connes.FactorWitness.tracialEquiv_of_spatialWitness,Connes.PaperFactorClosure.paperGroupFactors_isomorphic}
 
 \p{The group von Neumann algebra #{L(G)} is represented on #{\ell^2(G)} as
 the von Neumann closure of the left regular operators. Its canonical trace is
@@ -24,69 +24,9 @@ restricts conjugation to the two group von Neumann algebras, proves normality,
 and obtains trace preservation from the vacuum equation. Thus no operator-
 algebra conclusion is stored as an unexplained premise.}
 
-\p{For Zhou's groups, the concrete unitary is a composite of the two Fourier
-models and the fiber shear. Proposition 3.2 proves that the shear is a
-Haar-measure-preserving homeomorphism and strictly conjugates the two actions.
-Remark 3.3 emphasizes the decisive point: its quadratic correction is generally
-not additive, so the shear need not be a compact-group automorphism. Proposition
-3.4 then uses only the induced equivariant measure-space isomorphism after
-Fourier transform
-\citet{Proposition 3.2, Remark 3.3, and Proposition 3.4}{zhou2026icc}. The
-independent crossed-product discussion in
-\citet{Chapter 4, Section 2.3, equation (2.1)}{openai2026tenadvances}
-corroborates this general mechanism: the crossed product depends on the Haar
-probability space and its action, not on preservation of the compact-group law.}
-
-\p{The Lean boundary mirrors that distinction. The concrete
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Paper/Section3/CrossedHaar.lean#L108-L141}{\code{paperFiberShearHomeomorph} and \code{paperHaarHomeomorph}}
-package continuity, measure preservation, and action equivariance, but contain
-no additive-homomorphism field. Forgetting the topology gives the existing
-measurable \code{paperHaarEquiv}. At the foundation layer,
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L141-L162}{\code{EquivariantHaarHomeomorph}}
-records exactly this stronger witness and projects it to the measurable
-transport interface. The extra topology is an implementation aid for the
-continuous-coefficient argument, not a replacement for the paper's
-measure-theoretic statement.}
-
-\p{The closure proof has a separate job. Coordinate characters have norm-dense
-linear span in the continuous functions by Stone--Weierstrass. Since continuous
-coefficients act continuously as crossed-product multipliers, the generic
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L215-L375}{continuous-coefficient closure theorem}
-upgrades that density to equality of the generated von Neumann closures. The
-homeomorphism then transports continuous coefficients by pullback and yields
-the closure-membership equivalence
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L377-L460}{\code{continuousCrossedClosure_mem_iff}}.
-This does \em{not} assert that continuous functions are norm-dense in
-#{L^\infty}; instead it compares the particular von Neumann closures generated
-before and after adjoining all continuous coefficients.}
-
-\p{The paper-facing file now applies those two generic theorems once to each
-action, then composes the Fourier models with the shear. The final objects are
+\p{For Zhou's groups, the concrete unitary composes the two Fourier models with
+the fiber shear. The measure-transport and von Neumann closure obligations are
+separated in \ref{connes-000D} and \ref{connes-000E}. Together they construct
 \href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Paper/Section3/FactorClosure.lean#L276-L404}{\code{paperSpatialUnitary}, \code{paperSpatialWitness}, and \code{paperGroupFactors_isomorphic}}.
-The refactor removes parallel action-one/action-two closure plumbing while
-leaving the Proposition 3.4 endpoint and Zhou's section order unchanged.}
-
-\p{Chapter 4 of \citek{openai2026tenadvances} develops an independent
-binary-carry construction and is mathematical context, not the source of these
-Lean declarations. Adapted Lean infrastructure is traced separately to the pinned
-\href{https://github.com/openai/ten-proofs/tree/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6}{\code{openai/ten-proofs} snapshot},
-through the Connes project's
-\href{https://github.com/utensil/connes-rigidity/blob/main/docs/PROVENANCE.md}{provenance ledger}
-and \href{https://github.com/utensil/connes-rigidity/blob/main/docs/PORT_MAP.md}{port map}.
-The mathematical conclusion and every witness field used here are proved in
-the Connes source.}
-
-\p{\strong{Design adaptation: the consumer is closure membership.}
-Mapping a convenient generating family is only an intermediate result.
-The group-factor consumer needs an equivalence of membership in the completed
-von Neumann algebras. Keeping that biconditional as the witness field prevents
-a dense-span argument from being silently replaced by a statement about an
-algebraic subalgebra.}
-
-\p{\strong{Design adaptation: separate mathematical sufficiency from formal
-convenience.} A measurable equivariant isomorphism suffices for the abstract
-crossed-product identification. The available concrete shear is also a
-homeomorphism, and that stronger fact makes pullback preserve continuous
-coefficients. The formalization uses the topological witness for the density
-bridge and immediately forgets it when invoking the measurable transport. This
-keeps the proof efficient without falsely requiring an additive equivalence.}
+This is the tracial factor equivalence asserted in
+\citet{Proposition 3.4}{zhou2026icc}.}

--- a/trees/connes-0008.tree
+++ b/trees/connes-0008.tree
@@ -7,27 +7,16 @@
 \tag{module-theory}
 \taxon{Theorem}
 \title{Characteristic modules detect nonisomorphism}
-\lean/connes{Connes.PaperCharacteristic.paperSL3NoNontrivialAbelianNormalSubgroup,Connes.Sp4.no_nontrivial_normal_abelian_subgroup,Connes.PaperModuleSemisimple.firstProduct_semisimple,Connes.PaperNonisomorphism.paperCharacteristicModuleEquiv,Connes.PaperModuleSemisimpleTransport.paperGroups_not_isomorphic}
+\lean/connes{Connes.PaperModuleSemisimple.firstProduct_semisimple,Connes.PaperNonisomorphism.paperCharacteristicModuleEquiv,Connes.PaperModuleSemisimpleTransport.paperGroups_not_isomorphic}
 
 \p{The Section 6 invariant is semisimplicity of a module obtained from the
 characteristic abelian kernel. This is suitable for formal transport: a group
 isomorphism identifies the characteristic kernels, descends to an automorphism
 #{\sigma} of the finite quotient, and induces a linear equivalence between the
 first quotient module and the second module with its action restricted along
-#{\sigma}. Semisimplicity is invariant under that linear equivalence.}
-
-\p{The characteristic-kernel step maps an abelian normal subgroup to both
-factors of #{\mathrm{SL}_3(\mathbb F_2[t])\times
-\operatorname{Sp}_4(\mathbb F_2)}. It therefore needs two vanishing results.
-The polynomial-matrix argument
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/Characteristic.lean#L163-L196}{\code{PaperCharacteristic.paperSL3NoNontrivialAbelianNormalSubgroup}}
-handles the #{\mathrm{SL}_3} image. The stronger finite result
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/Sp4KernelCertificate.lean#L2097-L2115}{\code{Sp4.no_nontrivial_normal_abelian_subgroup}}
-handles the symplectic image through a kernel-checked certificate. The product
-argument applying both inputs is
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/CharacteristicTransport.lean#L59-L107}{\code{paperSemidirectNormalAbelian_le_kernel}}.
-This confines finite enumeration to the symplectic factor and keeps both
-factor-specific proofs out of the abstract module transport.}
+#{\sigma}. Semisimplicity is invariant under that linear equivalence.
+The characteristic-kernel and quotient-twist boundaries used here are
+separated in \ref{connes-000H}.}
 
 \p{On the first side, explicit decomposition into simple summands culminates
 in
@@ -41,10 +30,3 @@ The public contradiction is
 This records the invariant used in \citet{Section 6}{zhou2026icc} while keeping
 the group-theoretic, finite-certificate, and module-theoretic arguments in
 separate files.}
-
-\p{\strong{Design adaptation: twisting does not repair nonsplitting.}
-Restriction along a group automorphism is an equivalence of module
-categories, with inverse given by restriction along the inverse automorphism.
-The formal proof nevertheless exports the exact twisted obstruction needed by
-the consumer, so no unproved categorical transport principle remains hidden
-at the final contradiction.}

--- a/trees/connes-000A.tree
+++ b/trees/connes-000A.tree
@@ -34,6 +34,23 @@ unitary that maps completed algebras and the vacuum. The ICC bridge asks for
 orbit and displacement data. Each boundary contains exactly what its next
 theorem consumes, which makes hypothesis strength and reuse auditable.}
 
+\p{\strong{Forget structure after it has served its consumer.}
+The Section 3 shear is packaged as an equivariant measure-preserving
+homeomorphism because pullback must preserve continuous coefficients. Its
+canonical projection to an equivariant measurable equivalence is what the full
+#{L^\infty} crossed-product transport consumes. This one-way forgetting records
+both facts accurately: Zhou's factor argument does not need an additive map,
+while the Lean density bridge legitimately uses the continuity proved in
+\citet{Proposition 3.2 and Remark 3.3}{zhou2026icc}.}
+
+\p{\strong{Prefer library equivalences to pointwise cancellation.}
+Mathlib already supplies continuous pullback as a star-algebra equivalence, so
+its surjectivity gives the reverse generator inclusion without a custom
+involutivity proof. Likewise, the inverse law for conjugation by a linear
+isometry equivalence replaces a pointwise operator calculation. These
+replacements shorten the proof while exposing the actual mathematical reason:
+both steps are transport along equivalences.}
+
 \p{\strong{Keep final assembly proposition-valued.}
 Section 7 combines previously proved endpoints. It does not accept a broad
 record containing the desired conclusion as a field. This “certificate

--- a/trees/connes-000A.tree
+++ b/trees/connes-000A.tree
@@ -5,7 +5,7 @@
 \tag{lean}
 \tag{proof-engineering}
 \taxon{Remark}
-\title{Reusable proof-architecture adaptations}
+\title{Dependency placement and consumer boundaries}
 \lean/connes{Connes.PaperSpectralPropertyT.completion_of_spectralData,Connes.PaperFactorClosure.paperSpatialWitness,Connes.PaperICC.ActionData}
 
 \p{\strong{Place instances at their mathematical source.}
@@ -33,35 +33,3 @@ not as a stronger numerical constant. The factor bridge asks for a spatial
 unitary that maps completed algebras and the vacuum. The ICC bridge asks for
 orbit and displacement data. Each boundary contains exactly what its next
 theorem consumes, which makes hypothesis strength and reuse auditable.}
-
-\p{\strong{Forget structure after it has served its consumer.}
-The Section 3 shear is packaged as an equivariant measure-preserving
-homeomorphism because pullback must preserve continuous coefficients. Its
-canonical projection to an equivariant measurable equivalence is what the full
-#{L^\infty} crossed-product transport consumes. This one-way forgetting records
-both facts accurately: Zhou's factor argument does not need an additive map,
-while the Lean density bridge legitimately uses the continuity proved in
-\citet{Proposition 3.2 and Remark 3.3}{zhou2026icc}.}
-
-\p{\strong{Prefer library equivalences to pointwise cancellation.}
-Mathlib already supplies continuous pullback as a star-algebra equivalence, so
-its surjectivity gives the reverse generator inclusion without a custom
-involutivity proof. Likewise, the inverse law for conjugation by a linear
-isometry equivalence replaces a pointwise operator calculation. These
-replacements shorten the proof while exposing the actual mathematical reason:
-both steps are transport along equivalences.}
-
-\p{\strong{Keep final assembly proposition-valued.}
-Section 7 combines previously proved endpoints. It does not accept a broad
-record containing the desired conclusion as a field. This “certificate
-isolation” makes \code{#print axioms} meaningful and lets semantic review trace
-each conjunct to the file where its mathematics occurs.}
-
-\p{These lessons concern proof structure rather than the mathematical claims
-of \citek{zhou2026icc} or the independent binary-carry construction in Chapter
-4 of \citek{openai2026tenadvances}. The latter is mathematical context, not code
-provenance. Where the implementation adapts prior Lean infrastructure, the
-source is the pinned \code{openai/ten-proofs} snapshot recorded in the Connes
-project's provenance ledger and port map. The lessons are reusable in
-formalizations where a linear paper proof crosses topology, analysis, finite
-computation, and algebraic transport.}

--- a/trees/connes-000B.tree
+++ b/trees/connes-000B.tree
@@ -6,7 +6,7 @@
 \tag{property-t}
 \tag{formalization-estimate}
 \taxon{Remark}
-\title{Formalizing the remaining EJZK theorem}
+\title{EJZK route and effort envelope}
 \lean/connes{Connes.PaperPropertyT.elementaryGroup,Connes.HasKazhdanPropertyT,Connes.spectral_criterion_unconditional}
 \lean{SimpleGraph.lapMatrix,SimpleGraph.posSemidef_lapMatrix}
 
@@ -20,7 +20,7 @@ primary source-faithful route is the exact elementary-group theorem
 A}{ershov2017rootgraded} supplies broader supporting language. Our internal
 engineering estimate remains \strong{24--28 thousand new Lean lines}, with an
 internal uncertainty envelope of \strong{18--35 thousand}. This is about
-#{0.8}--#{1.5} times the current 22,962-line project and, by our internal
+#{0.8}--#{1.5} times the current 23,070-line project and, by our internal
 estimate, \strong{two to four times its present proof-search and engineering
 effort}. The changed source route reallocates work within the original range;
 it does not independently calibrate a new total. The literature supports the
@@ -63,61 +63,3 @@ route from finite spectral detection to property (T). The remaining work is
 the quantitative root-subgroup, fixed-space, graph, and detector mathematics
 listed above; it should reuse that shell rather than construct another PVM
 layer.}
-
-\p{The pinned Connes project uses Mathlib revision
-\href{https://github.com/leanprover-community/mathlib4/commit/905b95818eb32af7874a58b427f50c1711a5e96c}{\code{905b958}} with Lean 4.32.2.
-Mathlib supplies the graph Laplacian and its positivity theorem, exposed by
-the declaration links above, but not the
-Ershov--Jaikin-Zapirain graph-of-groups criterion, Kazhdan ratios, root
-gradings, codistance, or the graph argument. Kassabov's
-\citet{Theorem 2.2 and Lemmas 2.3--2.7, pp. 11--18}{kassabov2005universal}
-concern a free associative integer ring and require quotient transport before
-application to #{\mathbb F_2[t]}. For calibration over an arbitrary finitely
-generated ring and module, the cleaner reference is
-\citet{Appendix Theorem A.1, p. 110}{ershov2017rootgraded}. The direct route is
-the earlier quantitative development in \citet{Sections 2--6 and Appendix
-A}{ershov2010noncommutative}.}
-
-\p{TauCeti at revision
-\href{https://github.com/TauCetiProject/TauCeti/commit/cc6ce758421ce3a0731ff62667b7771cfc4aa3da}{\code{cc6ce75}}
-uses Mathlib \href{https://github.com/leanprover-community/mathlib4/commit/de5ce8a9a66a4aa68a9bdbb35b63a06d34d9ca11}{\code{de5ce8a}}
-and Lean 4.34.0-rc1. Its
-\href{https://github.com/TauCetiProject/TauCeti/blob/cc6ce758421ce3a0731ff62667b7771cfc4aa3da/TauCeti/LowDimTopology/Plumbing/DiagonalDominance.lean#L73-L74}{diagonal-dominance proof}
-consumes the same Mathlib Laplacian facts, but its source and roadmap
-contain no direct property-(T), Kazhdan, codistance, root-graded, or magic-graph
-lane. It is therefore not a drop-in dependency for this boundary. Moving the
-Connes development immediately to that pin would add, by our internal
-engineering estimate, \strong{2--5 thousand lines of migration and pin-repair
-work}; it would not reduce the mathematical estimate.}
-
-\p{Bounded elementary generation is not presently shorter. Nica's
-\citet{Theorem 2, p. 2}{nica2019bounded} gives
-
-##{\nu_3=\frac{3\cdot3^2-3}{2}+29=41,}
-
-and its proof invokes the Kornblum--Artin theorem for irreducibles in
-polynomial arithmetic progressions, stated as
-\citet{Theorem 3, p. 2}{nica2019bounded}. That input is absent from the pinned
-Mathlib revision. Our internal estimate for a self-contained Nica--Kassabov
-route is \strong{20--45 thousand lines} and \strong{three to six times the
-current engineering effort}, with roughly 70 percent internal uncertainty.
-Assuming Kornblum--Artin gives our internal estimate of \strong{8--15 thousand
-lines}, but merely moves the external boundary. Our internal estimate for a
-reusable formalization of the generic EJK theorem is \strong{45--90 thousand
-lines}; that generality is unnecessary for Zhou's application.}
-
-\p{The literature anchors for the route decomposition are Zhou's exact
-invocation \citet{Proposition 4.1, pp. 8--10}{zhou2026icc}; the exact
-elementary-group theorem, unweighted boundary graph, and packaged six-root
-estimate in \citet{Theorem 1.1, p. 1; Section 5.4, pp. 25--29; Proposition
-6.1, pp. 34--35}{ershov2010noncommutative}; the broader root-graded theorem and
-arbitrary-ring relative estimate in \citet{Theorem 1.1, p. 3; Appendix Theorem
-A.1, p. 110}{ershov2017rootgraded}; Kassabov's free-associative-ring estimates;
-and Nica's exact-ring alternative. None states our LOC or effort ranges.
-Chapter 4 of \citek{openai2026tenadvances} is independent binary-carry
-mathematical context, not code provenance and not authority for the EJZK
-theorem. Adapted Lean infrastructure is traced instead to the pinned
-\href{https://github.com/openai/ten-proofs/tree/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6}{\code{openai/ten-proofs} snapshot}
-and the Connes project's
-\href{https://github.com/utensil/connes-rigidity/blob/main/docs/PROVENANCE.md}{provenance ledger}
-and \href{https://github.com/utensil/connes-rigidity/blob/main/docs/PORT_MAP.md}{port map}.}

--- a/trees/connes-000D.tree
+++ b/trees/connes-000D.tree
@@ -1,0 +1,36 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{measure-theory}
+\taxon{Remark}
+\title{Nonadditive shear and measure transport}
+\lean/connes{Connes.CrossedProduct.EquivariantHaarHomeomorph,Connes.PaperCrossedHaar.paperHaarHomeomorph}
+
+\p{Proposition 3.2 proves that the fiber shear preserves Haar measure and
+strictly conjugates the two actions. Its quadratic correction is generally not
+additive, so Zhou's Remark 3.3
+does not claim a compact-group automorphism. Proposition 3.4 uses only the
+resulting equivariant measure-space isomorphism after Fourier transform
+\citet{Proposition 3.2, Remark 3.3, and Proposition 3.4}{zhou2026icc}. The
+independent crossed-product discussion in
+\citet{Chapter 4, Section 2.3, equation (2.1)}{openai2026tenadvances}
+states the same abstract mechanism: group-law compatibility of the underlying
+compact spaces is not required.}
+
+\p{The Lean boundary mirrors this distinction. The concrete
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Paper/Section3/CrossedHaar.lean#L108-L141}{\code{paperFiberShearHomeomorph} and \code{paperHaarHomeomorph}}
+package continuity, measure preservation, and action equivariance, but no
+additive-homomorphism field. At the foundation layer,
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L141-L162}{\code{EquivariantHaarHomeomorph}}
+projects this topological witness to the measurable transport interface. The
+extra topology is an implementation aid, not a stronger mathematical premise
+for the crossed-product identification.}
+
+\p{A measurable equivariant isomorphism is mathematically sufficient for the
+abstract transport. The concrete homeomorphism is formally convenient because
+pullback preserves continuous coefficients. The proof uses that extra
+structure for the density bridge and forgets it at the measurable boundary,
+without falsely requiring an additive equivalence. The separate closure step is
+recorded in \ref{connes-000E}.}

--- a/trees/connes-000E.tree
+++ b/trees/connes-000E.tree
@@ -1,0 +1,36 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{operator-algebra}
+\tag{von-neumann-algebra}
+\taxon{Remark}
+\title{Continuous coefficients and von Neumann closure}
+\lean/connes{Connes.CrossedProduct.vonNeumannClosure_crossedGeneratorSetOfContinuousCoefficients_eq,Connes.CrossedProduct.continuousCrossedClosure_mem_iff}
+
+\p{Coordinate characters have norm-dense linear span in the continuous
+functions by Stone--Weierstrass. Since continuous coefficients act continuously
+as crossed-product multipliers, the generic
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L215-L375}{continuous-coefficient closure theorem}
+upgrades that density to equality of the generated von Neumann closures.
+Pullback along the homeomorphism then gives
+\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L377-L460}{\code{continuousCrossedClosure_mem_iff}}.
+This does \em{not} say that continuous functions are norm-dense in
+#{L^\infty}; it compares the von Neumann closures generated after adjoining
+all continuous coefficients.}
+
+\p{The paper-facing proof applies the transport and closure bridges once to each
+action, then composes the Fourier models with the shear. This removes parallel
+action-one/action-two closure plumbing while preserving Zhou's Proposition 3.4
+endpoint and section order. Mapping a convenient generating family remains an
+intermediate step; the consumer-facing contract is equivalence of membership
+in the completed von Neumann algebras.}
+
+\p{Chapter 4 of \citek{openai2026tenadvances} is mathematical context, not the
+source of these declarations. Adapted Lean infrastructure is recorded in the
+Connes project's public
+\href{https://github.com/utensil/connes-rigidity/blob/main/docs/PROVENANCE.md}{provenance ledger}
+and \href{https://github.com/utensil/connes-rigidity/blob/main/docs/PORT_MAP.md}{port map}.
+The mathematical conclusion and every witness field used here are proved in
+the Connes source.}

--- a/trees/connes-000F.tree
+++ b/trees/connes-000F.tree
@@ -1,0 +1,26 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{proof-engineering}
+\taxon{Remark}
+\title{Structure forgetting and equivalence reuse}
+\lean/connes{Connes.CrossedProduct.EquivariantHaarHomeomorph,Connes.CrossedProduct.continuousCrossedClosure_mem_iff}
+
+\p{\strong{Forget structure after it has served its consumer.}
+The Section 3 shear is packaged as an equivariant measure-preserving
+homeomorphism because pullback must preserve continuous coefficients. Its
+canonical projection to an equivariant measurable equivalence is what the full
+#{L^\infty} crossed-product transport consumes. This one-way forgetting records
+both facts accurately: Zhou's factor argument does not need an additive map,
+while the Lean density bridge legitimately uses the continuity proved in
+\citet{Proposition 3.2 and Remark 3.3}{zhou2026icc}.}
+
+\p{\strong{Prefer library equivalences to pointwise cancellation.}
+Mathlib already supplies continuous pullback as a star-algebra equivalence, so
+its surjectivity gives the reverse generator inclusion without a custom
+involutivity proof. Likewise, the inverse law for conjugation by a linear
+isometry equivalence replaces a pointwise operator calculation. These
+replacements shorten the proof while exposing the actual mathematical reason:
+both steps are transport along equivalences.}

--- a/trees/connes-000G.tree
+++ b/trees/connes-000G.tree
@@ -1,0 +1,34 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{property-t}
+\tag{formalization-estimate}
+\taxon{Remark}
+\title{Available Mathlib and TauCeti infrastructure}
+\lean{SimpleGraph.lapMatrix,SimpleGraph.posSemidef_lapMatrix}
+
+\p{The pinned Connes project uses Mathlib revision
+\href{https://github.com/leanprover-community/mathlib4/commit/79cba2e8b532ff92484dfd99f45987bae8b2fd7e}{\code{79cba2e8}}
+with Lean 4.34.0-rc1. Mathlib supplies the graph Laplacian and its positivity
+theorem, exposed by the declaration links above, but not the
+Ershov--Jaikin-Zapirain graph-of-groups criterion, Kazhdan ratios, root
+gradings, codistance, or the graph argument. Kassabov's
+\citet{Theorem 2.2 and Lemmas 2.3--2.7, pp. 11--18}{kassabov2005universal}
+concern a free associative integer ring and require quotient transport before
+application to #{\mathbb F_2[t]}. For calibration over an arbitrary finitely
+generated ring and module, the cleaner reference is
+\citet{Appendix Theorem A.1, p. 110}{ershov2017rootgraded}. The direct route is
+the earlier quantitative development in \citet{Sections 2--6 and Appendix
+A}{ershov2010noncommutative}.}
+
+\p{TauCeti at revision
+\href{https://github.com/TauCetiProject/TauCeti/commit/cc6ce758421ce3a0731ff62667b7771cfc4aa3da}{\code{cc6ce75}}
+uses Mathlib \href{https://github.com/leanprover-community/mathlib4/commit/de5ce8a9a66a4aa68a9bdbb35b63a06d34d9ca11}{\code{de5ce8a}}
+and Lean 4.34.0-rc1. Its
+\href{https://github.com/TauCetiProject/TauCeti/blob/cc6ce758421ce3a0731ff62667b7771cfc4aa3da/TauCeti/LowDimTopology/Plumbing/DiagonalDominance.lean#L73-L74}{diagonal-dominance proof}
+consumes the same Mathlib Laplacian facts, but its source and roadmap contain no
+direct property-(T), Kazhdan, codistance, root-graded, or magic-graph lane. It
+is therefore not a drop-in dependency for this boundary; aligning project pins
+would not reduce the missing mathematics.}

--- a/trees/connes-000H.tree
+++ b/trees/connes-000H.tree
@@ -1,0 +1,30 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{group-theory}
+\tag{module-theory}
+\taxon{Remark}
+\title{Characteristic kernels and quotient-twisted transport}
+\lean/connes{Connes.PaperCharacteristic.paperSL3NoNontrivialAbelianNormalSubgroup,Connes.Sp4.no_nontrivial_normal_abelian_subgroup,Connes.PaperCharacteristicTransport.paperSemidirectNormalAbelian_le_kernel}
+
+\p{The characteristic-kernel step maps an abelian normal subgroup to both
+factors of #{\mathrm{SL}_3(\mathbb F_2[t])\times
+\operatorname{Sp}_4(\mathbb F_2)}. It therefore needs two vanishing results.
+The polynomial-matrix argument
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/Characteristic.lean#L163-L196}{\code{PaperCharacteristic.paperSL3NoNontrivialAbelianNormalSubgroup}}
+handles the #{\mathrm{SL}_3} image. The stronger finite result
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/Sp4KernelCertificate.lean#L2097-L2115}{\code{Sp4.no_nontrivial_normal_abelian_subgroup}}
+handles the symplectic image through a kernel-checked certificate. The product
+argument applying both inputs is
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/CharacteristicTransport.lean#L59-L107}{\code{paperSemidirectNormalAbelian_le_kernel}}.
+This confines finite enumeration to the symplectic factor and keeps both
+factor-specific proofs out of the abstract module transport.}
+
+\p{\strong{Design adaptation: twisting does not repair nonsplitting.}
+Restriction along a group automorphism is an equivalence of module
+categories, with inverse given by restriction along the inverse automorphism.
+The formal proof nevertheless exports the exact twisted obstruction needed by
+the consumer, so no unproved categorical transport principle remains hidden
+at the final contradiction.}

--- a/trees/connes-000I.tree
+++ b/trees/connes-000I.tree
@@ -1,0 +1,42 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{property-t}
+\tag{formalization-estimate}
+\taxon{Remark}
+\title{Alternative EJZK routes and literature anchors}
+\lean/connes{Connes.PaperPropertyT.elementaryGroup}
+
+\p{Bounded elementary generation is not presently shorter. Nica's
+\citet{Theorem 2, p. 2}{nica2019bounded} gives
+
+##{\nu_3=\frac{3\cdot3^2-3}{2}+29=41,}
+
+and its proof invokes the Kornblum--Artin theorem for irreducibles in
+polynomial arithmetic progressions, stated as
+\citet{Theorem 3, p. 2}{nica2019bounded}. That input is absent from the pinned
+Mathlib revision. Our internal estimate for a self-contained Nica--Kassabov
+route is \strong{20--45 thousand lines} and \strong{three to six times the
+current engineering effort}, with roughly 70 percent internal uncertainty.
+Assuming Kornblum--Artin gives our internal estimate of \strong{8--15 thousand
+lines}, but merely moves the external boundary. Our internal estimate for a
+reusable formalization of the generic EJK theorem is \strong{45--90 thousand
+lines}; that generality is unnecessary for Zhou's application.}
+
+\p{The literature anchors for the route decomposition are Zhou's exact
+invocation \citet{Proposition 4.1, pp. 8--10}{zhou2026icc}; the exact
+elementary-group theorem, unweighted boundary graph, and packaged six-root
+estimate in \citet{Theorem 1.1, p. 1; Section 5.4, pp. 25--29; Proposition
+6.1, pp. 34--35}{ershov2010noncommutative}; the broader root-graded theorem and
+arbitrary-ring relative estimate in \citet{Theorem 1.1, p. 3; Appendix Theorem
+A.1, p. 110}{ershov2017rootgraded}; Kassabov's free-associative-ring estimates;
+and Nica's exact-ring alternative. None states our LOC or effort ranges.
+Chapter 4 of \citek{openai2026tenadvances} is independent binary-carry
+mathematical context, not code provenance and not authority for the EJZK
+theorem. Adapted Lean infrastructure is traced instead to the pinned
+\href{https://github.com/openai/ten-proofs/tree/94bc0feb6a9ff12c7d31d6de640a725c9d43d2b6}{\code{openai/ten-proofs} snapshot}
+and the Connes project's
+\href{https://github.com/utensil/connes-rigidity/blob/main/docs/PROVENANCE.md}{provenance ledger}
+and \href{https://github.com/utensil/connes-rigidity/blob/main/docs/PORT_MAP.md}{port map}.}

--- a/trees/connes-000J.tree
+++ b/trees/connes-000J.tree
@@ -1,0 +1,24 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{proof-engineering}
+\taxon{Remark}
+\title{Proposition-valued final assembly}
+\lean/connes{Connes.PaperTheoremACompletion.theoremA,Connes.theoremA}
+
+\p{\strong{Keep final assembly proposition-valued.}
+Section 7 combines previously proved endpoints. It does not accept a broad
+record containing the desired conclusion as a field. This “certificate
+isolation” makes \code{#print axioms} meaningful and lets semantic review trace
+each conjunct to the file where its mathematics occurs.}
+
+\p{These lessons concern proof structure rather than the mathematical claims
+of \citek{zhou2026icc} or the independent binary-carry construction in Chapter
+4 of \citek{openai2026tenadvances}. The latter is mathematical context, not code
+provenance. Where the implementation adapts prior Lean infrastructure, the
+source is the pinned \code{openai/ten-proofs} snapshot recorded in the Connes
+project's provenance ledger and port map. The lessons are reusable in
+formalizations where a linear paper proof crosses topology, analysis, finite
+computation, and algebraic transport.}


### PR DESCRIPTION
## Summary

- separate the Section 3 factor theorem from the nonadditive Haar shear, measurable transport, and continuous-coefficient closure arguments
- apply the same reader-contract split to Section 6 characteristic transport, the reusable architecture lessons, and the EJZK outlook
- preserve the literature citations and exact Lean declaration links in each focused card
- refresh the Connes Mathlib/Lean pin and the source-line baseline after the verifier upgrade
- link the Section 3 discussion to the exact merged refactor revision

## Verification

- `just chk`
- Forester build
- 17-page A4 PDF rebuild
- full-document contact-sheet inspection plus original-resolution inspection of the reorganized sections
- no overfull boxes or unresolved references
- all newly named Lean declarations checked at the linked revision
- literature citation-key coverage preserved

This PR is human-gated. Auto-merge is disabled.