### PR TITLE
docs(fcap): extend the SpinRep roadmap notes

### DIFF
--- a/trees/fcap-0010.tree
+++ b/trees/fcap-0010.tree
@@ -7,7 +7,12 @@
 
 \title{Hyperbolic recurrence and real signatures}
 
-\p{A positive and a negative generator form a hyperbolic plane. Adjoining that plane tensors the Clifford algebra with two-by-two real matrices. Iteration removes the common part of a real signature and isolates its one-sided remainder.}
+\p{A positive and a negative generator form a hyperbolic plane. Adjoining
+that plane tensors the Clifford algebra with two-by-two real matrices.
+Iteration removes the common part of a real signature, while a sign switch
+gives a complementary one-sided recurrence. These are algebraic steps toward
+the real classification; the real Pin and Spin groups follow a separate
+branch through the double-cover theory.}
 
 \related{\ref{ca-0001}}
 
@@ -15,5 +20,7 @@
 \transclude{fcap-0012}
 \transclude{fcap-0013}
 \transclude{fcap-0014}
+\transclude{fcap-001X}
+\transclude{fcap-001Y}
 \transclude{fcap-0015}
 \transclude{fcap-0016}

--- a/trees/fcap-0016.tree
+++ b/trees/fcap-0016.tree
@@ -8,4 +8,29 @@
 \taxon{Remark}
 \title{What the recurrence does not classify}
 
-\p{Hyperbolic reduction determines the matrix factor coming from matched positive and negative axes. It leaves a one-sided algebra #{\Cl_{r,0}} or #{\Cl_{0,r}}. Classifying those residual algebras and arranging them into the mod-eight table requires additional base cases and periodicity identifications; it is not a consequence of the single #{(1,1)} recurrence. Lawson and Michelsohn give the full classical table in \citet{I.4, Theorem 4.3 and Tables I--II, pp. 27--29}{lawson2016spin}.}
+\p{Hyperbolic reduction determines the matrix factor coming from matched
+positive and negative axes. It leaves a one-sided algebra #{\Cl_{r,0}} or
+#{\Cl_{0,r}}. The signature-switch recurrence of \ref{fcap-001X} provides a
+second move, and \ref{fcap-0015} fixes the first real, complex, quaternionic,
+and matrix entries. These facts still have to be assembled into recurrences
+that close on each one-sided axis.}
+
+\p{A reviewed local candidate called SPINREP-050 establishes the quaternion
+recurrence
+
+##{\Cl_{p,q+2}\simeq
+\Cl_{q,p}\otimes_{\mathbb R}\mathbb H,}
+
+and another local candidate, SPINREP-053, iterates the recurrence chain to
+
+##{\Cl_{p+8,q}\simeq
+\Cl_{p,q}\otimes_{\mathbb R}M_{16}(\mathbb R).}
+
+Neither candidate is a merged TauCeti declaration or a public TauCeti pull
+request, so neither receives a Lean marker here.}
+
+\p{The residue-indexed mod-eight classification table remains unformalized.
+In particular, the mixed #{(1,1)} recurrence alone only removes matched axes;
+it cannot classify the one-sided remainder. Lawson--Michelsohn give the full
+classical periodicity and table in
+\citet{I.4, Theorem 4.3 and Tables I--II, pp. 27--29}{lawson2016spin}.}

--- a/trees/fcap-0017.tree
+++ b/trees/fcap-0017.tree
@@ -19,10 +19,15 @@ Clifford action is an isomorphism.
 The currently open TauCeti half-spin work is therefore not represented by a
 Lean marker here.}
 
-\p{The differential of #{\Spin(V)\to SO(V)}, highest weights, triality, and
-the Bott-periodic real table belong to later layers. Kostant supplies the
-differential in the classical complex setting. Lawson and Michelsohn treat
-the real Pin and Spin groups.
-None of
+\p{The generic mathematics of differentiating a smooth Lie-group
+homomorphism is developed in \ref{fcap-001Q}. What remains missing for the
+Spin cover is more specific: compatible Lie-group structures on TauCeti's
+abstract #{\Spin(V)} and #{SO(V)}, followed by the identification of their
+specialized differential with the algebraic quadratic action above. The open
+TauCeti PR linked in \ref{fcap-001W} proposes only the generic Lie functor.}
+
+\p{Highest weights, triality, and the Bott-periodic real table also belong to
+later layers. Kostant supplies the differential in the classical complex
+setting, and Lawson--Michelsohn treat the real Pin and Spin groups. None of
 these horizons follows merely from the algebraic restrictions
 #{\operatorname{spinRep}} and #{\operatorname{pinRep}}.}

--- a/trees/fcap-0019.tree
+++ b/trees/fcap-0019.tree
@@ -11,16 +11,20 @@
 \href{https://github.com/TauCetiProject/TauCetiRoadmap/tree/main/TauCetiRoadmap/RepresentationTheory/SpinRepresentations}{spin-representation roadmap}
 of \href{https://github.com/TauCetiProject/TauCeti}{Tau Ceti}. The filtered
 Clifford algebra first exposes its exterior shadow. Reflections then lead to
-the Pin and Spin extensions, while bivectors provide the infinitesimal
-orthogonal action. A polarization joins these global and infinitesimal
-constructions in the exterior spinor model. The real-signature recurrence is
-a parallel branch and does not depend on that join.}
+the global Pin and Spin extensions, while bivectors provide the algebraic
+infinitesimal orthogonal action. The Lie functor records the separate
+differential bridge from smooth group homomorphisms. A polarization joins the
+algebraic group and Lie constructions in the exterior spinor model. The
+real-signature recurrence and classification form a parallel algebraic branch
+and do not depend on the spinor-module or double-cover join.}
 
 \transclude{fcap-000F}
 
 \transclude{fcap-0007}
 
 \transclude{fcap-000M}
+
+\transclude{fcap-001Q}
 
 \transclude{fcap-001G}
 

--- a/trees/fcap-001Q.tree
+++ b/trees/fcap-001Q.tree
@@ -1,0 +1,22 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{lie}
+
+\title{Differentiating smooth group homomorphisms}
+
+\p{The quadratic Clifford construction in the preceding section is
+algebraic. A different bridge starts from a smooth homomorphism of Lie groups
+and differentiates it at the identity. This produces the functor from Lie
+groups to Lie algebras and explains which part of the Spin-representation
+roadmap is generic differential geometry, before any Lie-group structure on
+the abstract Spin and special orthogonal groups has been supplied.}
+
+\transclude{fcap-001R}
+\transclude{fcap-001S}
+\transclude{fcap-001T}
+\transclude{fcap-001U}
+\transclude{fcap-001V}
+\transclude{fcap-001W}

--- a/trees/fcap-001R.tree
+++ b/trees/fcap-001R.tree
@@ -1,0 +1,39 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{lie}
+
+\taxon{Definition}
+\title{The differential of a smooth homomorphism
+\citet{Section 2.1, p. 9}{liu2016lie}}
+
+\p{Let #{G} and #{H} be finite-dimensional real Lie groups, with
+identities #{e_G} and #{e_H}, and let #{\phi:G\to H} be a smooth group
+homomorphism. Their Lie algebras are the tangent spaces
+
+##{\mathfrak g=T_{e_G}G,
+\qquad \mathfrak h=T_{e_H}H.}
+
+The differential of #{\phi} at the identity is the linear map
+
+##{\operatorname{Lie}(\phi)=d\phi_{e_G}:
+\mathfrak g\longrightarrow\mathfrak h.}
+
+No connectedness or simply-connectedness hypothesis is needed to define this
+map. Those hypotheses enter the converse problem of integrating a Lie-algebra
+homomorphism, not the differentiation of a given smooth homomorphism.}
+
+\p{For #{X\in\mathfrak g}, let #{\widetilde X} be its left-invariant vector
+field,
+
+##{\widetilde X_g=d(L_g)_{e_G}X.}
+
+The homomorphism identity #{\phi\circ L_g=L_{\phi(g)}\circ\phi} gives
+
+##{d\phi_g(\widetilde X_g)
+=\widetilde{\operatorname{Lie}(\phi)(X)}_{\phi(g)}.}
+
+Thus differentiation at the identity and transport by left translation are
+two descriptions of the same infinitesimal map.}

--- a/trees/fcap-001S.tree
+++ b/trees/fcap-001S.tree
@@ -1,0 +1,25 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{lie}
+
+\taxon{Lemma}
+\title{The differential preserves the Lie bracket
+\citet{Section 2.1, p. 9}{liu2016lie}}
+
+\p{In the setting of \ref{fcap-001R}, the differential is a Lie-algebra
+homomorphism:
+
+##{\operatorname{Lie}(\phi)([X,Y])
+=[\operatorname{Lie}(\phi)(X),
+  \operatorname{Lie}(\phi)(Y)].}
+
+Indeed, the left-invariant fields #{\widetilde X} and #{\widetilde Y} are
+#{\phi}-related to the left-invariant fields determined by their images.
+Brackets of related vector fields are again related. Evaluating that relation
+at #{e_G} gives the displayed identity.}
+
+\p{This argument is local at the identity. In particular, bracket
+preservation does not require #{G} to be connected or simply connected.}

--- a/trees/fcap-001T.tree
+++ b/trees/fcap-001T.tree
@@ -1,0 +1,25 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{lie}
+
+\taxon{Theorem}
+\title{The Lie functor \citet{Section 2.2, p. 10}{liu2016lie}}
+
+\p{Differentiation at the identity is functorial. For smooth homomorphisms
+#{G\xrightarrow{\phi}H\xrightarrow{\psi}K}, the chain rule gives
+
+##{\operatorname{Lie}(\operatorname{id}_G)
+=\operatorname{id}_{\mathfrak g},
+\qquad
+\operatorname{Lie}(\psi\circ\phi)
+=\operatorname{Lie}(\psi)\circ\operatorname{Lie}(\phi).}
+
+Together with \ref{fcap-001S}, this defines a functor from Lie groups and
+smooth homomorphisms to Lie algebras and Lie-algebra homomorphisms.}
+
+\p{The stronger correspondence between simply connected Lie groups and Lie
+algebras concerns existence and uniqueness in the reverse direction. It is
+not a hypothesis of these functor laws.}

--- a/trees/fcap-001U.tree
+++ b/trees/fcap-001U.tree
@@ -1,0 +1,41 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{lie}
+
+\taxon{Theorem}
+\title{Naturality of the exponential
+\citet{Section 2.4, pp. 12--13}{liu2016lie}}
+
+\p{Let #{\phi:G\to H} be a smooth Lie-group homomorphism. For every
+#{X\in\mathfrak g},
+
+##{\phi(\exp_G X)
+=\exp_H\bigl(\operatorname{Lie}(\phi)(X)\bigr).}
+
+Equivalently, the square
+
+\tikzfig{
+\begin{tikzcd}[column sep=large,row sep=large]
+\mathfrak g \arrow[r,"\operatorname{Lie}(\phi)"]
+  \arrow[d,"\exp_G"']
+& \mathfrak h \arrow[d,"\exp_H"] \\
+G \arrow[r,"\phi"']
+& H
+\end{tikzcd}
+}
+
+commutes.}
+
+\subtree{
+\taxon{Proof}
+\p{The curve #{t\mapsto\phi(\exp_G(tX))} is a one-parameter subgroup of
+#{H}. Its tangent vector at #{t=0} is
+#{\operatorname{Lie}(\phi)(X)}. The curve
+#{t\mapsto\exp_H(t\operatorname{Lie}(\phi)(X))} has the same property and
+the same tangent vector. Uniqueness of the one-parameter subgroup with a
+given tangent vector identifies the curves; setting #{t=1} proves the
+formula.}
+}

--- a/trees/fcap-001V.tree
+++ b/trees/fcap-001V.tree
@@ -1,0 +1,30 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{lie}
+
+\taxon{Example}
+\title{Differentiating a matrix representation
+\citet{Sections 2.1 and 2.4, pp. 9, 12}{liu2016lie}}
+
+\p{Let #{V} be a finite-dimensional real vector space and let
+
+##{\rho:G\longrightarrow\operatorname{GL}(V)}
+
+be a smooth representation. Its differential is a Lie-algebra
+representation
+
+##{d\rho_{e_G}:\mathfrak g\longrightarrow\mathfrak{gl}(V).}
+
+Naturality of the exponential becomes
+
+##{\rho(\exp_G X)=\exp\bigl(d\rho_{e_G}(X)\bigr),}
+
+where the exponential on the right is the ordinary matrix exponential. For
+example, for the determinant homomorphism
+#{\det:\operatorname{GL}_n(\mathbb R)\to\mathbb R^\times},
+
+##{d(\det)_I(A)=\operatorname{tr}(A).}
+}

--- a/trees/fcap-001W.tree
+++ b/trees/fcap-001W.tree
@@ -1,0 +1,36 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{lie}
+
+\taxon{Remark}
+\title{Why explicit smoothness changes the roadmap
+\citet{Sections 2.1--2.4 and 2.8, pp. 9--13, 19--20}{liu2016lie};
+\citet{Section 3.1.2, pp. 106--107}{isaev2018theory}}
+
+\p{The constructions in \ref{fcap-001R}--\ref{fcap-001V} start with a
+smooth homomorphism. Their tangent map, bracket law, functor laws, and
+exponential naturality therefore do not require a theorem that upgrades a
+continuous homomorphism to a smooth one. The generic theorem does not invoke
+the closed-subgroup theorem; that theorem belongs to the later specialization
+to concrete matrix subgroups. This is the dependency split proposed in
+\href{https://github.com/TauCetiProject/TauCetiRoadmap/pull/224}{TauCetiRoadmap
+PR 224}.}
+
+\p{The exponential input is separate from the tangent and bracket input.
+Likewise, the Baker--Campbell--Hausdorff calculation can first be made in a
+matrix or general-linear group; using it inside a particular closed matrix
+subgroup additionally requires the subgroup's Lie structure. Liu describes
+the local exponential and BCH coordinates, while Isaev--Rubakov give the
+matrix Campbell--Hausdorff calculation.}
+
+\p{The open
+\href{https://github.com/TauCetiProject/TauCeti/pull/3078}{TauCeti draft PR 3078}
+proposes the generic construction and its functor and
+exponential laws. It is not merged, so these cards carry no Lean markers.
+Even after that generic interface lands, the differential of
+#{\Spin(Q)\to SO(Q)} still needs compatible Lie-group structures on the two
+abstract groups. The algebraic identification in \ref{fcap-000R} does not by
+itself supply those structures.}

--- a/trees/fcap-001X.tree
+++ b/trees/fcap-001X.tree
@@ -1,0 +1,39 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Theorem}
+\title{The signature-switch recurrence
+\citet{I.4, Theorem 4.1 and (4.1), pp. 25--26}{lawson2016spin}}
+\lean/tauceti{TauCeti.realCliffordSignatureSwitchRecurrenceEquiv,TauCeti.realCliffordSignatureSwitchRecurrenceEquiv_ι}
+
+\p{With the TauCeti signature convention of \ref{fcap-0011}, there is an
+algebra equivalence
+
+##{\Cl_{p+2,q}\simeq_{\mathbb R\text{-alg}}
+\Cl_{q,p}\otimes_{\mathbb R}M_2(\mathbb R).}
+
+The construction first separates the last positive coordinate from
+#{Q_{p+2,q}}. Adjoining that positive line permits a Clifford sign switch;
+negating #{Q_{p+1,q}} exchanges its positive and negative coordinate blocks.
+The resulting form is #{Q_{q+1,p+1}}, to which the hyperbolic recurrence of
+\ref{fcap-0013} applies.}
+
+\p{The accompanying generator theorem records this composition through the
+positive-coordinate splitter, the sign-switch isometry, and the generator
+formula for the hyperbolic equivalence. It fixes the equivalence on the
+canonical Clifford generators rather than asserting only that some algebra
+isomorphism exists.}
+
+\p{After converting between the two signature conventions, inverting
+Lawson--Michelsohn's equation (4.1), using
+#{\Cl^{\mathrm{Lawson}}_{0,2}\cong M_2(\mathbb R)}, and swapping the indices
+yields the displayed algebra isomorphism. Their equation (4.3) is instead the
+mixed #{(1,1)} recurrence used in \ref{fcap-0013}. Chevalley's split-matrix
+and orthogonal-sum constructions give the same structural ingredients
+\citet{II.2.1 and II.2.5, pp. 42--46}{chevalley1954algebraic}. The exact
+splitter composition and generator formula are additional data recorded by
+TauCeti.}

--- a/trees/fcap-001X.tree
+++ b/trees/fcap-001X.tree
@@ -8,7 +8,7 @@
 \taxon{Theorem}
 \title{The signature-switch recurrence
 \citet{I.4, Theorem 4.1 and (4.1), pp. 25--26}{lawson2016spin}}
-\lean/tauceti{TauCeti.realCliffordSignatureSwitchRecurrenceEquiv,TauCeti.realCliffordSignatureSwitchRecurrenceEquiv_ι}
+\lean/tauceti{TauCeti.realCliffordSignatureSwitchRecurrenceEquiv}
 
 \p{With the TauCeti signature convention of \ref{fcap-0011}, there is an
 algebra equivalence
@@ -22,11 +22,12 @@ negating #{Q_{p+1,q}} exchanges its positive and negative coordinate blocks.
 The resulting form is #{Q_{q+1,p+1}}, to which the hyperbolic recurrence of
 \ref{fcap-0013} applies.}
 
-\p{The accompanying generator theorem records this composition through the
-positive-coordinate splitter, the sign-switch isometry, and the generator
-formula for the hyperbolic equivalence. It fixes the equivalence on the
-canonical Clifford generators rather than asserting only that some algebra
-isomorphism exists.}
+\p{The accompanying generator theorem
+\<html:span>[class]{lean-ref}{[\code{SignatureSwitchRecurrenceEquiv_ι}](https://taucetiproject.github.io/TauCeti/docs/find/#doc/TauCeti.realCliffordSignatureSwitchRecurrenceEquiv_\%25CE\%25B9)}
+records this composition through the positive-coordinate splitter, the
+sign-switch isometry, and the generator formula for the hyperbolic
+equivalence. It fixes the equivalence on the canonical Clifford generators
+rather than asserting only that some algebra isomorphism exists.}
 
 \p{After converting between the two signature conventions, inverting
 Lawson--Michelsohn's equation (4.1), using

--- a/trees/fcap-001Y.tree
+++ b/trees/fcap-001Y.tree
@@ -1,0 +1,27 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{fcap}
+\tag{spin}
+\tag{clifford}
+
+\taxon{Remark}
+\title{Why algebraic periodicity is a separate branch
+\citet{II.2.1, II.2.5, and II.2.9, pp. 42--46, 65--66}{chevalley1954algebraic};
+\citet{I.4, Theorems 4.1 and 4.3, pp. 25--29}{lawson2016spin}}
+
+\p{The recurrences in \ref{fcap-0013}, \ref{fcap-0014}, and
+\ref{fcap-001X} use Clifford universal properties, orthogonal sums, tensor
+products, coordinate isometries, and the real base entries. They do not use
+the Spin representation, the structure theorem obtained from a spinor
+module, or the Pin and Spin double covers. This is the algebraic branch of
+Layer 7.}
+
+\p{The real groups #{\Pin(p,q)} and #{\Spin(p,q)} form a different branch.
+Their actions, kernels, and algebraic extensions specialize the group theory
+developed in \ref{fcap-0007}, and therefore genuinely consume the Layer-2
+Pin/Spin work. The distinction between these branches is the dependency
+correction proposed in
+\href{https://github.com/TauCetiProject/TauCetiRoadmap/pull/225}{TauCetiRoadmap
+PR 225}. It changes the order in which the mathematics can be built; it does
+not turn the roadmap proposal itself into a formal theorem.}


### PR DESCRIPTION
## Summary

- add a source-grounded Section 4.4 on differentiating smooth Lie-group homomorphisms, with Definition, Lemma, Theorem, Example, Proof, and Remark cards
- add Theorem 4.6.5 for TauCeti’s merged signature-switch recurrence and Remark 4.6.6 separating algebraic periodicity from real Pin/Spin group dependencies
- revise the FCAP storyline and its formalization horizons for TauCetiRoadmap PRs 224 and 225

## Scope and provenance

This PR is stacked exactly on `fcap@d53a771799022b83005831bcb948c9bb54c22f4e` and targets `fcap`. It adds 9 trees (`fcap-001Q`–`fcap-001Y`) and modifies 4 storyline trees (`fcap-0010`, `fcap-0016`, `fcap-0017`, `fcap-0019`). Every new tree is marked `agent-authored`; no protected `ca-*` or `tt-*` tree changes.

The mathematical sources are registered PDFs: Liu §§2.1–2.4, 2.8; Isaev–Rubakov §3.1.2; Lawson–Michelsohn I.4; and Chevalley II.2.1, II.2.5, II.2.9. The signature-switch card carries a whole-card TauCeti badge for the equivalence merged through TauCeti #2804 and an exact inline TauCeti link for its Unicode-named generator theorem. The Lie-functor cards remain unbadged because TauCeti #3078 is still a draft. Local-only SPINREP-050/053 candidates are horizon text only and are explicitly unbadged. This PR adds no expanded #3151 or #3281 card.

## Rendered evidence

- `just chk` passes
- full Forest build passes across 1,195 XML files; the focused exact-head rebuild also passes
- FCAP PDF renders to 40 pages with 96 HTTPS URI annotations, including 79 TauCeti documentation links
- PDF actions contain the exact ASCII-safe targets for `realCliffordSignatureSwitchRecurrenceEquiv` and `realCliffordSignatureSwitchRecurrenceEquiv_%CE%B9`; both resolver links open the intended declarations
- the corresponding web links remain exact and clickable
- LaTeX log has no overfull boxes or errors
- Chromium QA at 1440×1000 and 390×844 finds no horizontal overflow on the Lie section or signature-switch card

This PR is open and unmerged for independent audit.