### PR TITLE
fix(connes): remove redundant suite relations

### DIFF
--- a/trees/connes-0001.tree
+++ b/trees/connes-0001.tree
@@ -64,16 +64,14 @@ separate port at the construction and theorem nodes.}
 }
 
 \p{The mathematical weight is uneven. The characteristic-two construction in
-\ref{connes-000C} is concrete algebra and supplies every later carrier. The
-factor lane in \ref{connes-0007}, \ref{connes-000D}, and \ref{connes-000E} is
-heavy operator algebra: compact duals, Haar
+Section 2 is concrete algebra and supplies every later carrier. The factor
+lane in Section 3 is heavy operator algebra: compact duals, Haar
 measure, Fourier transforms, von Neumann closures, and trace transport. The
-property-(T) lane in \ref{connes-0003}, \ref{connes-0004}, and
-\ref{connes-0005} is heavy harmonic and representation theory: spectral
+property-(T) lane in Section 4 is heavy harmonic and representation theory: spectral
 measures and finite detectors are internal, while the deep EJZK theorem enters
-at one narrow boundary. The ICC lane in \ref{connes-0006} is the lightest
+at one narrow boundary. The ICC lane in Section 5 is the lightest
 conceptually, but still needs exact orbit and finite-quotient displacement
-calculations. The nonisomorphism lane in \ref{connes-0008} is the deepest
+calculations. The nonisomorphism lane in Section 6 is the deepest
 internal algebraic chain: characteristic kernels, quotient twists,
 semisimplicity, and a finite cocycle obstruction must survive transport along
 an arbitrary group isomorphism.}
@@ -81,19 +79,17 @@ an arbitrary group isomorphism.}
 \p{Much of the development is a direct formal translation: define Zhou's
 modules and actions, verify their algebraic laws, and instantiate standard
 transfer principles. The nonroutine points are where the paper suppresses an
-interface that Lean must make explicit. The tensor calculation becomes a
-square-span certificate in \ref{connes-000C}. Generator identities are upgraded
-to completed von Neumann algebras through the spatial witness of
-\ref{connes-0007}, \ref{connes-000D}, and \ref{connes-000E}; that bridge
+interface that Lean must make explicit. The tensor calculation becomes the
+square-span certificate in Section 2. Generator identities are upgraded
+to completed von Neumann algebras through the spatial witness and supporting
+transport remarks in Section 3; that bridge
 separates measurable crossed-product transport, continuous-coefficient closure,
 and the concrete nonadditive fiber shear. Quantitative spectral detection is
-separated from the exact qualitative boundary in \ref{connes-0003} and
-\ref{connes-0004}. The ICC proof
-uses the three-case criterion in \ref{connes-0006}, and nonisomorphism follows
-the quotient twist in \ref{connes-000H}. The assembly in \ref{connes-0002}
+separated from the exact qualitative boundary in Section 4. The ICC proof
+uses the three-case criterion in Section 5, and nonisomorphism follows
+the quotient twist in Section 6. The assembly in Section 7
 accepts proved propositions, not a record that already contains its conclusion.
-The broader lessons are collected in \ref{connes-000A}, \ref{connes-000F},
-and \ref{connes-000J}.}
+The broader lessons are collected in Section 8.}
 
 \p{The code has two architectural layers. Reusable group theory, linear
 algebra, topology, measure theory, and operator algebra live in a foundation
@@ -114,9 +110,8 @@ to handle the finite #{\operatorname{Sp}_4(\mathbb F_2)} factor; following the
 quotient automorphism induced by a hypothetical group isomorphism; and tying
 the factor target to the concrete Fourier shear and completed von Neumann
 closures. The final interface remains proposition-valued. Its assembly and
-trust boundary are detailed in \ref{connes-0002} and \ref{connes-0009}; the
-remaining EJZK work is scoped in \ref{connes-000B}, \ref{connes-000G}, and
-\ref{connes-000I}.}
+trust boundary are detailed in Section 7; the remaining EJZK work is scoped in
+Section 9.}
 
 \p{The notes use their own section numbers for a continuous reading order.
 Sections 2--7 correspond respectively to Zhou's Sections 2--7; that

--- a/trees/connes-0007.tree
+++ b/trees/connes-0007.tree
@@ -26,7 +26,7 @@ algebra conclusion is stored as an unexplained premise.}
 
 \p{For Zhou's groups, the concrete unitary composes the two Fourier models with
 the fiber shear. The measure-transport and von Neumann closure obligations are
-separated in \ref{connes-000D} and \ref{connes-000E}. Together they construct
+separated in the two remarks immediately below. Together they construct
 \href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Paper/Section3/FactorClosure.lean#L276-L404}{\code{paperSpatialUnitary}, \code{paperSpatialWitness}, and \code{paperGroupFactors_isomorphic}}.
 This is the tracial factor equivalence asserted in
 \citet{Proposition 3.4}{zhou2026icc}.}

--- a/trees/connes-0008.tree
+++ b/trees/connes-0008.tree
@@ -16,7 +16,7 @@ isomorphism identifies the characteristic kernels, descends to an automorphism
 first quotient module and the second module with its action restricted along
 #{\sigma}. Semisimplicity is invariant under that linear equivalence.
 The characteristic-kernel and quotient-twist boundaries used here are
-separated in \ref{connes-000H}.}
+separated in the following remark.}
 
 \p{On the first side, explicit decomposition into simple summands culminates
 in

--- a/trees/connes-000D.tree
+++ b/trees/connes-000D.tree
@@ -33,4 +33,4 @@ abstract transport. The concrete homeomorphism is formally convenient because
 pullback preserves continuous coefficients. The proof uses that extra
 structure for the density bridge and forgets it at the measurable boundary,
 without falsely requiring an additive equivalence. The separate closure step is
-recorded in \ref{connes-000E}.}
+recorded in the following remark.}


### PR DESCRIPTION
## Summary

- replace Connes root-to-child references with plain section references because every child is already transcluded
- replace three child-to-child references with reading-order prose
- preserve all transclusions, literature citations, Lean links, and mathematical content

## Verification

- `just chk`
- full Forester build
- generated HTML inspection confirms no `Related` panel on the Connes root or affected child cards
- diff hygiene, commit identity, and public-metadata scans