### PR TITLE
fix(connes): publish PDF and restore numbered overview links

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -278,6 +278,8 @@ function lize {
     show_lize_result fgap-0001
     ./lize.sh fcap-0001 # >/dev/null # 2>&1
     show_lize_result fcap-0001
+    ./lize.sh connes-0001 # >/dev/null # 2>&1
+    show_lize_result connes-0001
     ./lize.sh tt-0001 # >/dev/null # 2>&1
     show_lize_result tt-0001
     ./lize.sh uts-000C # >/dev/null # 2>&1

--- a/trees/connes-000K.tree
+++ b/trees/connes-000K.tree
@@ -60,16 +60,16 @@ separate port at the construction and theorem nodes.}
 }
 
 \p{The mathematical weight is uneven. The characteristic-two construction in
-[[connes-000C]] is concrete algebra and supplies every later carrier. The
-factor lane in [[connes-0007]], [[connes-000D]], and [[connes-000E]] is
+\ref{connes-000C} is concrete algebra and supplies every later carrier. The
+factor lane in \ref{connes-0007}, \ref{connes-000D}, and \ref{connes-000E} is
 heavy operator algebra: compact duals, Haar
 measure, Fourier transforms, von Neumann closures, and trace transport. The
-property-(T) lane in [[connes-0003]], [[connes-0004]], and
-[[connes-0005]] is heavy harmonic and representation theory: spectral
+property-(T) lane in \ref{connes-0003}, \ref{connes-0004}, and
+\ref{connes-0005} is heavy harmonic and representation theory: spectral
 measures and finite detectors are internal, while the deep EJZK theorem enters
-at one narrow boundary. The ICC lane in [[connes-0006]] is the lightest
+at one narrow boundary. The ICC lane in \ref{connes-0006} is the lightest
 conceptually, but still needs exact orbit and finite-quotient displacement
-calculations. The nonisomorphism lane in [[connes-0008]] is the deepest
+calculations. The nonisomorphism lane in \ref{connes-0008} is the deepest
 internal algebraic chain: characteristic kernels, quotient twists,
 semisimplicity, and a finite cocycle obstruction must survive transport along
 an arbitrary group isomorphism.}
@@ -78,18 +78,18 @@ an arbitrary group isomorphism.}
 modules and actions, verify their algebraic laws, and instantiate standard
 transfer principles. The nonroutine points are where the paper suppresses an
 interface that Lean must make explicit. The tensor calculation becomes a
-square-span certificate in [[connes-000C]]. Generator identities are upgraded
+square-span certificate in \ref{connes-000C}. Generator identities are upgraded
 to completed von Neumann algebras through the spatial witness of
-[[connes-0007]], [[connes-000D]], and [[connes-000E]]; that bridge
+\ref{connes-0007}, \ref{connes-000D}, and \ref{connes-000E}; that bridge
 separates measurable crossed-product transport, continuous-coefficient closure,
 and the concrete nonadditive fiber shear. Quantitative spectral detection is
-separated from the exact qualitative boundary in [[connes-0003]] and
-[[connes-0004]]. The ICC proof
-uses the three-case criterion in [[connes-0006]], and nonisomorphism follows
-the quotient twist in [[connes-000H]]. The assembly in [[connes-0002]]
+separated from the exact qualitative boundary in \ref{connes-0003} and
+\ref{connes-0004}. The ICC proof
+uses the three-case criterion in \ref{connes-0006}, and nonisomorphism follows
+the quotient twist in \ref{connes-000H}. The assembly in \ref{connes-0002}
 accepts proved propositions, not a record that already contains its conclusion.
-The broader lessons are collected in [[connes-000A]], [[connes-000F]],
-and [[connes-000J]].}
+The broader lessons are collected in \ref{connes-000A}, \ref{connes-000F},
+and \ref{connes-000J}.}
 
 \p{The code has two architectural layers. Reusable group theory, linear
 algebra, topology, measure theory, and operator algebra live in a foundation
@@ -110,9 +110,9 @@ to handle the finite #{\operatorname{Sp}_4(\mathbb F_2)} factor; following the
 quotient automorphism induced by a hypothetical group isomorphism; and tying
 the factor target to the concrete Fourier shear and completed von Neumann
 closures. The final interface remains proposition-valued. Its assembly and
-trust boundary are detailed in [[connes-0002]] and [[connes-0009]]; the
-remaining EJZK work is scoped in [[connes-000B]], [[connes-000G]], and
-[[connes-000I]].}
+trust boundary are detailed in \ref{connes-0002} and \ref{connes-0009}; the
+remaining EJZK work is scoped in \ref{connes-000B}, \ref{connes-000G}, and
+\ref{connes-000I}.}
 
 \p{The notes use their own section numbers for a continuous reading order.
 Sections 2--7 correspond respectively to Zhou's Sections 2--7; that


### PR DESCRIPTION
## Summary

- restore Forester `\ref` links in the standalone Formalization design card so the overview displays compact taxon-and-number labels
- preserve the addressed-card boundary from #121, keeping the complete suite root free of duplicated Related cards
- add `connes-0001` to the explicit CI LaTeX target list so the PDF declared by the root metadata is actually deployed

## Cause of the 404

`connes-0001` already declared `\meta{pdf}{true}`, which made the theme emit `/forest/connes-0001.pdf`. The CI build generated PDFs from a separate explicit list in `build.sh`, and that list omitted `connes-0001`.

## Verification

- `bash -n build.sh`
- `just chk`
- Forester build passed
- `connes-0001` PDF rebuilt: 17 A4 pages, no overfull boxes or unresolved references
- restored overview rendering visually inspected on pages 2–3
- graph contract preserved: suite root has 0 Related cards; standalone design card has 18
- local publication artifact exists at the same path used by the deployed PDF link
- exact `utensil <utensilcandel@gmail.com>` author and committer identity verified for both commits
