### PR TITLE
fix: capitalize AG suite titles

### DIFF
--- a/trees/ag-000H.tree
+++ b/trees/ag-000H.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative
 
-\note{preface}{
+\note{Preface}{
 
 \p{The note should contain:
 \ul{

--- a/trees/ag-000I.tree
+++ b/trees/ag-000I.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative
 
-\card{Definition}{signed distance function \citewiki{sdf}{Signed_distance_function}}{
+\card{Definition}{Signed distance function \citewiki{sdf}{Signed_distance_function}}{
 
 \p{
 Let #{\Omega} be a subset of a [metric space](https://en.wikipedia.org/wiki/Metric_space) #{X} with metric #{d}, and #{\partial \Omega} be its boundary. The distance between a point #{\point{p}} of #{X} and the subset #{\partial \Omega} of #{X} is defined as usual as

--- a/trees/ag-000J.tree
+++ b/trees/ag-000J.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative
 
-\card{Convention}{sign}{
+\card{Convention}{Sign}{
 \p{Simply put, SDFs are the minimum possible distance from a point to an implicit surface defined by #{f(\point{p})=0}.}
 
 \p{The convention adopted in this note is that the #{+} and #{-} signs indicate whether the point is outside or inside the surface, respectively, so that when a ray marches towards the surface from the outside, the distance is positive, becomes smaller when approaching the surface.

--- a/trees/ag-000K.tree
+++ b/trees/ag-000K.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere
 
-\refdeft{implicit surface}{sec. 1}{hart1996sphere}{
+\refdeft{Implicit surface}{sec. 1}{hart1996sphere}{
 \p{If an SDF #{f} is a continuous mapping, the subset #{\Omega}  can be implicitly described as the [locus](https://en.wikipedia.org/wiki/Locus_(mathematics)) of points
 
 ##{ \Omega = \{ p : f(p) \le 0 \} }

--- a/trees/ag-000M.tree
+++ b/trees/ag-000M.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt ag math draft cg
 \tag{cg}
 
-\note{implicit surfaces}{
+\note{Implicit surfaces}{
 \transclude{ag-000Y}
 \transclude{ag-000X}
 }

--- a/trees/ag-000N.tree
+++ b/trees/ag-000N.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere
 
-\note{ray-marching}{
+\note{Ray-marching}{
 \transclude{ag-001A}
 \transclude{ag-000V}
 \transclude{ag-000W}

--- a/trees/ag-000R.tree
+++ b/trees/ag-000R.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere
 
-\refdeft{point-to-set distance}{def. 1}{hart1996sphere}{
+\refdeft{Point-to-set distance}{def. 1}{hart1996sphere}{
 \p{
 The \newvocab{point-to-set distance} defines the distance from a point #{\point{x} \in \mathbb{R}^3} to a set #{A \subset \mathbb{R}^3} as the distance from #{x} to the closest point in #{A},
 

--- a/trees/ag-000S.tree
+++ b/trees/ag-000S.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray
 
-\refdeft{signed distance bound}{def. 2}{hart1996sphere}{
+\refdeft{Signed distance bound}{def. 2}{hart1996sphere}{
 \p{
 A function #{f: \mathbb{R}^3 \rightarrow \mathbb{R}} is a \newvocab{signed distance bound} of its implicit surface #{f^{-1}(0)} if and only if
 

--- a/trees/ag-000V.tree
+++ b/trees/ag-000V.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray
 
-\refdeft{ray equation}{sec. 1.1 eq. 3}{gillespie2024ray}{
+\refdeft{Ray equation}{sec. 1.1 eq. 3}{gillespie2024ray}{
 \p{
 A \vocab{ray} anchored at origin #{\boldsymbol{r}_o} in the direction of the unit vector #{\boldsymbol{r}_d} can be parametrically defined as a \newvocab{ray equation}
 

--- a/trees/ag-000W.tree
+++ b/trees/ag-000W.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray
 
-\refdeft{ray intersection}{sec. 1.1 eq. 4}{gillespie2024ray}{
+\refdeft{Ray intersection}{sec. 1.1 eq. 4}{gillespie2024ray}{
 \p{Plugging the \vocab{ray equation} #{r: \mathbb{R} \rightarrow \mathbb{R}^n} into the function #{f: \mathbb{R}^n \rightarrow \mathbb{R}} that defines the implicit surface produces the composite real function #{F: \mathbb{R} \rightarrow \mathbb{R}} where #{F=f \circ \boldsymbol{r}} such that the \vocab{solution}s to
 
 ##{

--- a/trees/ag-000X.tree
+++ b/trees/ag-000X.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\refdeft{implicit surface}{sec. 1}{winchenbach2024lipschitz}{
+\refdeft{Implicit surface}{sec. 1}{winchenbach2024lipschitz}{
 \p{Let #{\Omega} be a subset of a [topological space](https://en.wikipedia.org/wiki/Topological_space) #{X}, and #{\partial \Omega} be its [boundary](https://en.wikipedia.org/wiki/Boundary_(topology)).
 }
 

--- a/trees/ag-000Y.tree
+++ b/trees/ag-000Y.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{Definition}{level set \citewiki{level-set}{https://en.wikipedia.org/wiki/Level_set}}{
+\card{Definition}{Level set \citewiki{level-set}{https://en.wikipedia.org/wiki/Level_set}}{
 A \newvocab{level set} of a real-valued function #{f} (a.k.a. an iso-contour of a scalar field in 3D)
 
 ##{L_c(f)=\left\{\point{x} \mid \forall \point{x} \in X, f(\point{x})=c  \right\} }

--- a/trees/ag-0010.tree
+++ b/trees/ag-0010.tree
@@ -2,7 +2,7 @@
 % clifford hopf spin tt ag math draft cg
 \tag{cg}
 
-\note{sphere tracing}{
+\note{Sphere tracing}{
 \transclude{ag-000R}
 \transclude{ag-000S}
 \transclude{ag-000P}

--- a/trees/ag-0018.tree
+++ b/trees/ag-0018.tree
@@ -26,7 +26,7 @@
 \def\eps{\varepsilon}
 \def\tmax{t_{\max}}
 
-\card{Algorithm}{ray marching (naïve)}{
+\card{Algorithm}{Ray marching (naïve)}{
 \minialg{
 % \begin{algorithm*}{Ray marching (naive)}{}
 \alg/input{$\ro \in \RR^3$, ray origin}

--- a/trees/ag-0019.tree
+++ b/trees/ag-0019.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{Example}{ray marching (naïve)}{
+\card{Example}{Ray marching (naïve)}{
 
 \p{The following renders a scene with a unit sphere at the origin, the camera at #{(0,0,8)} and looking at the origin, through a screen of height 1.0, centered at 5.0 from the camera.
 }

--- a/trees/ag-001A.tree
+++ b/trees/ag-001A.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{Definition}{ray}{
+\card{Definition}{Ray}{
 \p{A \newvocab{ray} is a half-line that starts at a point and extends indefinitely in one direction.
 }
 

--- a/trees/ag-001B.tree
+++ b/trees/ag-001B.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{Definition}{ray marching (naïve)}{
+\card{Definition}{Ray marching (naïve)}{
 \p{The \newvocab{ray marching (naïve)} algorithm is to march a ray by a \em{fixed step size}, check if a \vocab{ray intersection} occurs at each step, until the ray reaches a maximum distance or step count.
 }
 

--- a/trees/ag-001C.tree
+++ b/trees/ag-001C.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{Definition}{ray marching}{
+\card{Definition}{Ray marching}{
 \p{To render a scene, the \newvocab{Ray marching} algorithm marches a ray from an origin towards a direction. At each step, the algorithm marches a short (possibly changing) distance and checks if a \vocab{ray intersection} occurs. This process continues until a \em{stopping condition} is met. The information obtained from the ray intersection is then used to determine the color of a pixel on the screen.
 }
 }

--- a/trees/ag-001D.tree
+++ b/trees/ag-001D.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{Example}{ray-marching for different types of rays}{
+\card{Example}{Ray-marching for different types of rays}{
 
 \p{A \vocab{view ray} has the origin at the camera, the direction is determined by the pixel on the screen that it passes through. It may intersect with a surface in the scene, and the information obtained from the intersection is used to determine the color of the corresponding pixel on the screen.}
 

--- a/trees/ag-001E.tree
+++ b/trees/ag-001E.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\card{Remark}{ray-casting/ray-tracing/ray-marching}{
+\card{Remark}{Ray-casting/ray-tracing/ray-marching}{
 \p{The \newvocab{ray-casting}/\newvocab{ray-tracing}/\newvocab{ray-marching} algorithms simply apply one of the multitude of root finding methods to solve the \vocab{ray intersection} equation.
 }
 

--- a/trees/ag-001I.tree
+++ b/trees/ag-001I.tree
@@ -12,7 +12,7 @@
 
 % cox1997ideals gathmann2013commutative hart1996sphere gillespie2024ray winchenbach2024lipschitz
 
-\refdeft{sphere tracing}{sec. 2.3, eq. 12}{hart1996sphere}{
+\refdeft{Sphere tracing}{sec. 2.3, eq. 12}{hart1996sphere}{
 \p{The \newvocab{sphere tracing} algorithm is to march a ray by an adaptive safe step size, which is the absolute value of the \vocab{signed distance bound} calculated by #{F/\lambda} per \ref{ag-000T}, the rest is the same as \vocabk{ray marching (naïve)}{ag-001B}.
 }
 


### PR DESCRIPTION
## Summary

- Capitalize the initial letter in the 21 authored title fields of the recursive `ag-000G` transclusion suite.
- Leave shared macros, styles, title bodies, blank title fields, intentional acronyms, and unrelated trees untouched.

## Verification

- `just build`
- `just verify-render` — 1,221 XML/HTML page pairs
- `just verify-pdf-fixtures` — seven PDF fixtures
- Scoped source-title lint and browser readback of the rendered `ag-000G` page