### PR TITLE
style: refine agent drafted badge

### DIFF
--- a/assets/uts-overrides.xsl
+++ b/assets/uts-overrides.xsl
@@ -177,11 +177,11 @@
             </xsl:if>
             <!-- AGENT-NOTE: This provenance mark is intentionally web-only; PDF output stays unchanged. -->
             <xsl:if test="../fr:meta[@name='agent-authored'][not(normalize-space(.)='false')]">
-                <span class="agent-authored-watermark" role="note" aria-label="Agent authored"
-                    title="Agent authored">
+                <span class="agent-authored-watermark" role="note" aria-label="Agent drafted"
+                    title="Agent drafted">
                     <span class="agent-authored-watermark-label" aria-hidden="true">
                         <span>AGENT</span>
-                        <span>AUTHORED</span>
+                        <span>DRAFTED</span>
                     </span>
                 </span>
             </xsl:if>

--- a/bun/uts-style.css
+++ b/bun/uts-style.css
@@ -148,8 +148,8 @@ section:has(> details > summary > header .agent-authored-watermark)
     > details
     > summary
     > header {
-    min-height: 4.75rem;
-    padding-inline-end: 6rem;
+    min-height: 4.375rem;
+    padding-inline-end: 5.5rem;
 }
 
 section:has(> details > summary > header .agent-authored-watermark)
@@ -157,7 +157,7 @@ section:has(> details > summary > header .agent-authored-watermark)
     > summary
     > header
     .link-buttons {
-    margin-inline-end: 7.5rem;
+    margin-inline-end: 6.375rem;
 }
 
 .agent-authored-watermark {
@@ -166,8 +166,8 @@ section:has(> details > summary > header .agent-authored-watermark)
     inset-inline-end: 0;
     z-index: 1;
     display: block;
-    width: 7.5rem;
-    height: 7.5rem;
+    width: 6.375rem;
+    height: 6.375rem;
     overflow: hidden;
     clip-path: polygon(100% 0, 0 0, 100% 100%);
     color: color-mix(in srgb, var(--uts-text) 48%, transparent);
@@ -179,11 +179,11 @@ section:has(> details > summary > header .agent-authored-watermark)
 
 .agent-authored-watermark-label {
     position: absolute;
-    inset-block-start: 1.45rem;
-    inset-inline-end: -0.05rem;
+    inset-block-start: 1.125rem;
+    inset-inline-end: -0.35rem;
     display: flex;
     flex-direction: column;
-    gap: 0.28em;
+    gap: 0.42em;
     align-items: center;
     width: 4.25rem;
     font-family: var(--sans);
@@ -203,8 +203,8 @@ section:has(> details > summary > header .agent-authored-watermark)
         > details
         > summary
         > header {
-        min-height: 4rem;
-        padding-inline-end: 4.5rem;
+        min-height: 3.75rem;
+        padding-inline-end: 4.25rem;
     }
 
     section:has(> details > summary > header .agent-authored-watermark)
@@ -212,17 +212,17 @@ section:has(> details > summary > header .agent-authored-watermark)
         > summary
         > header
         .link-buttons {
-        margin-inline-end: 6rem;
+        margin-inline-end: 5.15rem;
     }
 
     .agent-authored-watermark {
-        width: 6rem;
-        height: 6rem;
+        width: 5.15rem;
+        height: 5.15rem;
     }
 
     .agent-authored-watermark-label {
-        inset-block-start: 1.12rem;
-        inset-inline-end: -0.04rem;
+        inset-block-start: 0.91rem;
+        inset-inline-end: -0.3rem;
         width: 3.6rem;
         font-size: 0.54rem;
     }


### PR DESCRIPTION
## Scope

- change the web-only provenance badge wording, tooltip, and accessible label to `Agent drafted`
- shrink and re-centre only the clipped badge geometry so the diagonal label has about half its prior end clearance
- retune the badge's own header/button clearance at desktop and narrow widths

The `agent-authored` metadata contract and PDF output remain unchanged.

## Verification

- `just build`
- `CI=1 ./chk.sh`
- `just verify-render` — 1,222 XML/HTML page pairs
- `xmllint --noout assets/uts-overrides.xsl`
- browser readback and rendered desktop light/dark preview of `fgap-0001`

Preview snapshots were posted in the Forest work thread before opening this PR.