### PR TITLE
docs(connes): separate exposition and stabilize Lean references [AGENT]

### DIFF
--- a/assets/latex.xsl
+++ b/assets/latex.xsl
@@ -214,8 +214,7 @@
         </xsl:if>
         <xsl:call-template name="lean-markers">
           <xsl:with-param name="markers" select="." />
-          <xsl:with-param name="base" select="'https://github.com/utensil/connes-rigidity/search?q='" />
-          <xsl:with-param name="suffix" select="'&amp;type=code'" />
+          <xsl:with-param name="base" select="'https://utensil.github.io/connes-rigidity/docs/find/\#doc/'" />
           <xsl:with-param name="short" select="true()" />
         </xsl:call-template>
       </xsl:for-each>

--- a/assets/uts-overrides.xsl
+++ b/assets/uts-overrides.xsl
@@ -118,12 +118,24 @@
                 <xsl:call-template name="splitlean">
                     <xsl:with-param name="pText" select="." />
                     <xsl:with-param name="sep" select="','" />
-                    <xsl:with-param name="base" select="'https://github.com/utensil/connes-rigidity/search?q='" />
-                    <xsl:with-param name="suffix" select="'&amp;type=code'" />
+                    <xsl:with-param name="base" select="'https://utensil.github.io/connes-rigidity/docs/find/#doc/'" />
                     <xsl:with-param name="short" select="true()" />
                 </xsl:call-template>
             </div>
             <span class="meta-lean-symbol">L∃∀N</span>
+        </span>
+    </xsl:template>
+
+    <!-- Forest and the Connes reference share a GitHub Pages origin. Keep
+         declaration fragments intact instead of routing this sibling site as
+         a local Forest tree. -->
+    <xsl:template
+        match="fr:link[@type='external'][starts-with(@href, 'https://utensil.github.io/connes-rigidity/docs/find/#doc/')]"
+        priority="20">
+        <span class="link external">
+            <a href="{@href}">
+                <xsl:copy-of select="node()" />
+            </a>
         </span>
     </xsl:template>
 

--- a/trees/connes-0001.tree
+++ b/trees/connes-0001.tree
@@ -35,6 +35,7 @@
 \subtree{
   \title{Characteristic-two tensor kernel (Zhou §2)}
   \transclude{connes-000C}
+  \transclude{connes-000U}
 }
 
 \subtree{
@@ -47,13 +48,17 @@
 \subtree{
   \title{Property (T) by spectral transfer (Zhou §4)}
   \transclude{connes-0003}
+  \transclude{connes-000V}
   \transclude{connes-0004}
+  \transclude{connes-000Y}
   \transclude{connes-0005}
+  \transclude{connes-000W}
 }
 
 \subtree{
   \title{ICC by orbit displacement (Zhou §5)}
   \transclude{connes-0006}
+  \transclude{connes-000X}
 }
 
 \subtree{

--- a/trees/connes-0002.tree
+++ b/trees/connes-0002.tree
@@ -4,7 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{property-t}
-\taxon{Remark}
 \title{Exact external boundary}
 \lean/connes{Connes.theoremA,Connes.PaperPropertyT.elementaryGroup}
 
@@ -37,7 +36,14 @@ a claim that every expository sentence of \citek{zhou2026icc} has been encoded.}
 \end{tikzpicture}}
 
 \p{The solution import graph contains no axiom, opaque declaration, sorry, or
-admit. Lean's axiom report for \code{Connes.theoremA} contains only
-\code{propext}, \code{Classical.choice}, and \code{Quot.sound}, the usual
-Lean foundations used by the imported library. The one \code{sorry} in an
-independent Comparator challenge is outside the theorem's import graph.}
+admit. Lean's axiom report for \code{Connes.theoremA} contains only:}
+
+\ul{
+  \li{\code{propext};}
+  \li{\code{Classical.choice}; and}
+  \li{\code{Quot.sound}.}
+}
+
+\p{These are the usual Lean foundations used by the imported library. The one
+\code{sorry} in an independent Comparator challenge is outside the theorem's
+import graph.}

--- a/trees/connes-0002.tree
+++ b/trees/connes-0002.tree
@@ -8,11 +8,11 @@
 \lean/connes{Connes.theoremA,Connes.PaperPropertyT.elementaryGroup}
 
 \p{The public theorem is
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Main.lean#L17-L25}{\code{Connes.theoremA}}.
+\leanref/connes{Connes.theoremA}.
 Its sole mathematical parameter is
 #{\operatorname{HasKazhdanPropertyT}(\mathrm{EL}_3(\mathbb F_2[t]))}.
 The corresponding Lean boundary consists of
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L23-L39}{\code{PaperPropertyT.elementaryGroup}}
+\leanref/connes{Connes.PaperPropertyT.elementaryGroup}
 and \code{EJZKInput}.}
 
 \p{All spectral, factor, ICC, and nonisomorphism certificates downstream of that

--- a/trees/connes-0003.tree
+++ b/trees/connes-0003.tree
@@ -15,25 +15,6 @@ every #{\varepsilon>0} admit a unit vector #{\xi} satisfying
 ##{\lVert \pi(g)\xi-\xi\rVert<\varepsilon\qquad(g\in K).}
 
 The project defines property (T) by requiring every such representation to
-contain a nonzero invariant vector.}
-
-\p{The exact Lean boundary uses
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Core.lean#L46-L88}{the almost-invariance and property-(T) predicates}.
-This qualitative form matches the final consumer, while quantitative Kazhdan
-sets and constants remain local to any future proof of the EJZK input.}
-
-\p{The useful decomposition is the fixed subspace #{H^N} of a normal subgroup
-#{N} and its orthogonal complement. Relative property (T) forces a nonzero
-vector into #{H^N}; property (T) of the quotient then acts on #{H^N}.}
-
-\p{
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/PropertyTTransfer.lean#L264-L278}{The relative-and-quotient transfer theorem}
-packages this argument. Isolating it prevents the later spectral proof from
-depending on the concrete presentation of Zhou's groups.}
-
-\p{\strong{Boundary design: quantitative input, qualitative output.}
-A future EJZK development should expose Kazhdan pairs, ratios, or spectral
-gaps internally, then export
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L23-L39}{property (T) for the elementary group}.
-Changing the public theorem to demand a particular constant would strengthen
-the paper's hypothesis and couple every consumer to an arbitrary estimate.}
+contain a nonzero invariant vector. Relative property (T) for a subgroup
+#{N\leq G} requires every such representation to contain a nonzero vector
+fixed by #{N}.}

--- a/trees/connes-0004.tree
+++ b/trees/connes-0004.tree
@@ -7,41 +7,17 @@
 \tag{property-t}
 \taxon{Theorem}
 \title{Spectral bridge for split abelian extensions}
-\lean/connes{Connes.SplitAbelianExtension,Connes.ProjectionValuedSpectralMeasure,Connes.spectral_criterion,Connes.BinaryPontryaginDual.pointwisePontryaginDualEquiv}
+\lean/connes{Connes.spectral_criterion}
 
 \p{A split extension #{A\rtimes H} with #{A} abelian turns the restriction of a
 unitary representation to #{A} into harmonic analysis on the Pontryagin dual
-#{\widehat A}. The project records the group-theoretic data in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/SplitAbelianExtension.lean#L17-L32}{\code{SplitAbelianExtension}},
-so the analytic layer sees the kernel, quotient action, and section without
-unfolding a semidirect product.}
-
-\p{For a vector #{\xi}, a projection-valued spectral measure #{P} yields the
+#{\widehat A}. For a vector #{\xi}, a projection-valued spectral measure #{P}
+yields the
 positive scalar measure
 
 ##{\mu_\xi(B)=\langle P(B)\xi,\xi\rangle.}
 
 Its total mass is #{\lVert\xi\rVert^2}; kernel displacement becomes the energy
-#{\int_{\widehat A}|\chi(a)-1|^2\,d\mu_\xi(\chi)}; quotient-fixed vectors give
-invariant measures. These interfaces are formalized in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/ProjectionValuedSpectralMeasure.lean#L28-L187}{\code{ProjectionValuedSpectralMeasure}}
-and the generic criterion
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/SpectralCriterion.lean#L118-L180}{\code{spectral_criterion}}.
-A finite detection inequality forces positive mass at the trivial character;
-its spectral projection is then the required invariant vector.}
-
-\p{Over #{\mathbb F_2}, characters take values through the two-element circle
-subgroup. The local equivalence in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/BinaryPontryaginDual.lean#L229-L314}{\code{BinaryPontryaginDual.pointwisePontryaginDualEquiv}}
-identifies the dual of a linear dual with its evaluation module. This is a
-formalization bridge, not a new hypothesis: it replaces implicit Fourier
-coordinates by an explicit additive equivalence.}
-
-\p{\strong{Positive-atom extraction.}
-If an invariant probability measure #{\mu} satisfies
-
-##{c(1-\mu(\{1\}))\leq\sum_{a\in J}\int|\chi(a)-1|^2\,d\mu(\chi)}
-
-for some #{c>0}, then sufficiently small displacement on the finite detector
-#{J} forces #{\mu(\{1\})>0}. This small inequality is the direct consumer
-boundary between measure theory and relative property (T).}
+#{\int_{\widehat A}|\chi(a)-1|^2\,d\mu_\xi(\chi)}; and quotient-fixed vectors
+give invariant measures. A positive atom at the trivial character yields a
+nonzero invariant vector through its spectral projection.}

--- a/trees/connes-0005.tree
+++ b/trees/connes-0005.tree
@@ -16,6 +16,6 @@ the property-(T) theorem of \citet{Theorem 1.1 and Section 1.2}{ershov2017rootgr
 The equality step is not part of the remaining external boundary.}
 
 \p{Consequently the multiplicative equivalence
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L29-L46}{\code{PaperPropertyT.elementaryEquivSL3}}
+\leanref/connes{Connes.PaperPropertyT.elementaryEquivSL3}
 transports property (T) from the elementary group named by the cited theorem
 to #{\mathrm{SL}_3(R)}.}

--- a/trees/connes-0005.tree
+++ b/trees/connes-0005.tree
@@ -15,18 +15,7 @@ Euclidean row reduction to identify it with #{\mathrm{SL}_3(R)}, then invokes
 the property-(T) theorem of \citet{Theorem 1.1 and Section 1.2}{ershov2017rootgraded}.
 The equality step is not part of the remaining external boundary.}
 
-\p{The formalization implements determinant-preserving row operations and a
-Euclidean descent on polynomial entries, concluding with
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/SpecialLinear/ElementaryGeneration.lean#L377-L378}{\code{SpecialLinear.elementarySubgroup_eq_top}}.}
-
-\p{It then constructs
+\p{Consequently the multiplicative equivalence
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L29-L46}{\code{PaperPropertyT.elementaryEquivSL3}}
-and transports property (T) across that multiplicative equivalence. Thus the
-external premise names the exact group in the cited theorem, while the
-paper-facing consumer may work with #{\mathrm{SL}_3(R)}.}
-
-\p{\strong{Transport design: use an explicit equivalence.}
-Rewriting subgroup equality into carrier equality would expose dependent
-coercions throughout Section 4. A named multiplicative equivalence keeps
-transport at one boundary and lets later finite-index and quotient arguments
-remain presentation-independent.}
+transports property (T) from the elementary group named by the cited theorem
+to #{\mathrm{SL}_3(R)}.}

--- a/trees/connes-0006.tree
+++ b/trees/connes-0006.tree
@@ -21,9 +21,9 @@ of certificates:}
 }
 
 \p{The structure
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICC.lean#L37-L45}{\code{PaperICC.ActionData}}
+\leanref/connes{Connes.PaperICC.ActionData}
 is exactly this direct-consumer boundary. The generic theorem
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICC.lean#L147-L249}{\code{PaperICC.isICC_of_product_quotient}}
+\leanref/connes{Connes.PaperICC.isICC_of_product_quotient}
 then proves that these certificates imply ICC by splitting a nonidentity
 element into three exhaustive cases.}
 

--- a/trees/connes-0006.tree
+++ b/trees/connes-0006.tree
@@ -24,7 +24,8 @@ of certificates:}
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICC.lean#L37-L45}{\code{PaperICC.ActionData}}
 is exactly this direct-consumer boundary. The generic theorem
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICC.lean#L147-L249}{\code{PaperICC.isICC_of_product_quotient}}
-then splits a nonidentity element into three exhaustive cases.}
+then proves that these certificates imply ICC by splitting a nonidentity
+element into three exhaustive cases.}
 
 \ul{
   \li{A nontrivial #{S}-coordinate inherits an infinite conjugacy class from
@@ -33,17 +34,5 @@ then splits a nonidentity element into three exhaustive cases.}
   \li{A surviving #{Q}-coordinate reduces to the second certificate.}
 }
 
-\p{The paper-specific work is therefore confined to orbit calculations in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICCOrbits.lean}{\code{ICCOrbits.lean}}.
-Those calculations construct one data pair and yield
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICCOrbits.lean#L585-L597}{\code{paper_gammaOne_icc} and \code{paper_gammaTwo_icc}}.}
-
 \p{This organization follows the cases used in \citet{Section 5}{zhou2026icc}
 without building the concrete tensors into the reusable ICC theorem.}
-
-\p{\strong{Design adaptation: displacement is the finite-quotient input.}
-Conjugating an element with nontrivial #{Q}-coordinate by kernel elements
-changes its kernel coordinate by #{a(q\cdot a)^{-1}}. Asking directly for an
-infinite family of conjugates would duplicate this algebra in each action.
-The displacement certificate exposes the one expression whose infinite
-#{S}-orbit suffices.}

--- a/trees/connes-0007.tree
+++ b/trees/connes-0007.tree
@@ -17,11 +17,11 @@ facts are proved: conjugation by #{U} carries one closed operator algebra onto
 the other, and #{U\delta_e=\delta_e}.}
 
 \p{These are precisely the fields of
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/FactorWitness.lean#L19-L26}{\code{FactorWitness.SpatialWitness}}.
+\leanref/connes{Connes.FactorWitness.SpatialWitness}.
 }
 
 \p{The generic conversion
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/FactorWitness.lean#L121-L146}{\code{tracialEquiv_of_spatialWitness}}
+\leanref/connes{Connes.FactorWitness.tracialEquiv_of_spatialWitness}
 restricts conjugation to the two group von Neumann algebras, proves normality,
 and obtains trace preservation from the vacuum equation. Thus no operator-
 algebra conclusion is stored as an unexplained premise.}
@@ -29,6 +29,8 @@ algebra conclusion is stored as an unexplained premise.}
 \p{For Zhou's groups, the concrete unitary composes the two Fourier models with
 the fiber shear. The measure-transport and von Neumann closure obligations are
 separated in \ref{connes-000D} and \ref{connes-000E}. Together they construct
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Paper/Section3/FactorClosure.lean#L276-L404}{\code{paperSpatialUnitary}, \code{paperSpatialWitness}, and \code{paperGroupFactors_isomorphic}}.
+\leanref/connes{Connes.PaperFactorClosure.paperSpatialUnitary},
+\leanref/connes{Connes.PaperFactorClosure.paperSpatialWitness}, and
+\leanref/connes{Connes.PaperFactorClosure.paperGroupFactors_isomorphic}.
 This is the tracial factor equivalence asserted in
 \citet{Proposition 3.4}{zhou2026icc}.}

--- a/trees/connes-0008.tree
+++ b/trees/connes-0008.tree
@@ -22,15 +22,15 @@ separated in \ref{connes-000H}.}
 
 \p{On the first side, explicit decomposition into simple summands culminates
 in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/ModuleSemisimple.lean#L407-L453}{\code{PaperModuleSemisimple.firstProduct_semisimple}}.}
+\leanref/connes{Connes.PaperModuleSemisimple.firstProduct_semisimple}.}
 
 \p{On the second side, a nonsplit submodule obstruction is proved for every
 quotient twist #{\sigma}. The bridge
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/NonisomorphismTransport.lean#L24-L50}{\code{paperCharacteristicModuleEquiv}}
+\leanref/connes{Connes.PaperNonisomorphism.paperCharacteristicModuleEquiv}
 turns a hypothetical group isomorphism into the forbidden module equivalence.}
 
 \p{The public contradiction is
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/ModuleSemisimpleTransport.lean#L44-L57}{\code{paperGroups_not_isomorphic}}.
+\leanref/connes{Connes.PaperModuleSemisimpleTransport.paperGroups_not_isomorphic}.
 This records the invariant used in \citet{Section 6}{zhou2026icc} while keeping
 the group-theoretic, finite-certificate, and module-theoretic arguments in
 separate files.}

--- a/trees/connes-0009.tree
+++ b/trees/connes-0009.tree
@@ -12,12 +12,12 @@
 branch proves property (T) for both concrete groups from the EJZK input and
 the internally constructed finite detectors. The other branches provide ICC,
 the trace-preserving group-factor equivalence, and nonisomorphism. The theorem
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section7/TheoremACompletion.lean#L23-L40}{\code{PaperTheoremACompletion.theoremA}}
+\leanref/connes{Connes.PaperTheoremACompletion.theoremA}
 only gathers those endpoints; it performs no additional mathematical
 construction.}
 
 \p{The source-facing declaration
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Main.lean#L14-L25}{\code{Connes.theoremA}}
+\leanref/connes{Connes.theoremA}
 unwraps the one-field EJZK input and states the full existence conclusion. Its
 single substantive mathematical premise is
 #{T(\mathrm{EL}_3(\mathbb F_2[t]))}. The local equality

--- a/trees/connes-0009.tree
+++ b/trees/connes-0009.tree
@@ -25,14 +25,5 @@ single substantive mathematical premise is
 groups are already proofs in the import graph.}
 
 \p{\strong{Kernel and source trust boundary.}
-There is no solution-path \code{axiom}, \code{opaque}, \code{sorry}, or
-\code{admit}. Printing the axioms of the public theorem and the downstream
-endpoints reports only \code{propext}, \code{Classical.choice}, and
-\code{Quot.sound}. These are Lean/library foundations, not unformalized
-mathematical claims. The separate Comparator challenge contains one
-\code{sorry}, but its module is not imported by the solution.}
-
-\p{Accordingly, “complete” here means the load-bearing formalization of
-Theorem A in \citek{zhou2026icc} under the project's explicit definitions. It
-does not mean that the paper's narrative remarks or every alternative proof
-have been translated into Lean.}
+The precise external premise, axiom report, and meaning of completeness are
+recorded once in \ref{connes-0002}.}

--- a/trees/connes-000A.tree
+++ b/trees/connes-000A.tree
@@ -4,7 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{proof-engineering}
-\taxon{Remark}
 \title{Dependency placement and consumer boundaries}
 \lean/connes{Connes.PaperSpectralPropertyT.completion_of_spectralData,Connes.PaperFactorClosure.paperSpatialWitness,Connes.PaperICC.ActionData}
 
@@ -16,15 +15,16 @@ instance for a representation module belongs at the module boundary in
 Section 6. Early placement makes Zhou's section order an acyclic dependency
 discipline instead of a directory convention.}
 
-\p{Concrete examples are
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section3/DualHaar.lean#L24-L49}{the dual topology and Borel instances}
-and
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/Nonisomorphism.lean#L93-L98}{the representation-module carrier instance}.}
+\p{Concrete examples are:}
+
+\ul{
+  \li{\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section3/DualHaar.lean#L24-L49}{the dual topology and Borel instances}; and}
+  \li{\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/Nonisomorphism.lean#L93-L98}{the representation-module carrier instance}.}
+}
 
 \p{\strong{Isolate certificates from structural theorems.}
-Finite symplectic enumeration lives in \code{Sp4KernelCertificate.lean};
-concrete orbit witnesses live in \code{ICCOrbits.lean}; detector estimates live
-in the Section 4 detector files. Their consumers see named propositions or
+The finite symplectic enumeration, concrete orbit witnesses, and detector
+estimates live in dedicated files. Their consumers see named propositions or
 small structures. This prevents an exhaustive certificate, coordinate
 calculation, or normalization choice from contaminating a generic transfer
 theorem.}

--- a/trees/connes-000A.tree
+++ b/trees/connes-000A.tree
@@ -18,8 +18,15 @@ discipline instead of a directory convention.}
 \p{Concrete examples are:}
 
 \ul{
-  \li{\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section3/DualHaar.lean#L24-L49}{the dual topology and Borel instances}; and}
-  \li{\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/Nonisomorphism.lean#L93-L98}{the representation-module carrier instance}.}
+  \li{the dual topology instances
+  \leanref/connes/as{paperKernelTopology}{Connes.PaperDualHaar.paperKernelTopology}
+  and
+  \leanref/connes/as{paperKernelDiscreteTopology}{Connes.PaperDualHaar.paperKernelDiscreteTopology};}
+  \li{the Borel instances
+  \leanref/connes/as{paperCharacterMeasurableSpace}{Connes.PaperDualHaar.paperCharacterMeasurableSpace} and
+  \leanref/connes/as{paperCharacterBorelSpace}{Connes.PaperDualHaar.paperCharacterBorelSpace}; and}
+  \li{the representation-module carrier instance
+  \leanref/connes/as{representationAsModuleAddCommGroup}{Connes.PaperNonisomorphism.representationAsModuleAddCommGroup}.}
 }
 
 \p{\strong{Isolate certificates from structural theorems.}

--- a/trees/connes-000B.tree
+++ b/trees/connes-000B.tree
@@ -5,10 +5,9 @@
 \tag{lean}
 \tag{property-t}
 \tag{formalization-estimate}
-\taxon{Remark}
 \title{EJZK route and effort envelope}
-\lean/connes{Connes.PaperPropertyT.elementaryGroup,Connes.HasKazhdanPropertyT,Connes.spectral_criterion_unconditional}
-\lean{SimpleGraph.lapMatrix,SimpleGraph.posSemidef_lapMatrix}
+\lean/connes{Connes.PaperPropertyT.elementaryGroup}
+\lean{SimpleGraph.lapMatrix}
 
 \p{The exact property-(T) input is classical and mathematically well
 established. The literature survey in
@@ -67,9 +66,9 @@ route and its decomposition, not these LOC or effort figures.}
   \strong{1.5--3 thousand}.}
 }
 
-\p{These internal allocations overlap, and their subtotal excludes integration
-adapters, proof-search retries, and pin-specific repair risk. It therefore is
-not an arithmetic derivation of the 18--35 thousand-line envelope.}
+\p{The allocations overlap. Their subtotal also excludes integration adapters,
+proof-search retries, and pin-specific repair risk, so it is not an arithmetic
+derivation of the 18--35 thousand-line envelope.}
 
 \p{The existing analytic shell is not part of the missing estimate.
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/PositiveSpectralMeasure.lean#L2255-L2268}{\code{PositiveSpectralMeasure.spectral_criterion_unconditional}}

--- a/trees/connes-000B.tree
+++ b/trees/connes-000B.tree
@@ -71,7 +71,7 @@ proof-search retries, and pin-specific repair risk, so it is not an arithmetic
 derivation of the 18--35 thousand-line envelope.}
 
 \p{The existing analytic shell is not part of the missing estimate.
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/PositiveSpectralMeasure.lean#L2255-L2268}{\code{PositiveSpectralMeasure.spectral_criterion_unconditional}}
+\leanref/connes{Connes.spectral_criterion_unconditional}
 already constructs the positive spectral functional and closes the scalar/PVM
 route from finite spectral detection to property (T).}
 

--- a/trees/connes-000C.tree
+++ b/trees/connes-000C.tree
@@ -7,7 +7,7 @@
 \tag{characteristic-two}
 \taxon{Lemma}
 \title{Characteristic-two tensor retraction}
-\lean/connes{Connes.Construction.PaperKernel.C,Connes.Construction.PaperKernel.diagonal,Connes.Construction.PaperKernel.delta,Connes.Construction.PaperKernel.delta_diagonal,Connes.Construction.PaperKernel.squareSpan,Connes.Construction.PaperKernel.SquareSpanData.squares_span,Connes.Construction.PaperKernel.concreteSquareSpanData}
+\lean/connes{Connes.Construction.PaperKernel.delta_diagonal,Connes.Construction.PaperKernel.concreteSquareSpanData}
 
 \p{Let #{k=\mathbb F_2}, #{A=k[t]^3}, and let
 
@@ -16,38 +16,6 @@
 The diagonal function #{\Delta(a)=a\otimes a} lands in #{C}. Although
 #{\Delta} is not a linear map, Zhou's characteristic-two calculation produces
 a surjective linear retraction #{\delta:C\to A} satisfying
-#{\delta(\Delta(a))=a} \citet{Section 2, Lemma 2.1}{zhou2026icc}.}
-
-\p{The Lean carriers and diagonal are
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction.lean#L55-L73}{\code{Construction.PaperKernel.C} and \code{diagonal}};
-the coefficientwise map and retraction equation are
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction.lean#L136-L178}{\code{delta} and \code{delta_diagonal}}.}
-
-\p{Concretely, the implementation fixes the standard polynomial and coordinate
-bases. It takes the coefficientwise Hadamard product on #{k[t]}, applies it in
-the three coordinates of #{A}, lifts the resulting bilinear map through the
-tensor product, and restricts it to #{C}. The Boolean identity #{x^2=x} gives
-#{\delta(a\otimes a)=a}.}
-
-\p{This basis-dependent formula is an implementation of
-the basis-free mathematical role: a linear left inverse to the diagonal
-squares, equivariant for the diagonal #{\mathrm{SL}_3(k[t])}-action.}
-
-\p{Equivariance is not proved by expanding an arbitrary fixed tensor. The
-submodule
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction/PaperActions.lean#L103-L142}{\code{squareSpan}}
-is the span of the squares #{a\otimes a}. The equation is immediate on each
-square, hence on \code{squareSpan}.}
-
-\p{The basis calculation in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction/SquareSpan.lean#L206-L264}{\code{concreteSquareSpanData}}
-proves its \code{squares_span} field: every flip-fixed tensor belongs to that
-span. This is the bridge from a coordinate construction to the basis-free
-equivariance statement consumed by the two group actions.}
-
-\p{\strong{Design adaptation: separate the formula from its invariant role.}
-The coefficientwise definition makes \code{delta_diagonal} computationally
-transparent. The \code{SquareSpanData} interface hides those coordinates from
-later sections: consumers need only that squares span #{C}. This permits a
-future basis-free construction of the same retraction without changing the
-action or theorem interfaces.}
+#{\delta(\Delta(a))=a} \citet{Section 2, Lemma 2.1}{zhou2026icc}.
+The retraction is equivariant for the diagonal
+#{\mathrm{SL}_3(k[t])}-action.}

--- a/trees/connes-000D.tree
+++ b/trees/connes-000D.tree
@@ -4,7 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{measure-theory}
-\taxon{Remark}
 \title{Nonadditive shear and measure transport}
 \lean/connes{Connes.CrossedProduct.EquivariantHaarHomeomorph,Connes.PaperCrossedHaar.paperHaarHomeomorph}
 

--- a/trees/connes-000D.tree
+++ b/trees/connes-000D.tree
@@ -20,12 +20,13 @@ states the same abstract mechanism: group-law compatibility of the underlying
 compact spaces is not required.}
 
 \p{The Lean boundary mirrors this distinction. The concrete
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Paper/Section3/CrossedHaar.lean#L108-L141}{\code{paperFiberShearHomeomorph} and \code{paperHaarHomeomorph}}
+\leanref/connes{Connes.PaperCrossedHaar.paperFiberShearHomeomorph} and
+\leanref/connes{Connes.PaperCrossedHaar.paperHaarHomeomorph}
 package continuity, measure preservation, and action equivariance, but no
 additive-homomorphism field.}
 
 \p{At the foundation layer,
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L141-L162}{\code{EquivariantHaarHomeomorph}}
+\leanref/connes{Connes.CrossedProduct.EquivariantHaarHomeomorph}
 projects this topological witness to the measurable transport interface. The
 extra topology is an implementation aid, not a stronger mathematical premise
 for the crossed-product identification.}

--- a/trees/connes-000E.tree
+++ b/trees/connes-000E.tree
@@ -5,9 +5,8 @@
 \tag{lean}
 \tag{operator-algebra}
 \tag{von-neumann-algebra}
-\taxon{Remark}
 \title{Continuous coefficients and von Neumann closure}
-\lean/connes{Connes.CrossedProduct.vonNeumannClosure_crossedGeneratorSetOfContinuousCoefficients_eq,Connes.CrossedProduct.continuousCrossedClosure_mem_iff}
+\lean/connes{Connes.CrossedProduct.continuousCrossedClosure_mem_iff}
 
 \p{Coordinate characters have norm-dense linear span in the continuous
 functions by Stone--Weierstrass. Since continuous coefficients act continuously

--- a/trees/connes-000E.tree
+++ b/trees/connes-000E.tree
@@ -10,12 +10,12 @@
 
 \p{Coordinate characters have norm-dense linear span in the continuous
 functions by Stone--Weierstrass. Since continuous coefficients act continuously
-as crossed-product multipliers, the generic
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L215-L375}{continuous-coefficient closure theorem}
+as crossed-product multipliers, the generic continuous-coefficient closure theorem
+\leanref/connes{Connes.CrossedProduct.vonNeumannClosure_crossedGeneratorSetOfContinuousCoefficients_eq}
 upgrades that density to equality of the generated von Neumann closures.}
 
 \p{Pullback along the homeomorphism then gives
-\href{https://github.com/utensil/connes-rigidity/blob/a7a45d1985a06168f96a296413d14e99dd0af485/Connes/Foundation/OperatorAlgebra/CrossedProductFactorTransport.lean#L377-L460}{\code{continuousCrossedClosure_mem_iff}}.
+\leanref/connes{Connes.CrossedProduct.continuousCrossedClosure_mem_iff}.
 This does \em{not} say that continuous functions are norm-dense in
 #{L^\infty}; it compares the von Neumann closures generated after adjoining
 all continuous coefficients.}

--- a/trees/connes-000F.tree
+++ b/trees/connes-000F.tree
@@ -4,7 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{proof-engineering}
-\taxon{Remark}
 \title{Structure forgetting and equivalence reuse}
 \lean/connes{Connes.CrossedProduct.EquivariantHaarHomeomorph,Connes.CrossedProduct.continuousCrossedClosure_mem_iff}
 

--- a/trees/connes-000G.tree
+++ b/trees/connes-000G.tree
@@ -5,7 +5,6 @@
 \tag{lean}
 \tag{property-t}
 \tag{formalization-estimate}
-\taxon{Remark}
 \title{Available Mathlib and TauCeti infrastructure}
 \lean{SimpleGraph.lapMatrix,SimpleGraph.posSemidef_lapMatrix}
 
@@ -16,14 +15,13 @@ theorem, exposed by the declaration links above, but not the
 Ershov--Jaikin-Zapirain graph-of-groups criterion, Kazhdan ratios, root
 gradings, codistance, or the graph argument.}
 
-\p{Kassabov's
-\citet{Theorem 2.2 and Lemmas 2.3--2.7, pp. 11--18}{kassabov2005universal}
-concern a free associative integer ring and require quotient transport before
-application to #{\mathbb F_2[t]}. For calibration over an arbitrary finitely
-generated ring and module, the cleaner reference is
-\citet{Appendix Theorem A.1, p. 110}{ershov2017rootgraded}. The direct route is
-the earlier quantitative development in \citet{Sections 2--6 and Appendix
-A}{ershov2010noncommutative}.}
+\p{Kassabov's estimates for a free associative integer ring require quotient
+transport before application to #{\mathbb F_2[t]}
+\citet{Theorem 2.2 and Lemmas 2.3--2.7}{kassabov2005universal}. For an arbitrary
+finitely generated ring and module, the cleaner calibration is
+\citet{Appendix Theorem A.1}{ershov2017rootgraded}. The direct route is the
+earlier quantitative development
+\citet{Sections 2--6 and Appendix A}{ershov2010noncommutative}.}
 
 \p{TauCeti at revision
 \href{https://github.com/TauCetiProject/TauCeti/commit/cc6ce758421ce3a0731ff62667b7771cfc4aa3da}{\code{cc6ce75}}

--- a/trees/connes-000H.tree
+++ b/trees/connes-000H.tree
@@ -5,10 +5,7 @@
 \tag{lean}
 \tag{group-theory}
 \tag{module-theory}
-\taxon{Remark}
 \title{Characteristic kernels and quotient-twisted transport}
-\lean/connes{Connes.PaperCharacteristic.paperSL3NoNontrivialAbelianNormalSubgroup,Connes.Sp4.no_nontrivial_normal_abelian_subgroup,Connes.PaperCharacteristicTransport.paperSemidirectNormalAbelian_le_kernel}
-
 \p{The characteristic-kernel step maps an abelian normal subgroup to both
 factors of #{\mathrm{SL}_3(\mathbb F_2[t])\times
 \operatorname{Sp}_4(\mathbb F_2)}. It therefore needs two vanishing results:}

--- a/trees/connes-000H.tree
+++ b/trees/connes-000H.tree
@@ -12,16 +12,17 @@ factors of #{\mathrm{SL}_3(\mathbb F_2[t])\times
 
 \ul{
   \li{The polynomial-matrix argument
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/Characteristic.lean#L163-L196}{for the polynomial-matrix factor}
+\leanref/connes/as{paperSL3NoNontrivialAbelianNormalSubgroup}{Connes.PaperCharacteristic.paperSL3NoNontrivialAbelianNormalSubgroup}
+for the polynomial-matrix factor
 handles the #{\mathrm{SL}_3} image.}
   \li{The stronger finite result
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/Sp4KernelCertificate.lean#L2097-L2115}{\code{Sp4.no_nontrivial_normal_abelian_subgroup}}
+\leanref/connes/as{Sp4.no_nontrivial_normal_abelian_subgroup}{Connes.Sp4.no_nontrivial_normal_abelian_subgroup}
 handles the symplectic image through a kernel-checked certificate.}
 }
 
 \p{The product
 argument applying both inputs is
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section6/CharacteristicTransport.lean#L59-L107}{\code{paperSemidirectNormalAbelian_le_kernel}}.
+\leanref/connes/as{paperSemidirectNormalAbelian_le_kernel}{Connes.PaperCharacteristicTransport.paperSemidirectNormalAbelian_le_kernel}.
 This confines finite enumeration to the symplectic factor and keeps both
 factor-specific proofs out of the abstract module transport.}
 

--- a/trees/connes-000I.tree
+++ b/trees/connes-000I.tree
@@ -5,7 +5,6 @@
 \tag{lean}
 \tag{property-t}
 \tag{formalization-estimate}
-\taxon{Remark}
 \title{Alternative EJZK routes and literature anchors}
 \lean/connes{Connes.PaperPropertyT.elementaryGroup}
 

--- a/trees/connes-000J.tree
+++ b/trees/connes-000J.tree
@@ -4,7 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{proof-engineering}
-\taxon{Remark}
 \title{Proposition-valued final assembly}
 \lean/connes{Connes.PaperTheoremACompletion.theoremA,Connes.theoremA}
 

--- a/trees/connes-000K.tree
+++ b/trees/connes-000K.tree
@@ -57,15 +57,18 @@ separate port at the construction and theorem nodes.}
 
 \ul{
   \li{\strong{Construction.} The characteristic-two calculation in
-  \ref{connes-000C} is concrete algebra and supplies every later carrier.}
+  \ref{connes-000C}, with its Lean realization in \ref{connes-000U}, is
+  concrete algebra and supplies every later carrier.}
   \li{\strong{Factor equivalence.} \ref{connes-0007}, \ref{connes-000D}, and
   \ref{connes-000E} carry heavy operator algebra: compact duals, Haar measure,
   Fourier transforms, von Neumann closures, and trace transport.}
-  \li{\strong{Property (T).} \ref{connes-0003}, \ref{connes-0004}, and
-  \ref{connes-0005} carry heavy harmonic and representation theory. Spectral
+  \li{\strong{Property (T).} \ref{connes-0003}, \ref{connes-000V},
+  \ref{connes-0004}, \ref{connes-000Y}, \ref{connes-0005}, and
+  \ref{connes-000W} carry heavy harmonic and representation theory. Spectral
   measures and finite detectors are internal; EJZK enters at one boundary.}
   \li{\strong{ICC.} \ref{connes-0006} is the lightest lane conceptually, but
-  still needs exact orbit and finite-quotient displacement calculations.}
+  its implementation in \ref{connes-000X} still needs exact orbit and
+  finite-quotient displacement calculations.}
   \li{\strong{Nonisomorphism.} \ref{connes-0008} is the deepest internal
   algebraic chain. Characteristic kernels, quotient twists, semisimplicity,
   and a finite cocycle obstruction must survive an arbitrary isomorphism.}
@@ -75,12 +78,14 @@ separate port at the construction and theorem nodes.}
 require special design:}
 
 \ul{
-  \li{the square-span certificate in \ref{connes-000C};}
+  \li{the square-span certificate implemented in \ref{connes-000U};}
   \li{the spatial, measurable, and closure bridges in \ref{connes-0007},
   \ref{connes-000D}, and \ref{connes-000E};}
   \li{the quantitative detector and qualitative property-(T) boundary in
-  \ref{connes-0003} and \ref{connes-0004};}
-  \li{the three-case ICC criterion in \ref{connes-0006};}
+  \ref{connes-0003}, \ref{connes-000V}, \ref{connes-0004}, and
+  \ref{connes-000Y};}
+  \li{the three-case ICC criterion in \ref{connes-0006} and
+  \ref{connes-000X};}
   \li{the quotient twist in \ref{connes-000H}; and}
   \li{the proposition-valued assembly in \ref{connes-0002}.}
 }
@@ -119,7 +124,8 @@ or a twist-stable module obstruction.}
 \p{The final interface remains proposition-valued. Its assembly and
 trust boundary are detailed in \ref{connes-0002} and \ref{connes-0009}; the
 remaining EJZK work is scoped in \ref{connes-000B}, \ref{connes-000G}, and
-\ref{connes-000I}.}
+\ref{connes-000I}; the representation-universe boundary is recorded in
+\ref{connes-000L}.}
 
 \p{Section 1 separates the mathematical introduction, counterexample
 background, three motivations, and design. Sections 2--7 correspond respectively

--- a/trees/connes-000L.tree
+++ b/trees/connes-000L.tree
@@ -5,15 +5,14 @@
 \tag{lean}
 \tag{property-t}
 \tag{formalization-boundary}
-\taxon{Remark}
 \title{Representation-space universe boundary}
-\lean/connes{Connes.HasKazhdanPropertyT,Connes.spectral_criterion_unconditional}
+\lean/connes{Connes.HasKazhdanPropertyT}
 
 \p{The cited literature formulates property (T) by quantifying over unitary
-representations; see the basic definitions and elementary-group theorem in
-\citet{Section 3.1 and Theorem 1.1}{ershov2010noncommutative}, and the
-root-graded generalization in \citet{Theorem 1.1}{ershov2017rootgraded}. Lean
-must also make the size of each carrier explicit.}
+representations. The basic definitions and elementary-group theorem appear in
+\citet{Section 3.1 and Theorem 1.1}{ershov2010noncommutative}; the root-graded
+generalization is \citet{Theorem 1.1}{ershov2017rootgraded}. Lean must also make
+the size of each carrier explicit.}
 
 \p{The current
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Core.lean#L67-L75}{\code{HasKazhdanPropertyT}}

--- a/trees/connes-000L.tree
+++ b/trees/connes-000L.tree
@@ -15,7 +15,7 @@ generalization is \citet{Theorem 1.1}{ershov2017rootgraded}. Lean must also make
 the size of each carrier explicit.}
 
 \p{The current
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Core.lean#L67-L75}{\code{HasKazhdanPropertyT}}
+\leanref/connes{Connes.HasKazhdanPropertyT}
 takes a group in \code{Type u} and quantifies over Hilbert carriers in the same
 \code{Type u}. This conventional interface is sufficient for the theorem
 schema formalized here.}
@@ -69,6 +69,6 @@ Hilbert basis a small countable index, or transports the full property-(T)
 predicate across that model. Together these form the lowering seam.}
 
 \p{They are more focused than generalizing the entire
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/PositiveSpectralMeasure.lean#L2262-L2270}{spectral-criterion stack},
+\leanref/connes{Connes.spectral_criterion_unconditional} stack,
 but remain separate from closing the EJZK premise and from the present
 formalization.}

--- a/trees/connes-000M.tree
+++ b/trees/connes-000M.tree
@@ -4,7 +4,6 @@
 \tag{connes}
 \tag{operator-algebra}
 \tag{group-theory}
-\taxon{Remark}
 \title{Changing the kernel while preserving the measured action}
 \lean/connes{Connes.PaperCrossedHaar.paperHaarEquiv,Connes.PaperFactorClosure.paperGroupFactors_isomorphic}
 

--- a/trees/connes-000N.tree
+++ b/trees/connes-000N.tree
@@ -4,7 +4,6 @@
 \tag{connes}
 \tag{operator-algebra}
 \tag{group-cohomology}
-\taxon{Remark}
 \title{Changing the extension class and measurably gauging it away}
 \lean/connes{Connes.PaperDualActionConjugacy.paperFiberShear_conjugates_paperActions,Connes.PaperFactorClosure.paperGroupFactors_isomorphic}
 

--- a/trees/connes-000U.tree
+++ b/trees/connes-000U.tree
@@ -9,9 +9,11 @@
 \lean/connes{Connes.Construction.PaperKernel.delta_diagonal,Connes.Construction.PaperKernel.concreteSquareSpanData}
 
 \p{The Lean carriers and diagonal for \ref{connes-000C} are
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction.lean#L55-L73}{\code{Construction.PaperKernel.C} and \code{diagonal}};
+\leanref/connes{Connes.Construction.PaperKernel.C} and
+\leanref/connes{Connes.Construction.PaperKernel.diagonal};
 the coefficientwise map and retraction equation are
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction.lean#L136-L178}{\code{delta} and \code{delta_diagonal}}.}
+\leanref/connes{Connes.Construction.PaperKernel.delta} and
+\leanref/connes{Connes.Construction.PaperKernel.delta_diagonal}.}
 
 \p{The implementation fixes the standard polynomial and coordinate bases. It
 takes the coefficientwise Hadamard product on #{k[t]}, applies it in the three
@@ -23,12 +25,12 @@ product, and restricts it to #{C}. The Boolean identity #{x^2=x} gives
 inverse to the diagonal squares, equivariant for the diagonal
 #{\mathrm{SL}_3(k[t])}-action. Equivariance is not proved by expanding an
 arbitrary fixed tensor. The submodule
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction/PaperActions.lean#L103-L142}{\code{squareSpan}}
+\leanref/connes{Connes.Construction.PaperKernel.squareSpan}
 is the span of the squares #{a\otimes a}; the equation is immediate on each
 square, hence on their span.}
 
 \p{The basis calculation in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction/SquareSpan.lean#L206-L264}{\code{concreteSquareSpanData}}
+\leanref/connes{Connes.Construction.PaperKernel.concreteSquareSpanData}
 proves that every flip-fixed tensor belongs to this span. The
 \code{SquareSpanData} interface therefore hides the coordinates from later
 sections. Consumers need only the spanning result, so a future basis-free

--- a/trees/connes-000U.tree
+++ b/trees/connes-000U.tree
@@ -1,0 +1,36 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{tensor-algebra}
+\tag{characteristic-two}
+\title{Formalizing the characteristic-two retraction}
+\lean/connes{Connes.Construction.PaperKernel.delta_diagonal,Connes.Construction.PaperKernel.concreteSquareSpanData}
+
+\p{The Lean carriers and diagonal for \ref{connes-000C} are
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction.lean#L55-L73}{\code{Construction.PaperKernel.C} and \code{diagonal}};
+the coefficientwise map and retraction equation are
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction.lean#L136-L178}{\code{delta} and \code{delta_diagonal}}.}
+
+\p{The implementation fixes the standard polynomial and coordinate bases. It
+takes the coefficientwise Hadamard product on #{k[t]}, applies it in the three
+coordinates of #{A}, lifts the resulting bilinear map through the tensor
+product, and restricts it to #{C}. The Boolean identity #{x^2=x} gives
+#{\delta(a\otimes a)=a}.}
+
+\p{The basis-dependent formula implements a basis-free role: a linear left
+inverse to the diagonal squares, equivariant for the diagonal
+#{\mathrm{SL}_3(k[t])}-action. Equivariance is not proved by expanding an
+arbitrary fixed tensor. The submodule
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction/PaperActions.lean#L103-L142}{\code{squareSpan}}
+is the span of the squares #{a\otimes a}; the equation is immediate on each
+square, hence on their span.}
+
+\p{The basis calculation in
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Construction/SquareSpan.lean#L206-L264}{\code{concreteSquareSpanData}}
+proves that every flip-fixed tensor belongs to this span. The
+\code{SquareSpanData} interface therefore hides the coordinates from later
+sections. Consumers need only the spanning result, so a future basis-free
+construction could replace the formula without changing the action or theorem
+interfaces.}

--- a/trees/connes-000V.tree
+++ b/trees/connes-000V.tree
@@ -9,19 +9,24 @@
 \lean/connes{Connes.HasKazhdanPropertyT,Connes.HasRelativePropertyT,Connes.PaperPropertyT.elementaryGroup}
 
 \p{The exact Lean boundary for \ref{connes-0003} uses
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Core.lean#L46-L88}{the almost-invariance and property-(T) predicates}.
+the almost-invariance and property-(T) predicates
+\leanref/connes{Connes.UnitaryRepresentation.HasAlmostInvariantUnitVectors},
+\leanref/connes{Connes.HasKazhdanPropertyT}, and
+\leanref/connes{Connes.HasRelativePropertyT}.
 This qualitative form matches the final consumer, while quantitative Kazhdan
 sets and constants remain local to any future proof of the EJZK input.}
 
 \p{The transfer argument uses the fixed subspace #{H^N} of a normal subgroup
 #{N} and its orthogonal complement. Relative property (T) produces a nonzero
 vector in #{H^N}; property (T) of the quotient then acts on #{H^N}. The
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/PropertyTTransfer.lean#L264-L278}{relative-and-quotient transfer theorem}
+relative-and-quotient transfer theorem
+\leanref/connes{Connes.PropertyTTransfer.hasKazhdanPropertyT_of_relative_and_quotient}
 packages this step without exposing the concrete presentation of Zhou's
 groups to the spectral proof.}
 
 \p{A future EJZK development should use Kazhdan pairs, ratios, or spectral
 gaps internally, then export
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L23-L39}{property (T) for the elementary group}.
+\leanref/connes{Connes.PaperPropertyT.elementaryGroup} for property (T) of
+the elementary group.
 Demanding a particular constant at the public boundary would strengthen the
 paper's hypothesis and couple every consumer to an arbitrary estimate.}

--- a/trees/connes-000V.tree
+++ b/trees/connes-000V.tree
@@ -1,0 +1,27 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{property-t}
+\tag{proof-engineering}
+\title{Property-(T) transfer interface}
+\lean/connes{Connes.HasKazhdanPropertyT,Connes.HasRelativePropertyT,Connes.PaperPropertyT.elementaryGroup}
+
+\p{The exact Lean boundary for \ref{connes-0003} uses
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Core.lean#L46-L88}{the almost-invariance and property-(T) predicates}.
+This qualitative form matches the final consumer, while quantitative Kazhdan
+sets and constants remain local to any future proof of the EJZK input.}
+
+\p{The transfer argument uses the fixed subspace #{H^N} of a normal subgroup
+#{N} and its orthogonal complement. Relative property (T) produces a nonzero
+vector in #{H^N}; property (T) of the quotient then acts on #{H^N}. The
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/PropertyTTransfer.lean#L264-L278}{relative-and-quotient transfer theorem}
+packages this step without exposing the concrete presentation of Zhou's
+groups to the spectral proof.}
+
+\p{A future EJZK development should use Kazhdan pairs, ratios, or spectral
+gaps internally, then export
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L23-L39}{property (T) for the elementary group}.
+Demanding a particular constant at the public boundary would strengthen the
+paper's hypothesis and couple every consumer to an arbitrary estimate.}

--- a/trees/connes-000W.tree
+++ b/trees/connes-000W.tree
@@ -11,10 +11,10 @@
 \p{The formalization proves the equality used in \ref{connes-0005} by
 determinant-preserving row operations and Euclidean descent on polynomial
 entries, culminating in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/SpecialLinear/ElementaryGeneration.lean#L377-L378}{\code{SpecialLinear.elementarySubgroup_eq_top}}.}
+\leanref/connes{Connes.SpecialLinear.elementarySubgroup_eq_top}.}
 
 \p{It then constructs
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L29-L46}{\code{PaperPropertyT.elementaryEquivSL3}}
+\leanref/connes{Connes.PaperPropertyT.elementaryEquivSL3}
 and transports property (T) across the named multiplicative equivalence. The
 external premise therefore names the exact group in the cited theorem, while
 the paper-facing consumer works with #{\mathrm{SL}_3(R)}.}

--- a/trees/connes-000W.tree
+++ b/trees/connes-000W.tree
@@ -1,0 +1,25 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{linear-groups}
+\tag{property-t}
+\title{Formalizing elementary generation and transport}
+\lean/connes{Connes.SpecialLinear.elementarySubgroup_eq_top,Connes.PaperPropertyT.elementaryEquivSL3}
+
+\p{The formalization proves the equality used in \ref{connes-0005} by
+determinant-preserving row operations and Euclidean descent on polynomial
+entries, culminating in
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/SpecialLinear/ElementaryGeneration.lean#L377-L378}{\code{SpecialLinear.elementarySubgroup_eq_top}}.}
+
+\p{It then constructs
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section4/PropertyT.lean#L29-L46}{\code{PaperPropertyT.elementaryEquivSL3}}
+and transports property (T) across the named multiplicative equivalence. The
+external premise therefore names the exact group in the cited theorem, while
+the paper-facing consumer works with #{\mathrm{SL}_3(R)}.}
+
+\p{Rewriting subgroup equality into carrier equality would expose dependent
+coercions throughout Section 4. Keeping transport at one explicit equivalence
+also lets later finite-index and quotient arguments remain independent of the
+chosen presentation.}

--- a/trees/connes-000X.tree
+++ b/trees/connes-000X.tree
@@ -1,0 +1,21 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{group-theory}
+\tag{icc}
+\title{Formalizing the ICC criterion}
+\lean/connes{Connes.PaperICC.isICC_of_product_quotient,Connes.PaperICC.paper_gammaOne_icc,Connes.PaperICC.paper_gammaTwo_icc}
+
+\p{The paper-specific work behind \ref{connes-0006} is confined to orbit
+calculations in
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICCOrbits.lean}{\code{ICCOrbits.lean}}.
+Those calculations construct the action data and yield
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICCOrbits.lean#L585-L597}{\code{paper_gammaOne_icc} and \code{paper_gammaTwo_icc}}.}
+
+\p{The displacement certificate is the finite-quotient input. Conjugating an
+element with nontrivial #{Q}-coordinate by a kernel element changes its kernel
+coordinate by #{a(q\cdot a)^{-1}}. Asking directly for an infinite family of
+conjugates would duplicate this algebra for each action. The certificate
+instead exposes the one displacement whose infinite #{S}-orbit suffices.}

--- a/trees/connes-000X.tree
+++ b/trees/connes-000X.tree
@@ -12,7 +12,8 @@
 calculations in
 \href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICCOrbits.lean}{\code{ICCOrbits.lean}}.
 Those calculations construct the action data and yield
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Paper/Section5/ICCOrbits.lean#L585-L597}{\code{paper_gammaOne_icc} and \code{paper_gammaTwo_icc}}.}
+\leanref/connes{Connes.PaperICC.paper_gammaOne_icc} and
+\leanref/connes{Connes.PaperICC.paper_gammaTwo_icc}.}
 
 \p{The displacement certificate is the finite-quotient input. Conjugating an
 element with nontrivial #{Q}-coordinate by a kernel element changes its kernel

--- a/trees/connes-000Y.tree
+++ b/trees/connes-000Y.tree
@@ -10,14 +10,14 @@
 
 \p{The project records the group-theoretic data consumed by
 \ref{connes-0004} in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/SplitAbelianExtension.lean#L17-L32}{\code{SplitAbelianExtension}}.
+\leanref/connes{Connes.SplitAbelianExtension}.
 The analytic layer can therefore use the kernel, quotient action, and section
 without unfolding a semidirect product.}
 
 \p{The scalar measure and displacement interfaces are formalized in
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/ProjectionValuedSpectralMeasure.lean#L28-L187}{\code{ProjectionValuedSpectralMeasure}},
+\leanref/connes{Connes.ProjectionValuedSpectralMeasure},
 and the finite-detection argument is packaged by
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/SpectralCriterion.lean#L118-L180}{\code{spectral_criterion}}.}
+\leanref/connes{Connes.spectral_criterion}.}
 
 \p{The direct consumer boundary is the following positive-atom estimate. If an
 invariant probability measure #{\mu} satisfies
@@ -29,7 +29,7 @@ for some #{c>0}, then sufficiently small displacement on the finite detector
 
 \p{Over #{\mathbb F_2}, characters take values through the two-element circle
 subgroup. The local equivalence
-\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/BinaryPontryaginDual.lean#L229-L314}{\code{BinaryPontryaginDual.pointwisePontryaginDualEquiv}}
+\leanref/connes{Connes.BinaryPontryaginDual.pointwisePontryaginDualEquiv}
 identifies the dual of a linear dual with its evaluation module. This replaces
 implicit Fourier coordinates by an explicit additive equivalence; it is a
 formalization bridge, not an additional hypothesis.}

--- a/trees/connes-000Y.tree
+++ b/trees/connes-000Y.tree
@@ -1,0 +1,35 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{harmonic-analysis}
+\tag{property-t}
+\title{Formalizing the spectral bridge}
+\lean/connes{Connes.spectral_criterion}
+
+\p{The project records the group-theoretic data consumed by
+\ref{connes-0004} in
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/GroupTheory/SplitAbelianExtension.lean#L17-L32}{\code{SplitAbelianExtension}}.
+The analytic layer can therefore use the kernel, quotient action, and section
+without unfolding a semidirect product.}
+
+\p{The scalar measure and displacement interfaces are formalized in
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/ProjectionValuedSpectralMeasure.lean#L28-L187}{\code{ProjectionValuedSpectralMeasure}},
+and the finite-detection argument is packaged by
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/SpectralCriterion.lean#L118-L180}{\code{spectral_criterion}}.}
+
+\p{The direct consumer boundary is the following positive-atom estimate. If an
+invariant probability measure #{\mu} satisfies
+
+##{c(1-\mu(\{1\}))\leq\sum_{a\in J}\int|\chi(a)-1|^2\,d\mu(\chi)}
+
+for some #{c>0}, then sufficiently small displacement on the finite detector
+#{J} forces #{\mu(\{1\})>0}.}
+
+\p{Over #{\mathbb F_2}, characters take values through the two-element circle
+subgroup. The local equivalence
+\href{https://github.com/utensil/connes-rigidity/blob/main/Connes/Foundation/OperatorAlgebra/BinaryPontryaginDual.lean#L229-L314}{\code{BinaryPontryaginDual.pointwisePontryaginDualEquiv}}
+identifies the dual of a linear dual with its evaluation module. This replaces
+implicit Fourier coordinates by an explicit additive equivalence; it is a
+formalization bridge, not an additional hypothesis.}

--- a/trees/spin-macros.tree
+++ b/trees/spin-macros.tree
@@ -53,8 +53,10 @@
 % https://taucetiproject.github.io/TauCeti/docs/find/#doc/
 \def\lean/tauceti[x]{\meta{lean-tauceti}{\x}}
 \def\leanref/tauceti[x]{\<html:span>[class]{lean-ref}{[\code{\x}](https://taucetiproject.github.io/TauCeti/docs/find/#doc/\x)}}
-% https://github.com/utensil/connes-rigidity
+% https://utensil.github.io/connes-rigidity/docs/find/#doc/Connes.theoremA
 \def\lean/connes[x]{\meta{lean-connes}{\x}}
+\def\leanref/connes[x]{\<html:span>[class]{lean-ref}{[\code{\x}](https://utensil.github.io/connes-rigidity/docs/find/#doc/\x)}}
+\def\leanref/connes/as[label][x]{\<html:span>[class]{lean-ref}{[\code{\label}](https://utensil.github.io/connes-rigidity/docs/find/#doc/\x)}}
 \def\uses[x]{}
 
 \def\cite[x]{\citek{\x}}


### PR DESCRIPTION
## Summary

- reserve theorem styling for the eight Connes cards that state mathematical contracts and render thirteen expository cards as ordinary addressed sections
- extract five implementation/design cards immediately after the statements they explain, preserving Zhou Sections 2 through 7 as the reading spine
- refresh the formalization-design map so each lane names both its mathematical statement and its extracted implementation boundary
- replace Connes GitHub search and source-line references with stable doc-gen4 declaration links in card metadata, prose, HTML, and PDF
- preserve the one file-level `ICCOrbits.lean` link because it identifies a calculation file rather than a declaration

## Reader-facing result

The shaded cards now contain only definitions, lemmas, and theorems. Literature comparison, implementation detail, trust-boundary explanation, and the EJZK outlook remain ordinary sections. The design overview now links to the extracted kernel, property-(T), spectral, elementary-generation, ICC, and universe-boundary cards.

All Lean links now resolve by fully qualified declaration name through the Connes API reference, so source-file moves and line-number changes do not invalidate the notes.

## Verification

- `just chk`
- targeted Forester build
- 28-page A4 PDF build
- no overfull boxes, unresolved references, or undefined citations
- visual review of the updated design, nonisomorphism, and adaptation pages
- 48/48 unique Connes declaration targets present in the generated doc-gen4 index
- production XSL probe preserves all 48 declaration fragments and emits no legacy GitHub-search links
- exact `utensil <utensilcandel@gmail.com>` author/committer identity and clean public-metadata scan

Human-gated. Auto-merge is disabled. The exact-head lint and full Forest build passed in GitHub Actions.