### PR TITLE
docs(connes): normalize prose en dashes [AGENT]

### DIFF
--- a/trees/connes-000B.tree
+++ b/trees/connes-000B.tree
@@ -11,7 +11,7 @@
 
 \p{The exact property-(T) input is classical and mathematically well
 established. The literature survey in
-\citet{Section 1.2, pp. 3--4}{ershov2017rootgraded} recalls that Kazhdan's
+\citet{Section 1.2, pp. 3–4}{ershov2017rootgraded} recalls that Kazhdan's
 1967 theorem, together with subsequent work of Vaserstein, gives property (T)
 for #{G_\Phi(\mathbb F[t])=E_\Phi(\mathbb F[t])} when #{\mathbb F} is finite
 and #{\Phi} is a reduced irreducible classical root system of rank at least
@@ -29,9 +29,9 @@ route estimated below specializes the 2010 elementary-group theorem to
 the implementation layers below. The later root-graded treatment
 supplies broader supporting language.}
 
-\p{Our internal engineering estimate remains \strong{24--28 thousand new Lean lines}, with an
-internal uncertainty envelope of \strong{18--35 thousand}. This is about
-#{0.8}--#{1.5} times the current 23,070-line project and, by our internal
+\p{Our internal engineering estimate remains \strong{24–28 thousand new Lean lines}, with an
+internal uncertainty envelope of \strong{18–35 thousand}. This is about
+#{0.8}–#{1.5} times the current 23,070-line project and, by our internal
 estimate, \strong{two to four times its present proof-search and engineering
 effort}.}
 
@@ -45,30 +45,30 @@ route and its decomposition, not these LOC or effort figures.}
 \ol{
   \li{quantitative Kazhdan subsets, constants, and relative ratios, with a
   bridge to the current qualitative predicate; our internal allocation is
-  \strong{2--3.5 thousand lines};}
+  \strong{2–3.5 thousand lines};}
   \li{the six additive root-subgroup embeddings and the direct #{A_2}
-  commutator relations; our internal allocation is \strong{2--4 thousand}.
+  commutator relations; our internal allocation is \strong{2–4 thousand}.
   A Steinberg-group detour is optional, not required for this direct
   matrix-group specialization;}
   \li{fixed-space angles, codistance, and the class-two nilpotent estimate;
-  our internal allocation is \strong{5--9 thousand};}
+  our internal allocation is \strong{5–9 thousand};}
   \li{the unweighted standard-Laplacian boundary case on six vertices. This is
   Section 5.4 of \citek{ershov2010noncommutative}. Our internal allocation is
-  \strong{1.5--3 thousand}; the weighted criterion in Section 5.5 is a separate
+  \strong{1.5–3 thousand}; the weighted criterion in Section 5.5 is a separate
   generalization;}
   \li{the packaged relative-ratio estimate for the union of all six root
   subgroups in \citet{Proposition 6.1, p. 34}{ershov2010noncommutative}; our
-  internal allocation is \strong{3--5.5 thousand}. Six repeated Lean
+  internal allocation is \strong{3–5.5 thousand}. Six repeated Lean
   instantiations would be an implementation choice, not six mathematical
   inputs; and}
   \li{assembly plus the exact qualitative export theorem for
   the elementary-group property-(T) boundary; our internal allocation is
-  \strong{1.5--3 thousand}.}
+  \strong{1.5–3 thousand}.}
 }
 
 \p{The allocations overlap. Their subtotal also excludes integration adapters,
 proof-search retries, and pin-specific repair risk, so it is not an arithmetic
-derivation of the 18--35 thousand-line envelope.}
+derivation of the 18–35 thousand-line envelope.}
 
 \p{The existing analytic shell is not part of the missing estimate.
 \leanref/connes{Connes.spectral_criterion_unconditional}

--- a/trees/connes-000E.tree
+++ b/trees/connes-000E.tree
@@ -9,7 +9,7 @@
 \lean/connes{Connes.CrossedProduct.continuousCrossedClosure_mem_iff}
 
 \p{Coordinate characters have norm-dense linear span in the continuous
-functions by Stone--Weierstrass. Since continuous coefficients act continuously
+functions by Stone–Weierstrass. Since continuous coefficients act continuously
 as crossed-product multipliers, the generic continuous-coefficient closure theorem
 \leanref/connes{Connes.CrossedProduct.vonNeumannClosure_crossedGeneratorSetOfContinuousCoefficients_eq}
 upgrades that density to equality of the generated von Neumann closures.}

--- a/trees/connes-000G.tree
+++ b/trees/connes-000G.tree
@@ -12,16 +12,16 @@
 \href{https://github.com/leanprover-community/mathlib4/commit/79cba2e8b532ff92484dfd99f45987bae8b2fd7e}{\code{79cba2e8}}
 with Lean 4.34.0-rc1. Mathlib supplies the graph Laplacian and its positivity
 theorem, exposed by the declaration links above, but not the
-Ershov--Jaikin-Zapirain graph-of-groups criterion, Kazhdan ratios, root
+Ershov–Jaikin-Zapirain graph-of-groups criterion, Kazhdan ratios, root
 gradings, codistance, or the graph argument.}
 
 \p{Kassabov's estimates for a free associative integer ring require quotient
 transport before application to #{\mathbb F_2[t]}
-\citet{Theorem 2.2 and Lemmas 2.3--2.7}{kassabov2005universal}. For an arbitrary
+\citet{Theorem 2.2 and Lemmas 2.3–2.7}{kassabov2005universal}. For an arbitrary
 finitely generated ring and module, the cleaner calibration is
 \citet{Appendix Theorem A.1}{ershov2017rootgraded}. The direct route is the
 earlier quantitative development
-\citet{Sections 2--6 and Appendix A}{ershov2010noncommutative}.}
+\citet{Sections 2–6 and Appendix A}{ershov2010noncommutative}.}
 
 \p{TauCeti at revision
 \href{https://github.com/TauCetiProject/TauCeti/commit/cc6ce758421ce3a0731ff62667b7771cfc4aa3da}{\code{cc6ce75}}

--- a/trees/connes-000I.tree
+++ b/trees/connes-000I.tree
@@ -13,28 +13,28 @@
 
 ##{\nu_3=\frac{3\cdot3^2-3}{2}+29=41,}
 
-and its proof invokes the Kornblum--Artin theorem for irreducibles in
+and its proof invokes the Kornblum–Artin theorem for irreducibles in
 polynomial arithmetic progressions, stated as
 \citet{Theorem 3, p. 2}{nica2019bounded}. That input is absent from the pinned
 Mathlib revision.}
 
-\p{Our internal estimate for a self-contained Nica--Kassabov
-route is \strong{20--45 thousand lines} and \strong{three to six times the
+\p{Our internal estimate for a self-contained Nica–Kassabov
+route is \strong{20–45 thousand lines} and \strong{three to six times the
 current engineering effort}, with roughly 70 percent internal uncertainty.
 }
 
-\p{Assuming Kornblum--Artin gives our internal estimate of \strong{8--15 thousand
+\p{Assuming Kornblum–Artin gives our internal estimate of \strong{8–15 thousand
 lines}, but merely moves the external boundary. Our internal estimate for a
-reusable formalization of the generic EJK theorem is \strong{45--90 thousand
+reusable formalization of the generic EJK theorem is \strong{45–90 thousand
 lines}; that generality is unnecessary for Zhou's application.}
 
 \p{The route decomposition has four literature anchors:}
 
 \ul{
-  \li{Zhou's exact invocation \citet{Proposition 4.1, pp. 8--10}{zhou2026icc};}
+  \li{Zhou's exact invocation \citet{Proposition 4.1, pp. 8–10}{zhou2026icc};}
   \li{the elementary-group theorem, unweighted boundary graph, and packaged
-  six-root estimate \citet{Theorem 1.1, p. 1; Section 5.4, pp. 25--29;
-  Proposition 6.1, pp. 34--35}{ershov2010noncommutative};}
+  six-root estimate \citet{Theorem 1.1, p. 1; Section 5.4, pp. 25–29;
+  Proposition 6.1, pp. 34–35}{ershov2010noncommutative};}
   \li{the broader root-graded theorem and arbitrary-ring relative estimate
   \citet{Theorem 1.1, p. 3; Appendix Theorem A.1, p. 110}{ershov2017rootgraded};
   and}

--- a/trees/connes-000K.tree
+++ b/trees/connes-000K.tree
@@ -16,7 +16,7 @@ nonisomorphism. The final theorem assembles those four endpoints.}
 
 \p{The diagram is a map of both the proof and the notes. Solid arrows are
 internal Lean developments. The dashed arrow is the sole substantive
-mathematical input left external: the Ershov--Jaikin-Zapirain--Kassabov
+mathematical input left external: the Ershov–Jaikin-Zapirain–Kassabov
 property-(T) theorem for #{\mathrm{EL}_3(\mathbb F_2[t])}. Each lane uses a
 separate port at the construction and theorem nodes.}
 
@@ -128,12 +128,12 @@ remaining EJZK work is scoped in \ref{connes-000B}, \ref{connes-000G}, and
 \ref{connes-000L}.}
 
 \p{Section 1 separates the mathematical introduction, counterexample
-background, three motivations, and design. Sections 2--7 correspond respectively
-to Zhou's Sections 2--7; their headings record that correspondence without
+background, three motivations, and design. Sections 2–7 correspond respectively
+to Zhou's Sections 2–7; their headings record that correspondence without
 reusing Zhou's section number as the note title. Section 8 collects
-proof-engineering adaptations, Sections 9--10 compare the other two proof
+proof-engineering adaptations, Sections 9–10 compare the other two proof
 architectures, Section 11 scopes the remaining EJZK formalization, and Section
-12 records the human--agent contribution and review workflow.}
+12 records the human–agent contribution and review workflow.}
 
 \p{The formalization adapts selected public Lean proof blocks and organization
 patterns from a

--- a/trees/connes-000M.tree
+++ b/trees/connes-000M.tree
@@ -17,7 +17,7 @@ structure but not its Borel probability space or the relevant #{K}-action.
 \p{Pontryagin duality therefore presents every group factor by the same measured
 crossed product
 #{L^\infty(X\times Y)\rtimes K}
-\citet{Chapter 4, Sections 2.3, 4, and 6.1--6.2}{openai2026tenadvances}.}
+\citet{Chapter 4, Sections 2.3, 4, and 6.1–6.2}{openai2026tenadvances}.}
 
 \tikzfig{
 \begin{tikzpicture}[
@@ -54,16 +54,16 @@ action gives isomorphic factors.}
 distinguishes the groups. For the full family, the parameter #{n} is recovered
 from an intrinsic finite-orbit subgroup of #{E_n[2]/2E_n}; finite-index
 embeddings simultaneously prove mutual commensurability
-\citet{Chapter 4, Sections 5.1, 6.2, and 6.4--6.5}{openai2026tenadvances}.}
+\citet{Chapter 4, Sections 5.1, 6.2, and 6.4–6.5}{openai2026tenadvances}.}
 
 \p{The same chapter proves property (T) by a relative-property-(T) spectral
 estimate and a Boolean-polynomial support bound, rather than taking it only
 from a classical lattice theorem
-\citet{Chapter 4, Sections 5.2--5.5}{openai2026tenadvances}.}
+\citet{Chapter 4, Sections 5.2–5.5}{openai2026tenadvances}.}
 
 \p{This is not Zhou's deformation. Zhou keeps both the discrete kernel and the
 quotient fixed and changes the action; the quadratic shear then conjugates the
-two dual actions \citet{Section 1, pp. 2--3}{zhou2026icc}. Here the action on
+two dual actions \citet{Section 1, pp. 2–3}{zhou2026icc}. Here the action on
 the underlying measured space is already common, while the compact group law,
 hence its discrete dual, changes.}
 

--- a/trees/connes-000N.tree
+++ b/trees/connes-000N.tree
@@ -16,7 +16,7 @@ the split semidirect product #{\Gamma_0=A\rtimes Q} with an extension
 \p{The algebraic difference lies neither in the
 kernel nor in the action, but in the extension cocycle. The class is obtained
 as a Bockstein of the theta-characteristic cocycle
-\citet{Sections 3.1--3.3}{anthropic2026icc}.}
+\citet{Sections 3.1–3.3}{anthropic2026icc}.}
 
 \tikzfig{
 \begin{tikzpicture}[
@@ -55,14 +55,14 @@ construct phases #{\Psi_g}; their coboundary is exactly the dual twist
 #{u_\tau}.}
 
 \p{The resulting gauge is a trace-preserving isomorphism of the crossed
-products \citet{Sections 2.3 and 5.1--5.3, especially Theorems 5.1 and
+products \citet{Sections 2.3 and 5.1–5.3, especially Theorems 5.1 and
 5.2}{anthropic2026icc}.}
 
 \p{Nonisomorphism survives because #{[\tau]\ne0}: one
 extension splits and the other does not \citet{Section 4}{anthropic2026icc}.
 The paper proves ICC directly and obtains property (T) from the classical
 #{\operatorname{Sp}_4(\mathbb Z)} and relative-property-(T) input, followed by
-finite-index permanence \citet{Lemmas 3.7--3.8}{anthropic2026icc}.}
+finite-index permanence \citet{Lemmas 3.7–3.8}{anthropic2026icc}.}
 
 \p{The constructions vary three different algebraic data:}
 

--- a/trees/connes-000O.tree
+++ b/trees/connes-000O.tree
@@ -19,7 +19,7 @@ almost invariant unit vectors has a nonzero invariant vector
 von Neumann algebra a factor, while property (T) imposes
 representation-theoretic rigidity. These are the two hypotheses in the
 conjecture and in all three counterexample constructions below
-\citet{Section 1, pp. 1--2}{zhou2026icc}.}
+\citet{Section 1, pp. 1–2}{zhou2026icc}.}
 
 \p{Connes first proved that, for an ICC property-(T) group,
 #{\operatorname{Out}(L(\Gamma))} and the fundamental group
@@ -30,7 +30,7 @@ conjecture and in all three counterexample constructions below
 #{\Lambda}, an isomorphism #{L(\Lambda)\cong L(\Gamma)} should force
 #{\Lambda\cong\Gamma}. Zhou's introduction states this original 1982
 conjecture and distinguishes it from the later, narrower rigidity question for
-higher-rank lattices \citet{Section 1, pp. 1--2}{zhou2026icc}.}
+higher-rank lattices \citet{Section 1, pp. 1–2}{zhou2026icc}.}
 
 \p{The counterexamples considered here disprove the broad conjecture. They do
 not settle that higher-rank-lattice question.}

--- a/trees/connes-000P.tree
+++ b/trees/connes-000P.tree
@@ -9,7 +9,7 @@
 \p{The OpenAI and Zhou counterexamples were obtained independently and at
 nearly the same time. Zhou records that his preliminary manuscript predated
 the public OpenAI announcement, while acknowledging that the two projects were
-concurrent \citet{Section 1, pp. 2--3}{zhou2026icc}.}
+concurrent \citet{Section 1, pp. 2–3}{zhou2026icc}.}
 
 \p{OpenAI gives a countable family of pairwise nonisomorphic ICC property-(T)
 groups with isomorphic group factors
@@ -19,12 +19,12 @@ a different action-changing construction
 
 \p{The later Anthropic proof gives another explicit pair by comparing a split
 extension with a nonsplit one
-\citet{Sections 3--5}{anthropic2026icc}.}
+\citet{Sections 3–5}{anthropic2026icc}.}
 
 \p{These are not three presentations of one proof. The algebraic datum hidden
 by the factor sits at a different level in each construction, and each factor
 argument removes it by a different measurable mechanism. The mathematical
 and formalization motivations for comparing them are stated next. The detailed
 OpenAI and Anthropic architectures appear in \ref{connes-000M} and
-\ref{connes-000N}; Sections 2--7 below follow Zhou's proof in its original
+\ref{connes-000N}; Sections 2–7 below follow Zhou's proof in its original
 order.}

--- a/trees/connes-000Q.tree
+++ b/trees/connes-000Q.tree
@@ -19,14 +19,14 @@ measurable crossed-product transport.}}
   \li{\strong{Zhou: fix the kernel; vary the action and module structure.}
   \citet{Sections 1 and 3}{zhou2026icc}; and}
   \li{\strong{Anthropic: fix both; vary the extension class.}
-  \citet{Sections 3--5}{anthropic2026icc}.}
+  \citet{Sections 3–5}{anthropic2026icc}.}
 }
 
 \p{Three kinds of information loss stand out:}
 
 \ul{
   \li{\strong{Cocycle:} algebraically nontrivial, measurably removable;}
-  \li{\strong{Action:} Fourier--Pontryagin transport conjugates distinct
+  \li{\strong{Action:} Fourier–Pontryagin transport conjugates distinct
   module actions; and}
   \li{\strong{Extension data:} characteristic-two data distinguish groups while their
   factors remain isomorphic.}

--- a/trees/connes-000R.tree
+++ b/trees/connes-000R.tree
@@ -15,7 +15,7 @@ and exposition project. The division of work was concrete.}
   \li{selected Zhou's theorem and required completion of every Zhou-internal
   argument, with property (T) for #{\mathrm{EL}_3(\mathbb F_2[t])} as the
   single explicit external premise;}
-  \li{fixed Zhou's Sections 2--7 as the proof order and required the overview
+  \li{fixed Zhou's Sections 2–7 as the proof order and required the overview
   to show one construction feeding factor equivalence, property (T), ICC, and
   nonisomorphism; and}
   \li{required comparison of the OpenAI, Zhou, and Anthropic proofs by the


### PR DESCRIPTION
## Summary

- replace 43 TeX-style double hyphens in the Connes note suite with Unicode en dashes
- normalize surname pairs, section and page ranges, quantitative estimates, and paired terms
- preserve all 22 TikZ path operators and introduce no em dashes

## Verification

- `just chk`
- Forester build with the repository TeX inputs
- `./lize.sh connes-0001`: 28-page PDF
- HTML and extracted PDF text contain the expected Unicode en dashes
- no prose `--`, no em dashes, no overfull boxes, and no unresolved references

The repository-wide local wrapper reached the known optional `wgputoy` WASM guard before Forester; the content-specific gates above passed, and the PR full build is authoritative.