### PR TITLE
feat: add adaptive theme and light-paper controls

### DIFF
--- a/assets/uts-layout.xsl
+++ b/assets/uts-layout.xsl
@@ -31,7 +31,8 @@
                     <xsl:value-of select="/fr:tree/fr:frontmatter/fr:title/@text" />
                 </title>
                 <script src="{/fr:tree/@base-url}uts-forester.js"></script>
-                <script src="{/fr:tree/@base-url}uts-ondemand.js"></script>
+                <!-- AGENT-NOTE: Keep this minified loader module-scoped so its helpers cannot overwrite the synchronous preference controls. -->
+                <script type="module" src="{/fr:tree/@base-url}uts-ondemand.js"></script>
             </head>
             <body>
                 <ninja-keys placeholder="Start typing a note title or ID"></ninja-keys>
@@ -45,7 +46,7 @@
                                 </a>
                             </xsl:if>
                             <span class="logo-switches">
-                                <button id="theme-toggle" title="Theme (light/dark)">
+                                <button id="theme-toggle" title="Theme (auto/light/dark)">
                                     <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24"
                                         height="18" viewBox="0 0 24 24" fill="none"
                                         stroke="currentcolor" stroke-width="2"
@@ -65,6 +66,31 @@
                                         <line x1="21" y1="12" x2="23" y2="12"></line>
                                         <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
                                         <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
+                                    </svg>
+                                    <svg id="auto" xmlns="http://www.w3.org/2000/svg" width="24"
+                                        height="18" viewBox="0 0 24 24" fill="none"
+                                        stroke="currentcolor" stroke-width="2"
+                                        stroke-linecap="round" stroke-linejoin="round">
+                                        <defs>
+                                            <clipPath id="auto-filled-half">
+                                                <rect x="3" y="3" width="9" height="18"></rect>
+                                            </clipPath>
+                                        </defs>
+                                        <circle cx="12" cy="12" r="9" fill="currentcolor" stroke="none"
+                                            clip-path="url(#auto-filled-half)"></circle>
+                                        <circle cx="12" cy="12" r="9"></circle>
+                                    </svg>
+                                </button>
+                                <button id="light-paper-toggle"
+                                    title="Light paper (mix/near-white/sepia)">
+                                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="18"
+                                        viewBox="0 0 24 24" fill="none" stroke="currentcolor"
+                                        stroke-width="2" stroke-linecap="round"
+                                        stroke-linejoin="round">
+                                        <path d="M12 3a9 9 0 1 0 0 18h1.5a1.5 1.5 0 0 0 0-3H12a2 2 0 0 1-2-2v-1a2 2 0 0 1 2-2h3.5a3.5 3.5 0 0 0 0-7Z"></path>
+                                        <circle cx="7.5" cy="10" r="0.6" fill="currentcolor" stroke="none"></circle>
+                                        <circle cx="10.5" cy="7" r="0.6" fill="currentcolor" stroke="none"></circle>
+                                        <circle cx="14.5" cy="7.5" r="0.6" fill="currentcolor" stroke="none"></circle>
                                     </svg>
                                 </button>
                                 <button id="font-toggle" title="Font (serif/mono/sans)">

--- a/bun/uts-forester.ts
+++ b/bun/uts-forester.ts
@@ -1,20 +1,25 @@
-function getUserPreference() {
-    return localStorage.getItem('theme') || 'system'
+const systemTheme = matchMedia('(prefers-color-scheme: dark)')
+
+function getThemePreference() {
+    const theme = localStorage.getItem('theme')
+    if (theme === 'light' || theme === 'dark' || theme === 'auto') {
+        return theme
+    }
+    return 'auto'
 }
 
-function saveUserPreference(userPreference) {
-    localStorage.setItem('theme', userPreference)
+function saveThemePreference(themePreference) {
+    localStorage.setItem('theme', themePreference)
 }
 
-function getAppliedMode(userPreference) {
-    if (userPreference === 'light') {
+function getAppliedMode(themePreference) {
+    if (themePreference === 'light') {
         return 'light'
     }
-    if (userPreference === 'dark') {
+    if (themePreference === 'dark') {
         return 'dark'
     }
-    // system
-    if (matchMedia('(prefers-color-scheme: dark)').matches) {
+    if (systemTheme.matches) {
         return 'dark'
     }
     return 'light'
@@ -24,27 +29,89 @@ function setAppliedMode(mode) {
     document.documentElement.dataset.appliedMode = mode
 }
 
-function rotatePreferences(userPreference) {
-    if (userPreference === 'dark') {
+function rotateThemePreference(themePreference) {
+    if (themePreference === 'auto') {
         return 'light'
     }
-    if (userPreference === 'light') {
+    if (themePreference === 'light') {
         return 'dark'
     }
-    // for invalid values, just in case
-    return rotatePreferences(getAppliedMode('system'))
+    return 'auto'
 }
 
-// the class of body is toggled between none and dark
+function updateThemeToggleLabel() {
+    const themeToggle = document.getElementById('theme-toggle')
+    if (!themeToggle) return
+    const themePreference = getThemePreference()
+    const appliedMode = getAppliedMode(themePreference)
+    const nextThemePreference = rotateThemePreference(themePreference)
+    const detail =
+        themePreference === 'auto' ? `auto (${appliedMode})` : themePreference
+    const label = `Theme: ${detail}; next: ${nextThemePreference}`
+    themeToggle.title = label
+    themeToggle.setAttribute('aria-label', label)
+}
+
+function applyThemePreference(themePreference) {
+    document.documentElement.dataset.themePreference = themePreference
+    setAppliedMode(getAppliedMode(themePreference))
+    updateThemeToggleLabel()
+}
+
+function getLightPaperPreference() {
+    const lightPaper = localStorage.getItem('light-paper')
+    if (
+        lightPaper === 'mix' ||
+        lightPaper === 'near-white' ||
+        lightPaper === 'sepia'
+    ) {
+        return lightPaper
+    }
+    return 'mix'
+}
+
+function saveLightPaperPreference(lightPaperPreference) {
+    localStorage.setItem('light-paper', lightPaperPreference)
+}
+
+function rotateLightPaperPreference(lightPaperPreference) {
+    if (lightPaperPreference === 'mix') {
+        return 'near-white'
+    }
+    if (lightPaperPreference === 'near-white') {
+        return 'sepia'
+    }
+    return 'mix'
+}
+
+function updateLightPaperToggleLabel() {
+    const lightPaperToggle = document.getElementById('light-paper-toggle')
+    if (!lightPaperToggle) return
+    const lightPaperPreference = getLightPaperPreference()
+    const nextLightPaperPreference =
+        rotateLightPaperPreference(lightPaperPreference)
+    const label = `Light paper: ${lightPaperPreference}; next: ${nextLightPaperPreference}`
+    lightPaperToggle.title = label
+    lightPaperToggle.setAttribute('aria-label', label)
+}
+
+function applyLightPaperPreference(lightPaperPreference) {
+    document.documentElement.dataset.lightPaper = lightPaperPreference
+    updateLightPaperToggleLabel()
+}
+
 function rotateFontPreferences(currentFont) {
     if (currentFont === 'serif') return 'mono'
     if (currentFont === 'mono') return 'sans'
-    if (currentFont === 'sans') return 'muse'
     return 'serif'
 }
 
 function getFontPreference() {
-    return localStorage.getItem('font') || 'sans'
+    const font = localStorage.getItem('font')
+    if (font === 'serif' || font === 'mono' || font === 'sans') {
+        return font
+    }
+    return 'serif'
 }
 
 function saveFontPreference(font) {
@@ -55,18 +122,47 @@ function setAppliedFont(font) {
     document.documentElement.dataset.appliedFont = font
 }
 
+function updateFontToggleLabel() {
+    const fontToggle = document.getElementById('font-toggle')
+    if (!fontToggle) return
+    const fontPreference = getFontPreference()
+    const nextFontPreference = rotateFontPreferences(fontPreference)
+    const label = `Font: ${fontPreference}; next: ${nextFontPreference}`
+    fontToggle.title = label
+    fontToggle.setAttribute('aria-label', label)
+}
+
+function applyFontPreference(fontPreference) {
+    setAppliedFont(fontPreference)
+    updateFontToggleLabel()
+}
+
 function toggleFont() {
     const newFontPref = rotateFontPreferences(getFontPreference())
     saveFontPreference(newFontPref)
-    setAppliedFont(newFontPref)
+    applyFontPreference(newFontPref)
 }
 
 function toggleTheme() {
-    const newUserPref = rotatePreferences(getUserPreference())
-    userPreference = newUserPref
-    saveUserPreference(newUserPref)
-    setAppliedMode(getAppliedMode(newUserPref))
+    const newThemePreference = rotateThemePreference(getThemePreference())
+    saveThemePreference(newThemePreference)
+    applyThemePreference(newThemePreference)
 }
+
+function toggleLightPaper() {
+    const newLightPaperPreference = rotateLightPaperPreference(
+        getLightPaperPreference(),
+    )
+    saveLightPaperPreference(newLightPaperPreference)
+    applyLightPaperPreference(newLightPaperPreference)
+}
+
+// AGENT-NOTE: Keep the persisted preference distinct from the applied mode so auto can follow device changes.
+systemTheme.addEventListener('change', () => {
+    if (getThemePreference() === 'auto') {
+        applyThemePreference('auto')
+    }
+})
 
 function search() {
     const ninja = document.querySelector('ninja-keys')
@@ -84,10 +180,13 @@ function togglelang() {
 
 // on document ready
 document.addEventListener('DOMContentLoaded', () => {
-    // on clicking the button with id theme-toggle, the function toggleTheme is called
     document.getElementById('theme-toggle').onclick = toggleTheme
+    document.getElementById('light-paper-toggle').onclick = toggleLightPaper
     document.getElementById('font-toggle').onclick = toggleFont
     document.getElementById('search').onclick = search
+    applyThemePreference(getThemePreference())
+    applyLightPaperPreference(getLightPaperPreference())
+    applyFontPreference(getFontPreference())
     const langblock_toggle = document.getElementById('langblock-toggle')
     if (langblock_toggle) langblock_toggle.onclick = togglelang
 
@@ -189,8 +288,7 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 })
 
-// Important to be 1st in the DOM
-const theme = localStorage.getItem('theme') || getAppliedMode('system')
-document.documentElement.dataset.appliedMode = theme
-const font = localStorage.getItem('font') || 'serif'
-document.documentElement.dataset.appliedFont = font
+// Important to be first in the DOM, before the page body is parsed.
+applyThemePreference(getThemePreference())
+applyLightPaperPreference(getLightPaperPreference())
+applyFontPreference(getFontPreference())

--- a/bun/uts-style.css
+++ b/bun/uts-style.css
@@ -325,8 +325,8 @@ section:has(> details > summary > header .agent-authored-watermark)
     --uts-link-internal: #5d5d5d;
     --uts-text-gentle: rgb(132, 132, 132);
     --uts-text-cite: #10731d;
-    /* The only light-mode visual change: warm paper instead of white. */
-    --uts-background: #f4efde;
+    /* A restrained blend of the warm paper and the supplied near-white. */
+    --uts-background: #f8f5eb;
     --uts-surface: var(--uts-background);
     /* Keep colored taxon cards on their PDF-style white tint, not the paper. */
     --uts-taxon-surface: white;
@@ -341,6 +341,14 @@ section:has(> details > summary > header .agent-authored-watermark)
     --uts-taxon-theorem: #95dbfc;
     --uts-taxon-notation: #ffd27f;
     --uts-taxon-convention: #d369cb;
+}
+
+:root[data-applied-mode="light"][data-light-paper="near-white"] {
+    --uts-background: #fbfbf8;
+}
+
+:root[data-applied-mode="light"][data-light-paper="sepia"] {
+    --uts-background: #f4efde;
 }
 
 :root,
@@ -502,6 +510,7 @@ a.slug[href*="utensil"], a.slug[href*="jonmsterling"] {
 } */
 
 button#theme-toggle,
+button#light-paper-toggle,
 button#font-toggle {
     /* font-size: 26px; */
     margin: auto 4px;
@@ -523,11 +532,23 @@ button#search {
 }
 
 :root svg#sun,
+:root svg#auto,
 :root[data-applied-mode="dark"] svg#moon {
     display: none;
 }
 
 :root[data-applied-mode="dark"] svg#sun {
+    display: block;
+    color: var(--uts-text);
+}
+
+:root[data-theme-preference] button#theme-toggle svg {
+    display: none;
+}
+
+:root[data-theme-preference="auto"] button#theme-toggle svg#auto,
+:root[data-theme-preference="light"] button#theme-toggle svg#moon,
+:root[data-theme-preference="dark"] button#theme-toggle svg#sun {
     display: block;
     color: var(--uts-text);
 }


### PR DESCRIPTION
## Summary

- soften the default light canvas to `#f8f5eb`, while retaining remembered near-white and sepia paper choices
- add persistent `auto → light → dark → auto` theme selection; auto follows the device preference
- add the same-size light-paper control between theme and font, and normalize persistent serif / mono / sans font selection with serif default
- load the on-demand bundle as a module so its minified globals cannot overwrite the preference controls

## Verification

- `just chk`
- `just build` (1,236 XML pages restored and converted; only the two known external-link warnings)
- `just verify-render` (1,236 page pairs)
- Browser matrix: theme cycle, paper cycle, dark-mode isolation, font cycle, reload persistence, and device light → dark → light auto behavior
- 1728×1084 TT/CA preview pair posted in the designated Forest Discord thread

## Human gate

Intentionally unmerged and undeployed for review.