### PR TITLE
docs(connes): shorten the transcluded motivation [AGENT]

### DIFF
--- a/trees/connes-0001.tree
+++ b/trees/connes-0001.tree
@@ -17,18 +17,7 @@
   \title{Introduction}
   \transclude{connes-000O}
   \transclude{connes-000P}
-  \subtree{
-    \title{Motivation}
-    \p{The motivation for this formalization experiment is threefold. The
-    examples ask when algebraic information disappears after passage to an
-    operator algebra. Formalization tests whether the point of disappearance
-    can be made explicit in proof interfaces and library boundaries. The
-    agent-assisted workflow tests what evidence and exposition are needed to
-    prepare such a development for human examination.}
-    \transclude{connes-000Q}
-    \transclude{connes-000S}
-    \transclude{connes-000T}
-  }
+  \transclude{connes-000Z}
   \transclude{connes-000K}
 }
 

--- a/trees/connes-000Q.tree
+++ b/trees/connes-000Q.tree
@@ -3,7 +3,12 @@
 
 \tag{connes}
 \tag{operator-algebra}
+\tag{draft}
+\tag{agent-draft}
 \title{Mathematical motivation}
+
+\p{This draft expands the mathematical motivation summarized in
+\ref{connes-000Z}.}
 
 \p{The counterexample is not merely a negative answer to Connes' conjecture.
 Its richer content is a controlled experiment in nonfaithfulness. The three

--- a/trees/connes-000S.tree
+++ b/trees/connes-000S.tree
@@ -3,7 +3,12 @@
 
 \tag{connes}
 \tag{lean}
+\tag{draft}
+\tag{agent-draft}
 \title{Formalization motivation}
+
+\p{This draft expands the formalization motivation summarized in
+\ref{connes-000Z}.}
 
 \p{The mathematical comparison identifies where information is lost. The
 formalization asks whether that loss can be exposed as an explicit proof

--- a/trees/connes-000T.tree
+++ b/trees/connes-000T.tree
@@ -3,8 +3,12 @@
 
 \tag{connes}
 \tag{lean}
+\tag{draft}
 \tag{agent-draft}
 \title{Agent-assisted work and human examination}
+
+\p{This draft expands the examination method summarized in
+\ref{connes-000Z}.}
 
 \p{An agent-authored formalization is easier to examine when the code comes
 with a route back to the literature, an executable verification record, and an

--- a/trees/connes-000Z.tree
+++ b/trees/connes-000Z.tree
@@ -11,17 +11,17 @@
 \subtree{
   \title{Mathematical motivation}
 
-  \p{The negative answer is only the starting point. The three counterexamples
-  form a controlled test of nonfaithfulness. OpenAI varies the abelian kernel
+  \p{The three counterexamples form a controlled test of nonfaithfulness.
+  OpenAI varies the abelian kernel
   \citet{Chapter 4}{openai2026tenadvances}; Zhou fixes the kernel while varying
   the action and module structure \citet{Sections 1 and 3}{zhou2026icc}; and
   Anthropic fixes both while varying the extension class
   \citet{Sections 3–5}{anthropic2026icc}. In each construction, a genuine group
   distinction survives algebraically but disappears after measurable
   crossed-product transport. The comparison asks which distinctions survive
-  representation, twisting, duality, and analytic completion. Property (T) is
-  a control condition: failure of reconstruction persists for groups with
-  strong representation-theoretic rigidity.}
+  representation, twisting, duality, and analytic completion. Property (T)
+  here serves as a control condition: failure of reconstruction persists for
+  groups with strong representation-theoretic rigidity.}
 }
 
 \subtree{
@@ -39,9 +39,10 @@
 \subtree{
   \title{Agent-assisted work and human examination}
 
-  \p{The project also tests how an agent-authored formalization can be prepared
-  for human examination and digestion. Literature grounding, the exact
-  external premise boundary, provenance, technical proof replay, mathematical
+  \p{The project also tests whether an agent-authored formalization can be
+  brought to a standard suitable for human examination and digestion.
+  Literature grounding, the exact external premise boundary, provenance,
+  technical proof replay, mathematical
   audit, and companion notes answer different questions. Technical verification
   checks the formal statement and its replay; source and mathematical review
   ask whether the theorem, definitions, hypotheses, and supporting facts match

--- a/trees/connes-000Z.tree
+++ b/trees/connes-000Z.tree
@@ -1,0 +1,50 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{operator-algebra}
+\tag{lean}
+\title{Motivation}
+
+\p{The motivation for this formalization experiment is threefold.}
+
+\subtree{
+  \title{Mathematical motivation}
+
+  \p{The negative answer is only the starting point. The three counterexamples
+  form a controlled test of nonfaithfulness. OpenAI varies the abelian kernel
+  \citet{Chapter 4}{openai2026tenadvances}; Zhou fixes the kernel while varying
+  the action and module structure \citet{Sections 1 and 3}{zhou2026icc}; and
+  Anthropic fixes both while varying the extension class
+  \citet{Sections 3–5}{anthropic2026icc}. In each construction, a genuine group
+  distinction survives algebraically but disappears after measurable
+  crossed-product transport. The comparison asks which distinctions survive
+  representation, twisting, duality, and analytic completion. Property (T) is
+  a control condition: failure of reconstruction persists for groups with
+  strong representation-theoretic rigidity.}
+}
+
+\subtree{
+  \title{Formalization motivation}
+
+  \p{Formalization asks where the information is lost. Named interfaces for
+  the characteristic-two retraction, Fourier shear, measurable transport,
+  continuous closure, spectral detection, and characteristic-module
+  obstruction turn the claim that a factor forgets structure into an auditable
+  dependency map. This separates direct translation from designed bridges and
+  makes the project a consumer of Mathlib and TauCeti. Missing or bespoke
+  interfaces mark candidates for reusable contributions to those libraries.}
+}
+
+\subtree{
+  \title{Agent-assisted work and human examination}
+
+  \p{The project also tests how an agent-authored formalization can be prepared
+  for human examination and digestion. Literature grounding, the exact
+  external premise boundary, provenance, technical proof replay, mathematical
+  audit, and companion notes answer different questions. Technical verification
+  checks the formal statement and its replay; source and mathematical review
+  ask whether the theorem, definitions, hypotheses, and supporting facts match
+  the intended mathematics. A reader can then trace a claim from the literature
+  to its Lean declaration, downstream use, audit status, and executable check.}
+}


### PR DESCRIPTION
## Summary

- replace the long three-card motivation in the transcluded Connes suite with one concise addressed card
- preserve the mathematical, formalization, and human-examination motivations with their literature grounding
- retain the three detailed discussions as non-transcluded draft cards that link back to the summary
- preserve the root query result, agent-authored metadata, and standalone graph navigation

## Review

The prose and consumer-contract review repaired an awkward opening, vague library-contribution wording, a plural external-premise boundary, and a generic closing sentence. Subsequent review suggestions were treated as intent rather than literal patches: the mathematical account now begins directly with the comparison, property (T) is identified as the control condition in this comparison, and the agent-assisted objective is stated as reaching a standard suitable for productive human examination. Section 1 now moves from counterexample background through the three motivations into formalization design without repeating the full supporting discussion.

## Verification

- just chk
- Forester build
- Connes PDF build
- 27-page A4 PDF, with no overfull boxes, unresolved references, or unresolved citations
- visual inspection of the affected opening and transition pages
- graph check: the root transcludes only the concise card; the three draft expansions link back and appear as backlinks only on the standalone card
- query check: uts-016Q still selects only the three intended note-suite roots

Human-gated. Auto-merge is disabled.