### PR TITLE
fix: stabilize theme control row

### DIFF
--- a/assets/uts-layout.xsl
+++ b/assets/uts-layout.xsl
@@ -7,6 +7,9 @@
     xmlns:fr="http://www.forester-notes.org"
     xmlns:html="http://www.w3.org/1999/xhtml"
 >
+    <!-- AGENT-NOTE: The renderer supplies a hash of this layout and the paired UI assets. -->
+    <xsl:param name="ui_asset_revision" select="'unversioned'" />
+
     <!-- The following is based on
     https://git.sr.ht/~jonsterling/forester-base-theme/tree/main/item/tree.xsl -->
     <!-- All modifications should mark with comments: uts-begin/uts-end -->
@@ -17,7 +20,8 @@
                 <link rel="stylesheet" href="{/fr:tree/@base-url}style.css" />
                 <link rel="stylesheet" href="{/fr:tree/@base-url}katex.min.css" />
                 <!-- uts-begin -->
-                <link rel="stylesheet" href="{/fr:tree/@base-url}uts-style.css" />
+                <link rel="stylesheet"
+                    href="{/fr:tree/@base-url}uts-style.css?ui={$ui_asset_revision}" />
                 <!-- uts-end -->
                 <script type="text/javascript">
                     <xsl:if test="/fr:tree/fr:frontmatter/fr:source-path">
@@ -30,7 +34,7 @@
                 <title>
                     <xsl:value-of select="/fr:tree/fr:frontmatter/fr:title/@text" />
                 </title>
-                <script src="{/fr:tree/@base-url}uts-forester.js"></script>
+                <script src="{/fr:tree/@base-url}uts-forester.js?ui={$ui_asset_revision}"></script>
                 <!-- AGENT-NOTE: Keep this minified loader module-scoped so its helpers cannot overwrite the synchronous preference controls. -->
                 <script type="module" src="{/fr:tree/@base-url}uts-ondemand.js"></script>
             </head>
@@ -45,16 +49,19 @@
                                     <xsl:text>« Home</xsl:text>
                                 </a>
                             </xsl:if>
-                            <span class="logo-switches">
-                                <button id="theme-toggle" title="Theme (auto/light/dark)">
-                                    <svg id="moon" xmlns="http://www.w3.org/2000/svg" width="24"
-                                        height="18" viewBox="0 0 24 24" fill="none"
+                            <span class="logo-switches" role="group" aria-label="Display controls">
+                                <button class="logo-switch" id="theme-toggle" type="button"
+                                    title="Theme (auto/light/dark)">
+                                    <svg class="theme-glyph theme-glyph-moon"
+                                        xmlns="http://www.w3.org/2000/svg" width="24" height="18"
+                                        viewBox="0 0 24 24" fill="none" aria-hidden="true"
                                         stroke="currentcolor" stroke-width="2"
                                         stroke-linecap="round" stroke-linejoin="round">
                                         <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z"></path>
                                     </svg>
-                                    <svg id="sun" xmlns="http://www.w3.org/2000/svg" width="24"
-                                        height="18" viewBox="0 0 24 24" fill="none"
+                                    <svg class="theme-glyph theme-glyph-sun"
+                                        xmlns="http://www.w3.org/2000/svg" width="24" height="18"
+                                        viewBox="0 0 24 24" fill="none" aria-hidden="true"
                                         stroke="currentcolor" stroke-width="2"
                                         stroke-linecap="round" stroke-linejoin="round">
                                         <circle cx="12" cy="12" r="5"></circle>
@@ -67,8 +74,9 @@
                                         <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"></line>
                                         <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"></line>
                                     </svg>
-                                    <svg id="auto" xmlns="http://www.w3.org/2000/svg" width="24"
-                                        height="18" viewBox="0 0 24 24" fill="none"
+                                    <svg class="theme-glyph theme-glyph-auto"
+                                        xmlns="http://www.w3.org/2000/svg" width="24" height="18"
+                                        viewBox="0 0 24 24" fill="none" aria-hidden="true"
                                         stroke="currentcolor" stroke-width="2"
                                         stroke-linecap="round" stroke-linejoin="round">
                                         <defs>
@@ -81,10 +89,11 @@
                                         <circle cx="12" cy="12" r="9"></circle>
                                     </svg>
                                 </button>
-                                <button id="light-paper-toggle"
-                                    title="Light paper (mix/near-white/sepia)">
+                                <span class="logo-switch" id="light-paper-toggle" role="button"
+                                    tabindex="0" title="Light paper (mix/near-white/sepia)">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="18"
-                                        viewBox="0 0 24 24" fill="none" stroke="currentcolor"
+                                        viewBox="0 0 24 24" fill="none" aria-hidden="true"
+                                        stroke="currentcolor"
                                         stroke-width="2" stroke-linecap="round"
                                         stroke-linejoin="round">
                                         <path d="M12 3a9 9 0 1 0 0 18h1.5a1.5 1.5 0 0 0 0-3H12a2 2 0 0 1-2-2v-1a2 2 0 0 1 2-2h3.5a3.5 3.5 0 0 0 0-7Z"></path>
@@ -92,17 +101,19 @@
                                         <circle cx="10.5" cy="7" r="0.6" fill="currentcolor" stroke="none"></circle>
                                         <circle cx="14.5" cy="7.5" r="0.6" fill="currentcolor" stroke="none"></circle>
                                     </svg>
-                                </button>
-                                <button id="font-toggle" title="Font (serif/mono/sans)">
+                                </span>
+                                <button class="logo-switch" id="font-toggle" type="button"
+                                    title="Font (serif/mono/sans)">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="18"
-                                        viewBox="0 0 24 24" fill="currentcolor">
+                                        viewBox="0 0 24 24" fill="currentcolor" aria-hidden="true">
                                         <text x="12" y="20" text-anchor="middle"
                                             font-weight="normal">Aa</text>
                                     </svg>
                                 </button>
-                                <button id="search">
+                                <button class="logo-switch" id="search" type="button" title="Search">
                                     <svg xmlns="http://www.w3.org/2000/svg" width="24" height="18"
-                                        viewBox="0 0 24 24" fill="none" stroke="currentcolor"
+                                        viewBox="0 0 24 24" fill="none" aria-hidden="true"
+                                        stroke="currentcolor"
                                         stroke-width="2" stroke-linecap="round"
                                         stroke-linejoin="round">
                                         <circle cx="11" cy="11" r="8"></circle>

--- a/bun/uts-forester.ts
+++ b/bun/uts-forester.ts
@@ -157,6 +157,19 @@ function toggleLightPaper() {
     applyLightPaperPreference(newLightPaperPreference)
 }
 
+function bindControl(controlId, action) {
+    const control = document.getElementById(controlId)
+    if (!control) return
+    control.onclick = action
+    if (control.getAttribute('role') !== 'button') return
+    control.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+            event.preventDefault()
+            action()
+        }
+    })
+}
+
 // AGENT-NOTE: Keep the persisted preference distinct from the applied mode so auto can follow device changes.
 systemTheme.addEventListener('change', () => {
     if (getThemePreference() === 'auto') {
@@ -180,10 +193,10 @@ function togglelang() {
 
 // on document ready
 document.addEventListener('DOMContentLoaded', () => {
-    document.getElementById('theme-toggle').onclick = toggleTheme
-    document.getElementById('light-paper-toggle').onclick = toggleLightPaper
-    document.getElementById('font-toggle').onclick = toggleFont
-    document.getElementById('search').onclick = search
+    bindControl('theme-toggle', toggleTheme)
+    bindControl('light-paper-toggle', toggleLightPaper)
+    bindControl('font-toggle', toggleFont)
+    bindControl('search', search)
     applyThemePreference(getThemePreference())
     applyLightPaperPreference(getLightPaperPreference())
     applyFontPreference(getFontPreference())

--- a/bun/uts-style.css
+++ b/bun/uts-style.css
@@ -509,48 +509,57 @@ a.slug[href*="utensil"], a.slug[href*="jonmsterling"] {
     text-decoration-style: dotted !important;
 } */
 
-button#theme-toggle,
-button#light-paper-toggle,
-button#font-toggle {
-    /* font-size: 26px; */
-    margin: auto 4px;
-    cursor: pointer;
-    /* adding: 0; */
-    font: inherit;
-    background: 0 0;
-    border: 0;
+.logo-switches {
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+    margin-left: 4px;
+    vertical-align: middle;
+    white-space: nowrap;
 }
 
-button#search {
-    /* font-size: 26px; */
-    margin: auto 4px;
-    cursor: pointer;
-    /* adding: 0; */
-    font: inherit;
-    background: 0 0;
+.logo-switch {
+    box-sizing: border-box;
+    display: inline-flex;
+    flex: 0 0 24px;
+    align-items: center;
+    justify-content: center;
+    width: 24px;
+    height: 24px;
+    margin: 0;
+    padding: 0;
     border: 0;
+    border-radius: 2px;
+    color: var(--uts-text);
+    font: inherit;
+    line-height: 0;
+    vertical-align: middle;
+    cursor: pointer;
+    appearance: none;
+    background: transparent;
 }
 
-:root svg#sun,
-:root svg#auto,
-:root[data-applied-mode="dark"] svg#moon {
+.logo-switch svg {
+    display: block;
+    flex: 0 0 auto;
+    width: 24px;
+    height: 18px;
+}
+
+.logo-switch:focus-visible {
+    outline: 1px solid var(--uts-outline);
+    outline-offset: 2px;
+}
+
+#theme-toggle .theme-glyph {
     display: none;
 }
 
-:root[data-applied-mode="dark"] svg#sun {
+:root:not([data-theme-preference]) #theme-toggle .theme-glyph-auto,
+:root[data-theme-preference="auto"] #theme-toggle .theme-glyph-auto,
+:root[data-theme-preference="light"] #theme-toggle .theme-glyph-moon,
+:root[data-theme-preference="dark"] #theme-toggle .theme-glyph-sun {
     display: block;
-    color: var(--uts-text);
-}
-
-:root[data-theme-preference] button#theme-toggle svg {
-    display: none;
-}
-
-:root[data-theme-preference="auto"] button#theme-toggle svg#auto,
-:root[data-theme-preference="light"] button#theme-toggle svg#moon,
-:root[data-theme-preference="dark"] button#theme-toggle svg#sun {
-    display: block;
-    color: var(--uts-text);
 }
 
 svg.embedded-tex-svg,

--- a/convert_xml.sh
+++ b/convert_xml.sh
@@ -18,7 +18,8 @@ function convert_xml_to_html() {
 
     # bunx xslt3 -s:"$xml_file" -xsl:output/uts-forest.xsl -o:"$html_file"
     # -v
-    xsltproc --path $OUT_DIR -o "$html_file" $XSL_FILE "$xml_file"
+    local ui_asset_revision=${UI_ASSET_REVISION:-unversioned}
+    xsltproc --stringparam ui_asset_revision "$ui_asset_revision" --path $OUT_DIR -o "$html_file" $XSL_FILE "$xml_file"
     # echo "[convert_xml_to_html] Finished xsltproc for $html_file"
     # head -n 20 "$html_file"
 }
@@ -182,6 +183,7 @@ function convert_xml_files() {
         # echo "[convert_xml_files] $xml_file"
     # done
     local max_jobs=$(detect_max_jobs)
+    UI_ASSET_REVISION=$(shasum -a 256 "$OUT_DIR/uts-layout.xsl" "$OUT_DIR/uts-style.css" "$OUT_DIR/uts-forester.js" | shasum -a 256 | awk '{print $1}')
     echo "Max jobs: $max_jobs"
 
     if [ "$convert_all" = true ]; then
@@ -209,4 +211,3 @@ function convert_xml_files() {
 
 }
 # AGENT-NOTE: Updated for forest structure (xml listing and updated files)
-

--- a/verify-forester-output.sh
+++ b/verify-forester-output.sh
@@ -35,6 +35,15 @@ if [ ! -f "$output_dir/forester.js" ]; then
     exit 1
 fi
 
+for ui_asset in uts-layout.xsl uts-style.css uts-forester.js; do
+    if [ ! -s "$output_dir/$ui_asset" ]; then
+        echo "Publish output must include the required $ui_asset UI asset" >&2
+        exit 1
+    fi
+done
+
+ui_asset_revision=$(shasum -a 256 "$output_dir/uts-layout.xsl" "$output_dir/uts-style.css" "$output_dir/uts-forester.js" | shasum -a 256 | awk '{print $1}')
+
 for runtime_asset in wgputoy.js wgputoy_bg.wasm; do
     if [ ! -s "$output_dir/$runtime_asset" ]; then
         echo "Publish output must include the required $runtime_asset runtime" >&2
@@ -53,6 +62,14 @@ while IFS= read -r -d '' xml_file; do
     html_file="${xml_file%index.xml}index.html"
     if [ ! -f "$html_file" ]; then
         echo "Missing rendered HTML for $xml_file" >&2
+        exit 1
+    fi
+    if ! grep -Fq "uts-style.css?ui=$ui_asset_revision" "$html_file"; then
+        echo "Rendered HTML must reference the current UI stylesheet revision: $html_file" >&2
+        exit 1
+    fi
+    if ! grep -Fq "uts-forester.js?ui=$ui_asset_revision" "$html_file"; then
+        echo "Rendered HTML must reference the current UI script revision: $html_file" >&2
         exit 1
     fi
 done < <(find "$output_dir" -mindepth 2 -maxdepth 2 -type f -name index.xml -print0)


### PR DESCRIPTION
## Summary

- Normalize the four display controls to equal fixed icon slots and shared spacing.
- Keep auto, light, and dark as glyph states within the single theme control; make light paper an accessible peer icon rather than a native button.
- Revision rendered CSS and preference-script URLs from their emitted content, with an output-contract assertion, so Pages cannot pair new controls with stale UI assets.

## Validation

- `just chk`
- `just build`
- `just verify-render` (1,236 XML/HTML pairs)
- `just verify-pdf-fixtures` (10 PDF fixtures and publication-date assertions)
- Browser interaction matrix on TT and CA: click/keyboard cycles, persistent font/paper choices, and auto device-preference transitions.

## Gate

Human-gated: intentionally unmerged and undeployed. TT/CA preview captures are posted in the designated Forest Discord thread.