### PR TITLE
docs(connes): give note sections stable addresses [AGENT]

### DIFF
--- a/trees/connes-0001.tree
+++ b/trees/connes-0001.tree
@@ -13,81 +13,15 @@
 \author{utensil}
 \date{2026-08-12}
 
-\subtree{
-  \title{Introduction}
-  \transclude{connes-000O}
-  \transclude{connes-000P}
-  \transclude{connes-000Z}
-  \transclude{connes-000K}
-}
-
-\subtree{
-  \title{Characteristic-two tensor kernel (Zhou §2)}
-  \transclude{connes-000C}
-  \transclude{connes-000U}
-}
-
-\subtree{
-  \title{Factor equivalence by Fourier shear (Zhou §3)}
-  \transclude{connes-0007}
-  \transclude{connes-000D}
-  \transclude{connes-000E}
-}
-
-\subtree{
-  \title{Property (T) by spectral transfer (Zhou §4)}
-  \transclude{connes-0003}
-  \transclude{connes-000V}
-  \transclude{connes-0004}
-  \transclude{connes-000Y}
-  \transclude{connes-0005}
-  \transclude{connes-000W}
-}
-
-\subtree{
-  \title{ICC by orbit displacement (Zhou §5)}
-  \transclude{connes-0006}
-  \transclude{connes-000X}
-}
-
-\subtree{
-  \title{Nonisomorphism by characteristic modules (Zhou §6)}
-  \transclude{connes-0008}
-  \transclude{connes-000H}
-}
-
-\subtree{
-  \title{Theorem assembly and trust boundary (Zhou §7)}
-  \transclude{connes-0002}
-  \transclude{connes-0009}
-}
-
-\subtree{
-  \title{Formalization adaptations}
-  \transclude{connes-000A}
-  \transclude{connes-000F}
-  \transclude{connes-000J}
-}
-
-\subtree{
-  \title{OpenAI proof architecture}
-  \transclude{connes-000M}
-}
-
-\subtree{
-  \title{Anthropic proof architecture}
-  \transclude{connes-000N}
-}
-
-\subtree{
-  \title{EJZK formalization outlook}
-  \transclude{connes-000B}
-  \transclude{connes-000G}
-  \transclude{connes-000I}
-  \transclude{connes-000L}
-}
-
-\subtree{
-  \title{Disclosure of AI use}
-  \transclude{connes-000R}
-}
+\transclude{connes-0010}
+\transclude{connes-0011}
+\transclude{connes-0012}
+\transclude{connes-0013}
+\transclude{connes-0014}
+\transclude{connes-0015}
+\transclude{connes-0016}
+\transclude{connes-0017}
+\transclude{connes-0018}
+\transclude{connes-0019}
+\transclude{connes-001A}
+\transclude{connes-001B}

--- a/trees/connes-0010.tree
+++ b/trees/connes-0010.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Introduction}
+
+\transclude{connes-000O}
+\transclude{connes-000P}
+\transclude{connes-000Z}
+\transclude{connes-000K}

--- a/trees/connes-0011.tree
+++ b/trees/connes-0011.tree
@@ -1,0 +1,11 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Characteristic-two tensor kernel (Zhou §2)}
+
+\transclude{connes-000C}
+\transclude{connes-000U}
+

--- a/trees/connes-0012.tree
+++ b/trees/connes-0012.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Factor equivalence by Fourier shear (Zhou §3)}
+
+\transclude{connes-0007}
+\transclude{connes-000D}
+\transclude{connes-000E}
+

--- a/trees/connes-0013.tree
+++ b/trees/connes-0013.tree
@@ -1,0 +1,15 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Property (T) by spectral transfer (Zhou §4)}
+
+\transclude{connes-0003}
+\transclude{connes-000V}
+\transclude{connes-0004}
+\transclude{connes-000Y}
+\transclude{connes-0005}
+\transclude{connes-000W}
+

--- a/trees/connes-0014.tree
+++ b/trees/connes-0014.tree
@@ -1,0 +1,11 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{ICC by orbit displacement (Zhou §5)}
+
+\transclude{connes-0006}
+\transclude{connes-000X}
+

--- a/trees/connes-0015.tree
+++ b/trees/connes-0015.tree
@@ -1,0 +1,11 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Nonisomorphism by characteristic modules (Zhou §6)}
+
+\transclude{connes-0008}
+\transclude{connes-000H}
+

--- a/trees/connes-0016.tree
+++ b/trees/connes-0016.tree
@@ -1,0 +1,11 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Theorem assembly and trust boundary (Zhou §7)}
+
+\transclude{connes-0002}
+\transclude{connes-0009}
+

--- a/trees/connes-0017.tree
+++ b/trees/connes-0017.tree
@@ -1,0 +1,12 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Formalization adaptations}
+
+\transclude{connes-000A}
+\transclude{connes-000F}
+\transclude{connes-000J}
+

--- a/trees/connes-0018.tree
+++ b/trees/connes-0018.tree
@@ -1,0 +1,10 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{OpenAI proof architecture}
+
+\transclude{connes-000M}
+

--- a/trees/connes-0019.tree
+++ b/trees/connes-0019.tree
@@ -1,0 +1,10 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Anthropic proof architecture}
+
+\transclude{connes-000N}
+

--- a/trees/connes-001A.tree
+++ b/trees/connes-001A.tree
@@ -1,0 +1,13 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{EJZK formalization outlook}
+
+\transclude{connes-000B}
+\transclude{connes-000G}
+\transclude{connes-000I}
+\transclude{connes-000L}
+

--- a/trees/connes-001B.tree
+++ b/trees/connes-001B.tree
@@ -1,0 +1,10 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Disclosure of AI use}
+
+\transclude{connes-000R}
+


### PR DESCRIPTION
## Summary

- extract all twelve reader-facing top-level Connes sections into addressed, untaxoned assembler trees
- make `Disclosure of AI use` directly linkable at `connes-001B`
- preserve the existing section titles, content-card transclusions, reading order, and numbering
- keep the three motivation subsections anonymous as intentionally unstable internal structure

## Why all twelve

The full-suite audit found that every top-level section used the same anonymous-wrapper pattern. No other anonymous section-level subtrees exist in the Connes suite beyond the three motivation subsections explicitly excluded from this change.

## Verification

- `just chk`
- full Forester render
- all 12 stable HTML pages contain their expected child content
- `uts-016Q` still directly selects only `connes-0001`
- 27-page A4 PDF rebuild
- before/after extracted PDF text is byte-identical
- no overfull boxes, unresolved references, or citation errors
- visual review of the opening and disclosure section
- exact `utensil` author/committer identity and public-metadata scan

This PR is human-gated; auto-merge is disabled.

(per G-scope, G-size, G-lint, G-verify, G-commit, G-safe)