### PR TITLE
docs(connes): align notes with stabilized proof architecture [AGENT]

### DIFF
--- a/trees/connes-0007.tree
+++ b/trees/connes-0007.tree
@@ -7,7 +7,7 @@
 \tag{von-neumann-algebra}
 \taxon{Theorem}
 \title{Spatial implementation of the factor equivalence}
-\lean/connes{Connes.FactorWitness.SpatialWitness,Connes.FactorWitness.tracialEquiv_of_spatialWitness,Connes.PaperFactorClosure.paperGroupFactors_isomorphic}
+\lean/connes{Connes.FactorWitness.SpatialWitness,Connes.StarAlgEquiv.isNormal,Connes.FactorWitness.tracialEquiv_of_spatialWitness,Connes.PaperFactorClosure.paperGroupFactors_isomorphic}
 
 \p{The group von Neumann algebra #{L(G)} is represented on #{\ell^2(G)} as
 the von Neumann closure of the left regular operators. Its canonical trace is
@@ -20,11 +20,13 @@ the other, and #{U\delta_e=\delta_e}.}
 \leanref/connes{Connes.FactorWitness.SpatialWitness}.
 }
 
-\p{The generic conversion
+\p{The theorem
 \leanref/connes{Connes.FactorWitness.tracialEquiv_of_spatialWitness}
-restricts conjugation to the two group von Neumann algebras, proves normality,
-and obtains trace preservation from the vacuum equation. Thus no operator-
-algebra conclusion is stored as an unexplained premise.}
+restricts unitary conjugation to the two group von Neumann algebras.
+\leanref/connes{Connes.StarAlgEquiv.isNormal}
+proves that the induced star-algebra equivalence is normal, and the equation
+#{U\delta_e=\delta_e} proves that it preserves the canonical trace. These facts
+are proved from the spatial unitary rather than supplied as extra assumptions.}
 
 \p{For Zhou's groups, the concrete unitary composes the two Fourier models with
 the fiber shear. The measure-transport and von Neumann closure obligations are
@@ -32,5 +34,6 @@ separated in \ref{connes-000D} and \ref{connes-000E}. Together they construct
 \leanref/connes{Connes.PaperFactorClosure.paperSpatialUnitary},
 \leanref/connes{Connes.PaperFactorClosure.paperSpatialWitness}, and
 \leanref/connes{Connes.PaperFactorClosure.paperGroupFactors_isomorphic}.
-This is the tracial factor equivalence asserted in
-\citet{Proposition 3.4}{zhou2026icc}.}
+This is the #{*}-isomorphism asserted in
+\citet{Proposition 3.4}{zhou2026icc}; the Lean statement also records its
+normality and preservation of the canonical trace.}

--- a/trees/connes-000B.tree
+++ b/trees/connes-000B.tree
@@ -5,7 +5,7 @@
 \tag{lean}
 \tag{property-t}
 \tag{formalization-estimate}
-\title{EJZK route and effort envelope}
+\title{EJZK route and effort estimate}
 \lean/connes{Connes.PaperPropertyT.elementaryGroup}
 \lean{SimpleGraph.lapMatrix}
 
@@ -29,11 +29,11 @@ route estimated below specializes the 2010 elementary-group theorem to
 the implementation layers below. The later root-graded treatment
 supplies broader supporting language.}
 
-\p{Our internal engineering estimate remains \strong{24–28 thousand new Lean lines}, with an
-internal uncertainty envelope of \strong{18–35 thousand}. This is about
-#{0.8}–#{1.5} times the current 23,070-line project and, by our internal
-estimate, \strong{two to four times its present proof-search and engineering
-effort}.}
+\p{Our central estimate remains \strong{24–28 thousand new Lean lines}; a
+wider plausible range is \strong{18–35 thousand}. That range is about
+#{0.8}–#{1.5} times the roughly 23,000 lines already in the project. We
+expect the proof search and engineering to require \strong{two to four times
+the effort of the present formalization}.}
 
 \p{This estimates one explicit, quantitative route that fits the present
 Lean interfaces; it is neither a measure of confidence in the theorem nor a

--- a/trees/connes-000F.tree
+++ b/trees/connes-000F.tree
@@ -7,21 +7,21 @@
 \title{Structure forgetting and equivalence reuse}
 \lean/connes{Connes.CrossedProduct.EquivariantHaarHomeomorph,Connes.CrossedProduct.continuousCrossedClosure_mem_iff}
 
-\p{\strong{Forget structure after it has served its consumer.}
-The Section 3 shear is packaged as an equivariant measure-preserving
-homeomorphism because pullback must preserve continuous coefficients. Its
-canonical projection to an equivariant measurable equivalence is what the full
-#{L^\infty} crossed-product transport consumes.}
+\p{The formalization uses the topology of the fiber shear at an intermediate
+step. It defines the shear as an equivariant measure-preserving homeomorphism
+because pullback must preserve continuous coefficients. Once this density
+argument is complete, the crossed-product theorem uses only the underlying
+equivariant measurable equivalence.}
 
-\p{This one-way forgetting records
-both facts accurately: Zhou's factor argument does not need an additive map,
-while the Lean density bridge legitimately uses the continuity proved in
+\p{Zhou's shear need not be additive, so the Lean proof does not treat it as a
+compact-group automorphism. Continuity is retained for the density argument
+and then forgotten. This matches the two roles separated in
 \citet{Proposition 3.2 and Remark 3.3}{zhou2026icc}.}
 
-\p{\strong{Prefer library equivalences to pointwise cancellation.}
-Mathlib already supplies continuous pullback as a star-algebra equivalence, so
-its surjectivity gives the reverse generator inclusion without a custom
-involutivity proof. Likewise, the inverse law for conjugation by a linear
-isometry equivalence replaces a pointwise operator calculation. These
-replacements shorten the proof while exposing the actual mathematical reason:
-both steps are transport along equivalences.}
+\p{A second lesson came from the reverse inclusion between the generated
+operator algebras. Mathlib's continuous pullback is already a star-algebra
+equivalence, so its surjectivity proves that inclusion without a separate
+involutivity calculation. Similarly, the inverse law for conjugation by a
+linear isometry equivalence replaces a pointwise operator calculation. In
+both cases, an equality that first looked computational follows from the
+inverse laws of an equivalence.}

--- a/trees/connes-000G.tree
+++ b/trees/connes-000G.tree
@@ -9,7 +9,7 @@
 \lean{SimpleGraph.lapMatrix,SimpleGraph.posSemidef_lapMatrix}
 
 \p{The pinned Connes project uses Mathlib revision
-\href{https://github.com/leanprover-community/mathlib4/commit/79cba2e8b532ff92484dfd99f45987bae8b2fd7e}{\code{79cba2e8}}
+\href{https://github.com/leanprover-community/mathlib4/commit/062f1e3da80734a1b911a5c541d78612faf41b99}{\code{062f1e3d}}
 with Lean 4.34.0-rc1. Mathlib supplies the graph Laplacian and its positivity
 theorem, exposed by the declaration links above, but not the
 Ershov–Jaikin-Zapirain graph-of-groups criterion, Kazhdan ratios, root

--- a/trees/connes-000J.tree
+++ b/trees/connes-000J.tree
@@ -13,6 +13,12 @@ record containing the desired conclusion as a field. This “certificate
 isolation” makes \code{#print axioms} meaningful and lets semantic review trace
 each conjunct to the file where its mathematics occurs.}
 
+\p{The nonisomorphism conjunct is stated directly as the absence of a
+multiplicative equivalence, #{\neg\operatorname{Nonempty}(\Gamma_1\simeq
+\Gamma_2)}, rather than through a project-local synonym. This is Lean's
+standard expression for the absence of a group isomorphism, so the result
+proved in Section 6 can be used directly.}
+
 \p{The same assembly pattern applies when a linear paper proof crosses
 topology, analysis, finite computation, and algebraic transport: export small
 propositions from those layers, then combine them only at the theorem

--- a/trees/connes-000K.tree
+++ b/trees/connes-000K.tree
@@ -79,8 +79,11 @@ require special design:}
 
 \ul{
   \li{the square-span certificate implemented in \ref{connes-000U};}
-  \li{the spatial, measurable, and closure bridges in \ref{connes-0007},
-  \ref{connes-000D}, and \ref{connes-000E};}
+  \li{the Fourier-shear proof of factor equivalence: its unitary
+  implementation in \ref{connes-0007}, its normality proof in
+  \ref{connes-001C}, the four conjugation identities in \ref{connes-001D},
+  and the measure and closure arguments in \ref{connes-000D} and
+  \ref{connes-000E};}
   \li{the quantitative detector and qualitative property-(T) boundary in
   \ref{connes-0003}, \ref{connes-000V}, \ref{connes-0004}, and
   \ref{connes-000Y};}
@@ -90,8 +93,9 @@ require special design:}
   \li{the proposition-valued assembly in \ref{connes-0002}.}
 }
 
-\p{Reusable design lessons are isolated in \ref{connes-000A},
-\ref{connes-000F}, and \ref{connes-000J}.}
+\p{The formalization lessons are discussed in \ref{connes-000A},
+\ref{connes-000F}, \ref{connes-001C}, \ref{connes-001D}, and
+\ref{connes-000J}.}
 
 \p{The code has two layers. Reusable group theory, linear
 algebra, topology, measure theory, and operator algebra live in a foundation

--- a/trees/connes-000L.tree
+++ b/trees/connes-000L.tree
@@ -43,7 +43,7 @@ The converse is nontrivial and is not part of the present interface.}
 }
 
 \p{The pinned
-\href{https://github.com/leanprover-community/mathlib4/commit/79cba2e8b532ff92484dfd99f45987bae8b2fd7e}{Mathlib}
+\href{https://github.com/leanprover-community/mathlib4/commit/062f1e3da80734a1b911a5c541d78612faf41b99}{Mathlib}
 already contains separability of spans
 (\leanref{TopologicalSpace.IsSeparable.span}), separability of closures
 (\leanref{TopologicalSpace.IsSeparable.closure}), completeness of closed spans

--- a/trees/connes-0017.tree
+++ b/trees/connes-0017.tree
@@ -8,5 +8,6 @@
 
 \transclude{connes-000A}
 \transclude{connes-000F}
+\transclude{connes-001C}
+\transclude{connes-001D}
 \transclude{connes-000J}
-

--- a/trees/connes-001C.tree
+++ b/trees/connes-001C.tree
@@ -1,0 +1,35 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{operator-algebra}
+\tag{proof-engineering}
+\title{Normality of the factor isomorphism}
+\lean/connes{Connes.IsProjectionSupremum,Connes.StarAlgEquiv.isNormal}
+
+\p{Zhou's Proposition 3.4 identifies the two group factors by combining
+Fourier transform with the fiber shear
+\citet{Proposition 3.4}{zhou2026icc}. In Lean, the resulting star-algebra
+equivalence must also be proved normal. The formalization expresses this by
+requiring the equivalence and its inverse to preserve suprema of projections.}
+
+\p{The definition
+\leanref/connes{Connes.IsProjectionSupremum}
+says that #{p} is a projection, every member of #{S} is a projection below
+#{p}, and #{p} lies below every projection that is an upper bound for #{S}.
+The last condition ranges only over projections, rather than all upper bounds
+as in the stronger ambient predicate \code{IsLUB}.}
+
+\p{For star subalgebras of bounded operators, the usual order on projections
+is characterized by #{p\leq q\iff pq=p}. A star-algebra equivalence preserves
+multiplication, so
+\leanref/connes{Connes.IsProjectionSupremum.map_starAlgEquiv}
+uses this characterization to preserve projection suprema. Applying the same
+argument to the equivalence and its inverse gives
+\leanref/connes{Connes.StarAlgEquiv.isNormal}.}
+
+\p{This refactor leaves the definitions of projection supremum and normal
+star-algebra equivalence independent of bounded operators. The operator order
+appears only in the theorem that applies those definitions to the group
+factors in \ref{connes-0007}.}

--- a/trees/connes-001D.tree
+++ b/trees/connes-001D.tree
@@ -1,0 +1,34 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{operator-algebra}
+\tag{proof-engineering}
+\title{Four conjugation identities}
+
+\p{To identify the generated von Neumann algebras, Lean checks what each
+chosen unitary does to the regular-representation generators. There is one
+calculation for the abelian kernel and one for the acting group in each of
+Zhou's two group constructions, giving four identities in all.}
+
+\p{For the first group, see the kernel
+\leanref/connes/as{calculation}{Connes.PaperGroupFactor.paperGroupFactorUnitaryOne_conj_inl}
+and the acting-group
+\leanref/connes/as{calculation}{Connes.PaperGroupQuotient.paperGroupFactorUnitaryOne_conj_inr}.
+For the second group, see the corresponding kernel
+\leanref/connes/as{calculation}{Connes.PaperGroupFactor.paperGroupFactorUnitaryTwo_conj_inl}
+and acting-group
+\leanref/connes/as{calculation}{Connes.PaperGroupQuotient.paperGroupFactorUnitaryTwo_conj_inr}.}
+
+\p{These calculations spell out a step summarized by the Fourier and
+crossed-product identifications in
+\citet{Proposition 3.4}{zhou2026icc}. They carry the generators through the
+Fubini equivalence for a semidirect product and then through the Fourier
+unitary.}
+
+\p{Most explicit heartbeat settings disappeared during the later proof
+cleanup. These four declarations still require a larger elaboration limit
+because Lean must simplify nested equivalences and pointwise operator
+formulas. The limit controls elaboration time; it adds no mathematical
+assumption.}


### PR DESCRIPTION
## Summary

- synchronize the notes with the projection and theorem refactors in [connes-rigidity #13](https://github.com/utensil/connes-rigidity/pull/13) and the heartbeat cleanup in [#15](https://github.com/utensil/connes-rigidity/pull/15)
- explain normality through projection suprema and the usual operator order on projections
- restore the Fourier-shear discussion to a focused account of what the formalization revealed
- describe the four remaining costly conjugation identities in a separate card, with exact API-documentation links
- update the group-nonisomorphism statement, proof map, Mathlib snapshot, and EJZK effort estimate

## Readability

The normality proof, Fourier-shear lesson, and elaboration note are now separate cards. The revised prose uses standard mathematical terminology and direct descriptions of Lean behavior. Internal review metaphors and compressed engineering labels have been removed. No mathematical claim, literature citation, or declaration link was removed.

## Verification

- `just chk`
- `just build`
- `./lize.sh connes-0001`
- 28-page A4 PDF, with no overfull boxes, unresolved references, or undefined citations
- visual inspection of all affected pages
- all referenced declarations checked against the deployed Lean documentation
- exact-head [GitHub lint and full Forest build](https://github.com/utensil/forest/actions/runs/32629035907) passed

The PR remains human-gated. Auto-merge is disabled.