### PR TITLE
fix: consolidate overlapping daily entries

### DIFF
--- a/extract_week.py
+++ b/extract_week.py
@@ -16,9 +16,10 @@ The extractor moves dated ``\\subtree[YYYY-MM-DD]{...}`` daily blocks from
 logical ``YYYY-Www-links`` subtree.  The root transcludes only the weekly tree.
 
 The operation is deterministic and idempotent. A week may be partial when the
-source diary contains only some of its dates. Re-running after a successful
-extraction validates the generated files without changing them; ``--check``
-makes that validation explicit.
+source diary contains only some of its dates. The link collection is collapsed
+as one boundary, while its dated daily children are expanded once that boundary
+is opened. Re-running after a successful extraction validates the generated
+files without changing them; ``--check`` makes that validation explicit.
 """
 
 from __future__ import annotations
@@ -121,19 +122,22 @@ def repair_spanning_daily_entries(text: str) -> tuple[str, int]:
 
 
 def weekly_tree(week: str, monday: date, entries: list[Entry]) -> str:
-    """Build one weekly file with native prose and an in-file link subtree."""
+    """Build one weekly file with one collapsed collection and open daily children."""
 
     body = "\n\n".join(entry.source for entry in entries)
     return (
         "\\import{macros}\n\n"
-        f"\\title{{Week {monday.isocalendar().week}, {monday.isocalendar().year}}}\n"
+        f"\\title{{{week}}}\n"
         f"\\date{{{monday.isoformat()}}}\n\n"
         "\\scope{\n"
         "  \\put\\transclude/toc{false}\n"
         "  \\put\\transclude/expanded{false}\n"
         f"  \\subtree[{week}-links]{{\n"
-        f"\\title{{Link selections ({week})}}\n\n"
+        f"\\title{{🔗 {week}}}\n\n"
+        "    \\scope{\n"
+        "      \\put\\transclude/expanded{true}\n"
         f"{body}\n"
+        "    }\n"
         "  }\n"
         "}\n"
     )
@@ -178,10 +182,33 @@ def select_week_entries(entries: list[Entry], week_days: tuple[date, ...]) -> li
     return selected
 
 
-def normalize_week_tree(text: str) -> str:
-    """Remove the retired weekly-description template without touching prose."""
+def normalize_week_tree(text: str, week: str) -> str:
+    """Migrate generated collection chrome without touching daily or weekly prose."""
 
-    return text.replace(TEMPLATE_DESCRIPTION, "")
+    normalized = text.replace(TEMPLATE_DESCRIPTION, "")
+    year, week_number, _ = parse_week(week)
+    normalized = normalized.replace(
+        f"\\title{{Week {week_number}, {year}}}", f"\\title{{{week}}}", 1
+    )
+    old_title = f"\\title{{Link selections ({week})}}"
+    new_title = f"\\title{{🔗 {week}}}"
+    normalized = normalized.replace(old_title, new_title)
+
+    scope_marker = "    \\scope{\n      \\put\\transclude/expanded{true}\n"
+    if scope_marker in normalized:
+        return normalized
+
+    subtree_marker = f"  \\subtree[{week}-links]{{"
+    subtree_start = normalized.find(subtree_marker)
+    title_marker = f"{new_title}\n\n"
+    title_start = normalized.find(title_marker, subtree_start)
+    if subtree_start == -1 or title_start == -1:
+        raise ValueError(f"{week}.tree does not have the generated link-collection structure")
+    subtree_close = matching_brace(normalized, subtree_start + len(subtree_marker) - 1)
+    after_title = title_start + len(title_marker)
+    normalized = normalized[:after_title] + scope_marker + normalized[after_title:]
+    subtree_close += len(scope_marker)
+    return normalized[:subtree_close] + "    }\n" + normalized[subtree_close:]
 
 
 def replace_entries_with_weeknote(root: str, entries: list[Entry], week: str) -> str:
@@ -219,10 +246,14 @@ def validate_extracted(
     root_days = {entry.day for entry in find_entries(root)}
     if root_days.intersection(week_days):
         raise ValueError("root still contains extracted daily entries")
+    if f"\\title{{{week}}}" not in week_tree:
+        raise ValueError("weekly tree does not contain the required stem title")
     if f"\\subtree[{week}-links]{{" not in week_tree:
         raise ValueError("weekly tree does not contain its in-file link-selection subtree")
-    if f"\\title{{Link selections ({week})}}" not in week_tree:
+    if f"\\title{{🔗 {week}}}" not in week_tree:
         raise ValueError("weekly tree does not contain the required link-selection title")
+    if "    \\scope{\n      \\put\\transclude/expanded{true}\n" not in week_tree:
+        raise ValueError("weekly link-selection subtree does not expand its daily children")
     found = find_entries(week_tree)
     if not found or any(entry.day not in set(week_days) for entry in found):
         raise ValueError("weekly link-selection subtree contains invalid daily entries")
@@ -265,9 +296,9 @@ def extract_all(source: Path, trees_dir: Path, check: bool) -> int:
     for path in existing_paths:
         _, _, week_days = parse_week(path.stem)
         existing = path.read_text(encoding="utf-8")
-        normalized = normalize_week_tree(existing)
+        normalized = normalize_week_tree(existing, path.stem)
         if check and normalized != existing:
-            raise ValueError(f"{path.name} still contains the retired description template")
+            raise ValueError(f"{path.name} still has retired weekly collection chrome")
         validate_extracted(root, normalized, path.stem, week_days)
         if normalized != existing:
             planned_writes[path] = normalized
@@ -355,13 +386,13 @@ def main() -> int:
 
         if week_path.exists():
             existing = week_path.read_text(encoding="utf-8")
-            normalized = normalize_week_tree(existing)
+            normalized = normalize_week_tree(existing, args.week)
             if args.check and normalized != existing:
-                raise ValueError("weekly tree still contains the retired description template")
+                raise ValueError("weekly tree still has retired collection chrome")
             validate_extracted(root, normalized, args.week, week_days)
             if normalized != existing:
                 write_text(week_path, normalized)
-                print(f"normalized {args.week}: removed retired description template")
+                print(f"normalized {args.week}: updated generated collection chrome")
                 return 0
             print(f"validated {args.week}: already extracted")
             return 0

--- a/justfile
+++ b/justfile
@@ -15,6 +15,9 @@ extract-week WEEK:
 extract-all-weeks:
     uv run extract_week.py --all
 
+weeknote-candidates +PARAMS:
+    uv run weeknote_candidates.py {{PARAMS}}
+
 hn +PARAMS:
     hx `just new {{PARAMS}}`
 

--- a/trees/2024-W01.tree
+++ b/trees/2024-W01.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 1, 2024}
+\title{2024-W01}
 \date{2024-01-01}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W01-links]{
-\title{Link selections (2024-W01)}
+\title{🔗 2024-W01}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-01-01]{\mdnote{2024-01-01}{\tags{#os}
 The readings during this period are reflected in
 
@@ -16,5 +18,6 @@ The readings during this period are reflected in
 - [Studying group algebras with GAP](https://utensil.github.io/blog/posts/group-algebra/)
 - [Notes on Zeon Algebra](https://utensil.github.io/blog/posts/zeon-algebra/)
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W17.tree
+++ b/trees/2024-W17.tree
@@ -1,15 +1,18 @@
 \import{macros}
 
-\title{Week 17, 2024}
+\title{2024-W17}
 \date{2024-04-22}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W17-links]{
-\title{Link selections (2024-W17)}
+\title{🔗 2024-W17}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-04-25]{\mdnote{2024-04-25}{The readings during this period are reflected in [[spin-0001]]. Some are yet to be reflected in [[hopf-0001]].
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W19.tree
+++ b/trees/2024-W19.tree
@@ -1,17 +1,20 @@
 \import{macros}
 
-\title{Week 19, 2024}
+\title{2024-W19}
 \date{2024-05-06}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W19-links]{
-\title{Link selections (2024-W19)}
+\title{🔗 2024-W19}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-05-09]{\mdnote{2024-05-09}{The readings during this period are reflected in [[tt-0001]].
 
 [[uts-000C]] was ported to Forester on 07-22.
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W30.tree
+++ b/trees/2024-W30.tree
@@ -1,15 +1,18 @@
 \import{macros}
 
-\title{Week 30, 2024}
+\title{2024-W30}
 \date{2024-07-22}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W30-links]{
-\title{Link selections (2024-W30)}
+\title{🔗 2024-W30}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-07-27]{\mdnote{2024-07-27}{The readings during this period are yet to be reflected in [[ag-0001]].
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W32.tree
+++ b/trees/2024-W32.tree
@@ -3,7 +3,7 @@
 \title{2024-W32}
 \date{2024-08-05}
 
-\p{The week recorded work on [[uts-000G]] and [[uts-000H]].}
+\p{[[uts-000G]] and [[uts-000H]]. Many experiments on Forester are done, as summarized in [[uts-000X]].}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W32.tree
+++ b/trees/2024-W32.tree
@@ -3,6 +3,8 @@
 \title{2024-W32}
 \date{2024-08-05}
 
+\p{The week recorded work on [[uts-000G]] and [[uts-000H]].}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W32.tree
+++ b/trees/2024-W32.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 32, 2024}
+\title{2024-W32}
 \date{2024-08-05}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W32-links]{
-\title{Link selections (2024-W32)}
+\title{🔗 2024-W32}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-08-11]{\mdnote{2024-08-11}{The readings during this period are reflected in
 
 - [[uts-000G]]
@@ -17,5 +19,6 @@
 Many experiments on Forester are done, as summarized in [[uts-000X]].
 
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W36.tree
+++ b/trees/2024-W36.tree
@@ -3,6 +3,8 @@
 \title{2024-W36}
 \date{2024-09-02}
 
+\p{Work advanced the rendering candidates [[uts-001A]], [[uts-001B]], and [[uts-001C]], with further polishing of [[ca-0001]] and [[uts-000C]]. Reading included \citef{lengyel2024foundations} and a return to \citef{trautman1997clifford}.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W36.tree
+++ b/trees/2024-W36.tree
@@ -3,7 +3,9 @@
 \title{2024-W36}
 \date{2024-09-02}
 
-\p{Work advanced the rendering candidates [[uts-001A]], [[uts-001B]], and [[uts-001C]], with further polishing of [[ca-0001]] and [[uts-000C]]. Reading included \citef{lengyel2024foundations} and a return to \citef{trautman1997clifford}.}
+\p{mark candidates for rendering PDB: [[uts-001A]], [[uts-001B]], and [[uts-001C]]. Polish [[ca-0001]]. Some more on [[uts-000C]].}
+
+\p{Skim through \citef{lengyel2024foundations}. Re-skim \citef{trautman1997clifford}.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W36.tree
+++ b/trees/2024-W36.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 36, 2024}
+\title{2024-W36}
 \date{2024-09-02}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W36-links]{
-\title{Link selections (2024-W36)}
+\title{🔗 2024-W36}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-09-08]{\mdnote{2024-09-08}{\tags{#gpu #render #web #z3}
 - mark candidates for rendering PDB: [[uts-001A]]
 - fail to run Z3 in browser (due to `SharedArrayBuffer` again)
@@ -68,5 +70,6 @@ spaces
   - Pencils and set operators in 3D CGA
   - Factorizations of the Conformal Villarceau Motion
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W37.tree
+++ b/trees/2024-W37.tree
@@ -3,7 +3,9 @@
 \title{2024-W37}
 \date{2024-09-09}
 
-\p{Made a start on [[ag-000G]] and [[ag-000O]], and worked out a shader for [[uts-001D]]. Investigated projects using egg and marked \citef{rossel2024bridging}, \citef{rossel2024equality}, and \citef{bentkamp2023verified} for further reading.}
+\p{make a start on [[ag-000G]]. make [[ag-000O]]. work out shader for [[uts-001D]]. trying to figure out curvature calculation in shaders.}
+
+\p{add egglog and ginac, and streamline the build process of Rust WASM dependencies. reading source of projects using egg; TODO: read more egg papers: \citef{rossel2024bridging}, \citef{rossel2024equality}, \citef{bentkamp2023verified}.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W37.tree
+++ b/trees/2024-W37.tree
@@ -3,6 +3,8 @@
 \title{2024-W37}
 \date{2024-09-09}
 
+\p{Made a start on [[ag-000G]] and [[ag-000O]], and worked out a shader for [[uts-001D]]. Investigated projects using egg and marked \citef{rossel2024bridging}, \citef{rossel2024equality}, and \citef{bentkamp2023verified} for further reading.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W37.tree
+++ b/trees/2024-W37.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 37, 2024}
+\title{2024-W37}
 \date{2024-09-09}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W37-links]{
-\title{Link selections (2024-W37)}
+\title{🔗 2024-W37}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-09-15]{\mdnote{2024-09-15}{\tags{#apl #benchmark #compiler #gpu #os #render #rust #sci #shader #web}
 - found [Compile Julia code to WebAssembly](https://tshort.github.io/WebAssemblyCompiler.jl/stable/)
 - found [SHADERed](https://shadered.org/shaders) as another source of shader examples, particularly some are written in Rust, supported via one of its plugins
@@ -65,5 +67,6 @@
 - add `egglog` and `ginac`, and streamline the build process of Rust WASM dependencies
 - reading source of projects using egg: `jafioti/luminal`, `marcusrossel/lean-egg`, `verified-optimization/CvxLean` etc. TODO: read more egg papers: \citef{rossel2024bridging}\citef{rossel2024equality}\citef{bentkamp2023verified}
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W38.tree
+++ b/trees/2024-W38.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 38, 2024}
+\title{2024-W38}
 \date{2024-09-16}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W38-links]{
-\title{Link selections (2024-W38)}
+\title{🔗 2024-W38}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-09-22]{\mdnote{2024-09-22}{\tags{#os #quantum}
 - skimmed \citef{carosso2018geometric}: "Geometric quantization is an attempt at using the differential-geometric ingredients of classical phase spaces regarded as symplectic manifolds in order to define a corresponding quantum theory."
 - skimmed \citef{pinkall2024differential}: "Unlike the common approach in existing textbooks on this topic, there is a strong focus on variational problems, ranging from elastic curves to surface that minimize area or Willmore functional."
@@ -37,5 +39,6 @@ Make some progress on [[ag-000G]], particularly on mixing 4 elements (formulas, 
   - [pga3.glsl](https://git.sr.ht/~srasu/game_engine/tree/master/item/shader/include/pga3.glsl)
   - [Normals and the Inverse Transpose, Part 1: Grassmann Algebra](https://www.reedbeta.com/blog/normals-inverse-transpose-part-1/) in 2018
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W39.tree
+++ b/trees/2024-W39.tree
@@ -3,7 +3,11 @@
 \title{2024-W39}
 \date{2024-09-23}
 
-\p{Added [[uts-001K]], [[uts-001N]], and [[uts-001P]], while continuing [[ag-000G]] with particular progress on [[ag-001J]].}
+\p{submit a bug report to Chromium. improve the VSCode Forester extension to have Hover, Go to definition, Search by title, and user-defined patterns for triggering completion.}
+
+\p{add [[uts-001N]], [[uts-001P]], and [[uts-001K]]. add live reload. improve various loading and WebGL animation experience.}
+
+\p{more progress on [[ag-000G]], particularly on [[ag-001J]].}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W39.tree
+++ b/trees/2024-W39.tree
@@ -3,6 +3,8 @@
 \title{2024-W39}
 \date{2024-09-23}
 
+\p{Added [[uts-001K]], [[uts-001N]], and [[uts-001P]], while continuing [[ag-000G]] with particular progress on [[ag-001J]].}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W39.tree
+++ b/trees/2024-W39.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 39, 2024}
+\title{2024-W39}
 \date{2024-09-23}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W39-links]{
-\title{Link selections (2024-W39)}
+\title{🔗 2024-W39}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-09-29]{\mdnote{2024-09-29}{\tags{#gpu #os}
 - watch [Coding Adventure: Optimizing a Ray Tracer (by building a BVH)](https://www.youtube.com/watch?v=C1H4zIiCOaI) and learn about the importance of BVH in ray tracing, and [gkjohnson/three-mesh-bvh](https://github.com/gkjohnson/three-mesh-bvh)
 - collect [autodiff in GPU](https://github.com/stars/utensil/lists/ad-gpu)
@@ -54,5 +56,6 @@
 - found [three-gpu-pathtracer](https://github.com/gkjohnson/three-gpu-pathtracer) and related projects, particularly [Physically Based Materials](https://gkjohnson.github.io/three-gpu-pathtracer/example/bundle/index.html), and that [Steve Trettel](https://x.com/stevejtrettel) uses it to render black holes and Hopf fibrations
 - found \citef{yariv2020multiview} ([lioryariv/idr](https://github.com/lioryariv/idr))
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W40.tree
+++ b/trees/2024-W40.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 40, 2024}
+\title{2024-W40}
 \date{2024-09-30}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W40-links]{
-\title{Link selections (2024-W40)}
+\title{🔗 2024-W40}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-10-06]{\mdnote{2024-10-06}{\tags{#apl #os #tla #z3}
 - found [ipe](https://github.com/otfried/ipe) that is used extensively in [tungsteno](https://www.tungsteno.io/post/exp-classification_compact_surfaces/) ([source](https://github.com/TungstenHub/tngt-ipe/tree/master))
 - [Why I use TLA+ and not(TLA+)](https://protocols-made-fun.com/specification/modelchecking/tlaplus/quint/2024/10/05/tla-and-not-tla.html), learn about PlusCal, [Quint](https://quint-lang.org/) and [Apalache](https://apalache-mc.org/) (TLA+ to Z3)
@@ -50,5 +52,6 @@
 - skim [rubik-lean4](https://github.com/vihdzp/rubik-lean4) and be reminded of \citef{bonzio2018nxnxn} and \citef{salkinder2021nxnxn}
 - skim [read-lean](https://github.com/madvorak/read-lean)
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W41.tree
+++ b/trees/2024-W41.tree
@@ -3,6 +3,8 @@
 \title{2024-W41}
 \date{2024-10-07}
 
+\p{Worked on native-land GPU computation and added plans to formal-land. Ported [[uts-001R]] and read \citef{wu2024multi} alongside Mirage.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W41.tree
+++ b/trees/2024-W41.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 41, 2024}
+\title{2024-W41}
 \date{2024-10-07}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W41-links]{
-\title{Link selections (2024-W41)}
+\title{🔗 2024-W41}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-10-11]{\mdnote{2024-10-11}{\tags{#gpu}
 - work on [native-land](https://github.com/utensil/native-land) about GPU computation, see relavant README updates.
 }}
@@ -43,5 +45,6 @@
 - port [[uts-001R]]
 - make [the Railscasts theme for Zed](https://gist.github.com/utensil/a279928e07fe23558fa688ca4d82181e)
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W41.tree
+++ b/trees/2024-W41.tree
@@ -3,7 +3,11 @@
 \title{2024-W41}
 \date{2024-10-07}
 
-\p{Worked on native-land GPU computation and added plans to formal-land. Ported [[uts-001R]] and read \citef{wu2024multi} alongside Mirage.}
+\p{work on native-land about GPU computation, see relevant README updates. add more plans in formal-land.}
+
+\p{recovered Research Codebase Manifesto from Lean-MLIR. recovered quotes from CICM 2020 Slack chat. add CI with WebGPU on Mac and Ubuntu thanks to llvmpipe, lavapipe, Vulkan SDK, and Mesa setup.}
+
+\p{\citef{wu2024multi} and learn about Mirage. port [[uts-001R]].}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W42.tree
+++ b/trees/2024-W42.tree
@@ -3,7 +3,11 @@
 \title{2024-W42}
 \date{2024-10-14}
 
-\p{Worked on native-land's rust-gpu path and on formal-land's multi-toolchain Lean infrastructure, while moving to a Neovim setup for Rust, Lean, and Forester. Wrote [[uts-002F]]. Reading traced black-hole rendering through \citef{james2015gravitational} and \citef{james2015visualizing}, and surveyed geometric-algebra, sparse-tensor, and e-graph references including \citef{fang2024identifying}, \citef{low2023gafro}, and \citef{zhao2024felix}.}
+\p{work on native-land, trying to make rust-gpu fully work. work on formal-land, trying to establish the infrastructure to explore multiple Lean 4 projects with independent toolchains and dependencies. switching to Neovim, make it work for Rust, Lean, and Forester. write [[uts-002F]].}
+
+\p{initial citation trace for \citef{james2015gravitational} and \citef{james2015visualizing}. skimmed \citef{fang2024identifying}. learn about \citef{haftmann2013haskell}: the type class for Isabelle, but its expressiveness is limited.}
+
+\p{skim \citef{low2023gafro}, a good library and benchmark, and \citef{eid2024developing}, with good references but in C#{\#}. skim \citef{sharma2024comprehensive}, an interesting area with sparse tensors as an in-memory database in mind. skim \citef{zhao2024felix}, which uses egg.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W42.tree
+++ b/trees/2024-W42.tree
@@ -3,6 +3,8 @@
 \title{2024-W42}
 \date{2024-10-14}
 
+\p{Worked on native-land's rust-gpu path and on formal-land's multi-toolchain Lean infrastructure, while moving to a Neovim setup for Rust, Lean, and Forester. Wrote [[uts-002F]]. Reading traced black-hole rendering through \citef{james2015gravitational} and \citef{james2015visualizing}, and surveyed geometric-algebra, sparse-tensor, and e-graph references including \citef{fang2024identifying}, \citef{low2023gafro}, and \citef{zhao2024felix}.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W42.tree
+++ b/trees/2024-W42.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 42, 2024}
+\title{2024-W42}
 \date{2024-10-14}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W42-links]{
-\title{Link selections (2024-W42)}
+\title{🔗 2024-W42}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-10-18]{\mdnote{2024-10-18}{\tags{#formal #gpu #lean #neovim #rust}
 - work on native-land, trying to make rust-gpu fully work
 - work on formal-land, trying to establish the infrastructure to explore multiple Lean 4 projects with independent toolchains and dependencies
@@ -39,5 +41,6 @@
 - SDQLite \citef{schleich2023optimizing} (based on [SDQL](https://github.com/edin-dal/sdql)) is an intermediate language that expresses sparse tensor workloads by separating the tensoropt computations from the storage formats
 - reminds me of \citef{wu2024multi}
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W43.tree
+++ b/trees/2024-W43.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 43, 2024}
+\title{2024-W43}
 \date{2024-10-21}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W43-links]{
-\title{Link selections (2024-W43)}
+\title{🔗 2024-W43}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-10-25]{\mdnote{2024-10-25}{\tags{#benchmark #formal #rust #tui}
 - work on native-land
     - trying to make GA and math benchmark work, also evaluating the feasibility of benchmarking C++ libraries from Rust
@@ -16,5 +18,6 @@
 - work on formal-land, make Verso work
 - debug various TUI tools
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W43.tree
+++ b/trees/2024-W43.tree
@@ -3,7 +3,7 @@
 \title{2024-W43}
 \date{2024-10-21}
 
-\p{Continued native-land work and made formal-land's Verso setup work.}
+\p{work on native-land, trying to make GA and math benchmark work, also evaluating the feasibility of benchmarking C++ libraries from Rust; pass CI on runpod. work on formal-land, make Verso work. debug various TUI tools.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W43.tree
+++ b/trees/2024-W43.tree
@@ -3,6 +3,8 @@
 \title{2024-W43}
 \date{2024-10-21}
 
+\p{Continued native-land work and made formal-land's Verso setup work.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W44.tree
+++ b/trees/2024-W44.tree
@@ -1,16 +1,19 @@
 \import{macros}
 
-\title{Week 44, 2024}
+\title{2024-W44}
 \date{2024-10-28}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W44-links]{
-\title{Link selections (2024-W44)}
+\title{🔗 2024-W44}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-10-30]{\mdnote{2024-10-30}{\tags{#✍️}
 - finish [[uts-002H]]
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W44.tree
+++ b/trees/2024-W44.tree
@@ -3,7 +3,7 @@
 \title{2024-W44}
 \date{2024-10-28}
 
-\p{Finished [[uts-002H]].}
+\p{finish [[uts-002H]].}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W44.tree
+++ b/trees/2024-W44.tree
@@ -3,6 +3,8 @@
 \title{2024-W44}
 \date{2024-10-28}
 
+\p{Finished [[uts-002H]].}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W45.tree
+++ b/trees/2024-W45.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 45, 2024}
+\title{2024-W45}
 \date{2024-11-04}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W45-links]{
-\title{Link selections (2024-W45)}
+\title{🔗 2024-W45}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-11-10]{\mdnote{2024-11-10}{\tags{#idea #lean #rust #wasm}
 - contemplate the idea of better file management with Rust
 - meet datachain, extism, revisit mage-ai, should evaluate kestra, contemplate the idea of ML orchestration with Rust where each node is a WASM plugin, [BAML](https://github.com/BoundaryML/baml) has some potential
@@ -36,5 +38,6 @@
 - [RustGPU: Pros&Cons](https://github.com/schell/renderling/blob/main/NOTES.md#cons--limititions--gotchas), the author [becomes a maintainer of RustGPU](https://rust-gpu.github.io/blog/2024/11/06/new-maintainers/)
 - found [VR Schwarzschild black hole shader (works with SPS and SPS-I)](https://gist.github.com/MichaelMoroz/b35d456056f3b958962ffb93f37ac55c)
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W46.tree
+++ b/trees/2024-W46.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 46, 2024}
+\title{2024-W46}
 \date{2024-11-11}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W46-links]{
-\title{Link selections (2024-W46)}
+\title{🔗 2024-W46}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-11-12]{\mdnote{2024-11-12}{\tags{#citation #lean #os #rust #✍️}
 - experiments on using [aider](https://aider.chat/) for LLM assisted project-level pair programming
     - [this PR](https://github.com/utensil/lean4_jupyter/pull/2) is a most extensive one
@@ -22,5 +24,6 @@
 - found \citef{michor2008topics} and \citef{milne2012algebraic}, helpful for [[ag-0001]]
 - plan to read \citef{mosto2024templex}
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W46.tree
+++ b/trees/2024-W46.tree
@@ -3,6 +3,8 @@
 \title{2024-W46}
 \date{2024-11-11}
 
+\p{Collected \citef{michor2008topics} and \citef{milne2012algebraic} for [[ag-0001]], and planned a reading of \citef{mosto2024templex}.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W46.tree
+++ b/trees/2024-W46.tree
@@ -3,7 +3,7 @@
 \title{2024-W46}
 \date{2024-11-11}
 
-\p{Collected \citef{michor2008topics} and \citef{milne2012algebraic} for [[ag-0001]], and planned a reading of \citef{mosto2024templex}.}
+\p{found \citef{riccardo2024towards}, Cat for DL. found \citef{michor2008topics} and \citef{milne2012algebraic}, helpful for [[ag-0001]]. plan to read \citef{mosto2024templex}.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W47.tree
+++ b/trees/2024-W47.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 47, 2024}
+\title{2024-W47}
 \date{2024-11-18}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W47-links]{
-\title{Link selections (2024-W47)}
+\title{🔗 2024-W47}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-11-23]{\mdnote{2024-11-23}{- 🚧 busy
 }}
 
@@ -33,5 +35,6 @@
     - \citef{pepe2024staresnet}
     - \citef{filimoshina2024note}
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W48.tree
+++ b/trees/2024-W48.tree
@@ -3,6 +3,8 @@
 \title{2024-W48}
 \date{2024-11-25}
 
+\p{Tried DeepSeek Deep Think and added [[uts-002I]].}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2024-W48.tree
+++ b/trees/2024-W48.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 48, 2024}
+\title{2024-W48}
 \date{2024-11-25}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W48-links]{
-\title{Link selections (2024-W48)}
+\title{🔗 2024-W48}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-12-01]{\mdnote{2024-12-01}{\tags{#git #os #render #rust}
 - try Deepseek Deep Think, add [[uts-002I]]
 - rethinking self-hosted git repos, CI, and pages, found
@@ -39,5 +41,6 @@
 \subtree[2024-11-27]{\mdnote{2024-11-27}{\tags{#haskell}
 - [Haskell: A Great Procedural Language](https://entropicthoughts.com/haskell-procedural-programming)
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W48.tree
+++ b/trees/2024-W48.tree
@@ -3,7 +3,7 @@
 \title{2024-W48}
 \date{2024-11-25}
 
-\p{Tried DeepSeek Deep Think and added [[uts-002I]].}
+\p{try DeepSeek Deep Think, add [[uts-002I]]. learn a bit more about Slang, V, and Lobster.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2024-W50.tree
+++ b/trees/2024-W50.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 50, 2024}
+\title{2024-W50}
 \date{2024-12-09}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W50-links]{
-\title{Link selections (2024-W50)}
+\title{🔗 2024-W50}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-12-13]{\mdnote{2024-12-13}{- recieved [pygae/galgebra#529](https://github.com/pygae/galgebra/issues/529) about Shirokov inverse, read \citef{shirokov2021computing}
 }}
 
@@ -31,5 +33,6 @@
 \subtree[2024-12-09]{\mdnote{2024-12-09}{- 🚧 busy
 - reading 📘*Zen and the Art of Motorcycle Maintenance: An Inquiry into Values*
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W51.tree
+++ b/trees/2024-W51.tree
@@ -1,18 +1,21 @@
 \import{macros}
 
-\title{Week 51, 2024}
+\title{2024-W51}
 \date{2024-12-16}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W51-links]{
-\title{Link selections (2024-W51)}
+\title{🔗 2024-W51}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-12-17]{\mdnote{2024-12-17}{\tags{#os}
 - 🎿🪂
 - reading Wang Guowei's philosophical works
 - [Ghostty Is Native—So What?](https://gpanders.com/blog/ghostty-is-native-so-what/)
 }}
-  }
+      }
+}
 }

--- a/trees/2024-W52.tree
+++ b/trees/2024-W52.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 52, 2024}
+\title{2024-W52}
 \date{2024-12-23}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2024-W52-links]{
-\title{Link selections (2024-W52)}
+\title{🔗 2024-W52}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2024-12-27]{\mdnote{2024-12-27}{\tags{#rust #zig}
 - [When Zig is safer and faster than Rust](https://zackoverflow.dev/writing/unsafe-rust-vs-zig)
     - and [How to Actually Write C](https://zackoverflow.dev/writing/how-to-actually-write-c)
@@ -19,5 +21,6 @@
 
 \subtree[2024-12-24]{\mdnote{2024-12-24}{- found \citef{hutter2024introduction}
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W01.tree
+++ b/trees/2025-W01.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 1, 2025}
+\title{2025-W01}
 \date{2024-12-30}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W01-links]{
-\title{Link selections (2025-W01)}
+\title{🔗 2025-W01}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-01-01]{\mdnote{2025-01-01}{- 📦 move to new office and get used to everything
 - 🗓️ making plans for the new year
 }}
@@ -22,5 +24,6 @@
     - previously I was reluctant to use stow as it's written in Perl
     - maybe I'll also try `brew bundle` too
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W02.tree
+++ b/trees/2025-W02.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 2, 2025}
+\title{2025-W02}
 \date{2025-01-06}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W02-links]{
-\title{Link selections (2025-W02)}
+\title{🔗 2025-W02}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-01-11]{\mdnote{2025-01-11}{\tags{#os #physics #quantum #render #rust #zig}
 - articles on lobste.rs
     - [Elementary Water Rendering](https://jysandy.github.io/posts/gradient-water-rendering/)
@@ -26,5 +28,6 @@
 - wish to write more serious Zig in new year, found [Mach](https://machengine.org/)
 - found *Histoire de la philosophie* by Émile Bréhier
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W04.tree
+++ b/trees/2025-W04.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 4, 2025}
+\title{2025-W04}
 \date{2025-01-20}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W04-links]{
-\title{Link selections (2025-W04)}
+\title{🔗 2025-W04}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-01-23]{\mdnote{2025-01-23}{\tags{#news #typst #✍️}
 - busy with Spring Festival
 - WeRead books and wrote some reviews
@@ -19,5 +21,6 @@
 }
 
 }
-  }
+      }
+}
 }

--- a/trees/2025-W09.tree
+++ b/trees/2025-W09.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 9, 2025}
+\title{2025-W09}
 \date{2025-02-24}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W09-links]{
-\title{Link selections (2025-W09)}
+\title{🔗 2025-W09}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-02-27]{\mdnote{2025-02-27}{\tags{#raymarching #rss}
 - [Raymarching The Gunk](https://jarllarsson.github.io/gen/gunkraymarcher.html)
 }}
@@ -24,5 +26,6 @@
 - [Serving local LLMs with MLX](https://kconner.com/2025/02/17/running-local-llms-with-mlx.html)
 - [Enough with all the Raft](https://www.hytradboi.com/2025/2016d6c4-b08d-40b3-af2f-67926ca8521f-enough-with-all-the-raft)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W10.tree
+++ b/trees/2025-W10.tree
@@ -1,17 +1,20 @@
 \import{macros}
 
-\title{Week 10, 2025}
+\title{2025-W10}
 \date{2025-03-03}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W10-links]{
-\title{Link selections (2025-W10)}
+\title{🔗 2025-W10}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-03-07]{\mdnote{2025-03-07}{\tags{#rust #zig}
 - found some readings for Rust and Zig, see [native-land commits](https://github.com/utensil/native-land/commit/e1ced218d8ad3365acca745e38279306644e475f)
 
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W11.tree
+++ b/trees/2025-W11.tree
@@ -3,6 +3,8 @@
 \title{2025-W11}
 \date{2025-03-10}
 
+\p{Learned from \citef{helmstetter2013minimal} about testing whether a multivector is a versor, in connection with the galgebra issue.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W11.tree
+++ b/trees/2025-W11.tree
@@ -3,7 +3,7 @@
 \title{2025-W11}
 \date{2025-03-10}
 
-\p{Learned from \citef{helmstetter2013minimal} about testing whether a multivector is a versor, in connection with the galgebra issue.}
+\p{learn about \citef{helmstetter2013minimal}, a paper about determining whether a multivector is a versor, as versors are invertible lipschitzian elements, related to galgebra issue 533.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W11.tree
+++ b/trees/2025-W11.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 11, 2025}
+\title{2025-W11}
 \date{2025-03-10}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W11-links]{
-\title{Link selections (2025-W11)}
+\title{🔗 2025-W11}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-03-13]{\mdnote{2025-03-13}{- learn about \citef{helmstetter2013minimal}, a paper about determining whether a multivector is a versor, as versors are invertible lipschitzian elements, related to [galgebra#533](https://github.com/pygae/galgebra/issues/533)
 }}
 
@@ -28,5 +30,6 @@
         - \citef{guo2025deepseek}
         - \citef{li2023camel} for [Owl](https://github.com/camel-ai/owl)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W12.tree
+++ b/trees/2025-W12.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 12, 2025}
+\title{2025-W12}
 \date{2025-03-17}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W12-links]{
-\title{Link selections (2025-W12)}
+\title{🔗 2025-W12}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-03-18]{\mdnote{2025-03-18}{\tags{#ocaml #os #racket #tui}
 - found [Rhombus](https://rhombus-lang.org/), a Racket without parenthesis
 - [Writing a SIGGRAPH paper (for fun) (2020)](https://www.mattkeeter.com/projects/siggraph/)
@@ -17,5 +19,6 @@
 - found \citef{murphy2024reinforcement}, some ML books by the same author are [on Github](https://github.com/AniruddhaChattopadhyay/Books)
 - found \citef{prasolov1995intuitive}
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W13.tree
+++ b/trees/2025-W13.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 13, 2025}
+\title{2025-W13}
 \date{2025-03-24}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W13-links]{
-\title{Link selections (2025-W13)}
+\title{🔗 2025-W13}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-03-30]{\mdnote{2025-03-30}{\tags{#agent #idea}
 - work on exporting Discord chat and feeding them to [RAG](https://github.com/stars/utensil/lists/llm-kb), the result is not quite ideal
 - try DeepSeek-v3-0324, but still not as good as Claude 3.5 for my use cases
@@ -41,5 +43,6 @@
 - [attention is logarithmic, actually](https://supaiku.com/attention-is-logarithmic)
 - \citef{roelfs2025willing}, the [Kingdon](https://github.com/tBuLi/kingdon) paper
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W13.tree
+++ b/trees/2025-W13.tree
@@ -3,6 +3,8 @@
 \title{2025-W13}
 \date{2025-03-24}
 
+\p{Wrote [[uts-0167]], reflecting on fragmented learning and the move from daily capture toward a more coherent weekly practice.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W13.tree
+++ b/trees/2025-W13.tree
@@ -3,7 +3,7 @@
 \title{2025-W13}
 \date{2025-03-24}
 
-\p{Wrote [[uts-0167]], reflecting on fragmented learning and the move from daily capture toward a more coherent weekly practice.}
+\p{work on exporting Discord chat and feeding them to RAG; the result is not quite ideal. learn more about Elixir, including the Axon and Numerical Elixir ecosystem. wrote [[uts-0167]].}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W14.tree
+++ b/trees/2025-W14.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 14, 2025}
+\title{2025-W14}
 \date{2025-03-31}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W14-links]{
-\title{Link selections (2025-W14)}
+\title{🔗 2025-W14}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-04-05]{\mdnote{2025-04-05}{\tags{#os #rust}
 - [Atproto Ethos](https://atproto.com/articles/atproto-ethos)
 - [BPF From Scratch In Rust](https://yeet.cx/blog/bpf-from-scratch-in-rust/)
@@ -61,5 +63,6 @@
 - [Expressing Japanese Grammar Through TypeScript Type System](https://github.com/typedgrammar/typed-japanese/blob/main/blog.md)
     - I really wanted this for French, except for not in TypeScript, but something Rust-like
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W15.tree
+++ b/trees/2025-W15.tree
@@ -3,6 +3,8 @@
 \title{2025-W15}
 \date{2025-04-07}
 
+\p{Wrote [[uts-016A]] and read an account of Erlang's design beyond lightweight processes and message passing.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W15.tree
+++ b/trees/2025-W15.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 15, 2025}
+\title{2025-W15}
 \date{2025-04-07}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W15-links]{
-\title{Link selections (2025-W15)}
+\title{🔗 2025-W15}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-04-13]{\mdnote{2025-04-13}{\tags{#compiler #ebpf #elixir #lean #tui #zig}
 - looking for Zig libraries for TUI, `io_uring`, eBPF, scripting, e-graph
     - the candidates are `libvaxis`, `libxev`, `zbpf`, `Cyber`, `zegg`, respectively
@@ -63,5 +65,6 @@
 - [Model error](https://surfingcomplexity.blog/2025/04/06/model-error/)
 - wrote [[uts-016A]]
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W15.tree
+++ b/trees/2025-W15.tree
@@ -3,7 +3,7 @@
 \title{2025-W15}
 \date{2025-04-07}
 
-\p{Wrote [[uts-016A]] and read an account of Erlang's design beyond lightweight processes and message passing.}
+\p{wrote [[uts-016A]]. Erlang’s not about lightweight processes and message passing; further reading: \citef{armstrong2003making}.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W16.tree
+++ b/trees/2025-W16.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 16, 2025}
+\title{2025-W16}
 \date{2025-04-14}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W16-links]{
-\title{Link selections (2025-W16)}
+\title{🔗 2025-W16}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-04-19]{\mdnote{2025-04-19}{\tags{#elixir #formal #os}
 - [Common shell script mistakes](https://www.pixelbeat.org/programming/shell_script_mistakes.html)
 - [Four Years of Jai](https://smarimccarthy.is/posts/2024-12-02-four-years-of-jai/)
@@ -89,5 +91,6 @@
     - and it would be insteresting to see the visualization for `monoio`
 - [Solving One Million Sudoku Puzzles per hour](https://www.miakoring.de/blog/sudoku) in Swift
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W17.tree
+++ b/trees/2025-W17.tree
@@ -3,6 +3,8 @@
 \title{2025-W17}
 \date{2025-04-21}
 
+\p{Explored alternative language-model architectures and interval-arithmetic implicit surfaces, with pointers gathered for [[ag-000G]].}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W17.tree
+++ b/trees/2025-W17.tree
@@ -3,7 +3,9 @@
 \title{2025-W17}
 \date{2025-04-21}
 
-\p{Explored alternative language-model architectures and interval-arithmetic implicit surfaces, with pointers gathered for [[ag-000G]].}
+\p{made a start on improving PDF organization in and out of MarginNote. wish to learn more about other architectures of LMs, including \citef{ma2025bitnet}, \citef{zhao2025d1}, \citef{wang2025m1}, \citef{peng2025rwkv}, and \citef{warner2024smarter}.}
+
+\p{watched Implicit Surfaces using interval arithmetic to evaluate SDFs; the ideas behind Fidget and \citef{keeter2020massively} are well explained, GOAT-level inspiring, and should be further explored in [[ag-000G]].}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W17.tree
+++ b/trees/2025-W17.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 17, 2025}
+\title{2025-W17}
 \date{2025-04-21}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W17-links]{
-\title{Link selections (2025-W17)}
+\title{🔗 2025-W17}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-04-27]{\mdnote{2025-04-27}{\tags{#apl #news #os #web}
 - found [APL Cultivations](https://xpqz.github.io/cultivations/Intro.html)
 - found [Dive into Systems (2020)](https://diveintosystems.org/)
@@ -97,5 +99,6 @@
 - note more about Taiji and practice more
 }
 }
-  }
+      }
+}
 }

--- a/trees/2025-W18.tree
+++ b/trees/2025-W18.tree
@@ -3,6 +3,8 @@
 \title{2025-W18}
 \date{2025-04-28}
 
+\p{Wrote [[uts-016B]]. Reading included \citef{ren2025deepseekproverv2} and a skim of \citef{lipman2024flow}.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W18.tree
+++ b/trees/2025-W18.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 18, 2025}
+\title{2025-W18}
 \date{2025-04-28}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W18-links]{
-\title{Link selections (2025-W18)}
+\title{🔗 2025-W18}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-05-04]{\mdnote{2025-05-04}{\tags{#git #interop #lean #os}
 - found [pyonji](https://git.sr.ht/~emersion/pyonji), a tool to support sr.ht style e-mail patches
 - [Git: programmatic staging](https://choly.ca/post/git-programmatic-staging/)
@@ -69,5 +71,6 @@
     - [Notes about Raft's paper](https://pierrezemb.fr/posts/notes-about-raft/)
 - [toycalculator, an MLIR/LLVM compiler experiment.](https://peeterjoot.com/2025/04/27/toycalculator-an-mlir-llvm-compiler-experiment/)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W18.tree
+++ b/trees/2025-W18.tree
@@ -3,7 +3,7 @@
 \title{2025-W18}
 \date{2025-04-28}
 
-\p{Wrote [[uts-016B]]. Reading included \citef{ren2025deepseekproverv2} and a skim of \citef{lipman2024flow}.}
+\p{wrote [[uts-016B]]. \citef{ren2025deepseekproverv2}; notes on LM could be based on \citef{tie2025survey} and the following papers related to R1. found critics of R1 and GRPO: \citef{liu2025understanding} and \citef{yue2025does}. skimmed \citef{lipman2024flow}.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W19.tree
+++ b/trees/2025-W19.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 19, 2025}
+\title{2025-W19}
 \date{2025-05-05}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W19-links]{
-\title{Link selections (2025-W19)}
+\title{🔗 2025-W19}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-05-09]{\mdnote{2025-05-09}{\tags{#os #rust #zig}
 - [Memory Safety Features in Zig](https://gencmurat.com/en/posts/memory-safety-features-in-zig/)
     - very well summarized, with great examples
@@ -99,5 +101,6 @@
     - I'm amazed that the author is using GPU to simulate physics for realtime audio
 }
 }
-  }
+      }
+}
 }

--- a/trees/2025-W19.tree
+++ b/trees/2025-W19.tree
@@ -36,17 +36,7 @@
 - got zig to work inside lima with minimal setup
 }}
 
-\subtree[2025-05-07]{\mdnote{2025-05-07}{\tags{#os #rust #tui #web #zig}
-- [Zig’s Low-Level Safety Features Leave Rust in the Dust](https://www.reddit.com/r/Zig/comments/1kgk07m/zigs_lowlevel_safety_features_leave_rust_in_the/)
-- [Zig defer Patterns](https://matklad.github.io/2024/03/21/defer-patterns.html)
-- [Glossary Web Component](https://dbushell.com/2025/05/07/glossary-web-component/)
-- [Recreating an iOS Animation with GLSL (interactive tutorial)](https://nmattia.com/posts/2025-05-07-airpods-hearing-test-animation/)
-- found [Argo CD - Declarative Continuous Delivery for k8s](https://github.com/argoproj/argo-cd)
-- found [bash/POSIX-compatible shell implemented in Rust](https://github.com/reubeno/brush)
-- found [nnd: A TUI alternative to gdb](https://github.com/al13n321/nnd)
-}}
-
-\subtree[2025-05-07-2]{\mdnote{2025-05-07}{\tags{#ebpf #os #rust #tui #zig}
+\subtree[2025-05-07]{\mdnote{2025-05-07}{\tags{#ebpf #os #rust #tui #zig}
 - [Zig’s Low-Level Safety Features Leave Rust in the Dust](https://www.reddit.com/r/Zig/comments/1kgk07m/zigs_lowlevel_safety_features_leave_rust_in_the/)
 - found [Parallel, Concurrent and Distributed Programming](https://ilyasergey.net/YSC4231/) in Scala
 - found [nnd: A TUI alternative to gdb](https://github.com/al13n321/nnd)
@@ -65,6 +55,11 @@
     - [KernelScript eBPF-centric programming language](https://github.com/multikernel/kernelscript) ([on HN](https://news.ycombinator.com/item?id=44722518)) #lang
     - [OOMProf - Take a heap profile just before OOMkill using eBPF](https://lobste.rs/s/cknohu) #chaos
 - found [alternative open source front-ends for popular internet platforms](https://github.com/mendel5/alternative-front-ends)
+- [Zig defer Patterns](https://matklad.github.io/2024/03/21/defer-patterns.html)
+- [Glossary Web Component](https://dbushell.com/2025/05/07/glossary-web-component/)
+- [Recreating an iOS Animation with GLSL (interactive tutorial)](https://nmattia.com/posts/2025-05-07-airpods-hearing-test-animation/)
+- found [Argo CD - Declarative Continuous Delivery for k8s](https://github.com/argoproj/argo-cd)
+- found [bash/POSIX-compatible shell implemented in Rust](https://github.com/reubeno/brush)
 }}
 
 \subtree[2025-05-06]{

--- a/trees/2025-W20.tree
+++ b/trees/2025-W20.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 20, 2025}
+\title{2025-W20}
 \date{2025-05-12}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W20-links]{
-\title{Link selections (2025-W20)}
+\title{🔗 2025-W20}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-05-18]{\mdnote{2025-05-18}{\tags{#apl #compiler #game #gpu #os #physics #quantum #shader #zig}
 - found [Algorithms by Jeff Erickson (2019)](https://jeffe.cs.illinois.edu/teaching/algorithms)
 - \citef{van2025comparing}
@@ -134,5 +136,6 @@
 - [Private Internet (2024)](https://kevincox.ca/2024/08/16/private-internet/)
 - [A tool to verify estimates, II: a flexible proof assistant](https://terrytao.wordpress.com/2025/05/09/a-tool-to-verify-estimates-ii-a-flexible-proof-assistant/)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W21.tree
+++ b/trees/2025-W21.tree
@@ -3,6 +3,8 @@
 \title{2025-W21}
 \date{2025-05-19}
 
+\p{Collected a paper set for [[uts-016E]].}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W21.tree
+++ b/trees/2025-W21.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 21, 2025}
+\title{2025-W21}
 \date{2025-05-19}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W21-links]{
-\title{Link selections (2025-W21)}
+\title{🔗 2025-W21}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-05-25]{\mdnote{2025-05-25}{\tags{#formal #haskell #lean #ocaml #os #rust #zig}
 - [Having your compile-time cake and eating it too](https://0x44.xyz/blog/comptime-1)
     - [Hindley-Milner (HM)](\verb>>>|https://en.wikipedia.org/wiki/Hindley%E2%80%93Milner_type_system>>>), the most popular human-friendly type system, used in Swift, Rust, Scala, Haskell, OCaml etc.
@@ -122,5 +124,6 @@
 - found [TestDesiderata](https://testdesiderata.com/)
 - found [macOS VMs in a Docker Container](https://github.com/trycua/cua/tree/main/libs/lumier)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W21.tree
+++ b/trees/2025-W21.tree
@@ -3,7 +3,7 @@
 \title{2025-W21}
 \date{2025-05-19}
 
-\p{Collected a paper set for [[uts-016E]].}
+\p{learn about Glean, a system for collecting, deriving and querying facts about source code. found many papers, see [[uts-016E]].}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W22.tree
+++ b/trees/2025-W22.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 22, 2025}
+\title{2025-W22}
 \date{2025-05-26}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W22-links]{
-\title{Link selections (2025-W22)}
+\title{🔗 2025-W22}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-06-01]{\mdnote{2025-06-01}{\tags{#git #lean #neovim #os #sec #tla #zig}
 - [Tools built on tree-sitter's concrete syntax trees](https://www.scannedinavian.com/tools-built-on-tree-sitters-concrete-syntax-trees.html)
     - found [ssr.nvim](https://github.com/cshuaimin/ssr.nvim), Structural search and replace for Neovim, seems more convenient than `ast-grep`
@@ -106,5 +108,6 @@
     - [On File Formats](https://solhsa.com/oldernews2025.html#ON-FILE-FORMATS)
     - [What Works (and Doesn't) Selling Formal Methods](https://www.galois.com/articles/what-works-and-doesnt-selling-formal-methods)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W22.tree
+++ b/trees/2025-W22.tree
@@ -3,7 +3,7 @@
 \title{2025-W22}
 \date{2025-05-26}
 
-\p{Learned two new Rubik's-cube formulas, recorded in [[uts-016I]] and [[uts-016H]].}
+\p{learn 2 new formulas for Rubik's cube, see [[uts-016I]] and [[uts-016H]]. learn about uzi from LLM Codegen go Brrr.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W22.tree
+++ b/trees/2025-W22.tree
@@ -3,6 +3,8 @@
 \title{2025-W22}
 \date{2025-05-26}
 
+\p{Learned two new Rubik's-cube formulas, recorded in [[uts-016I]] and [[uts-016H]].}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W23.tree
+++ b/trees/2025-W23.tree
@@ -3,6 +3,8 @@
 \title{2025-W23}
 \date{2025-06-02}
 
+\p{Continued learning speed solving for the Rubik's cube and recorded it in [[uts-016J]].}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W23.tree
+++ b/trees/2025-W23.tree
@@ -3,7 +3,7 @@
 \title{2025-W23}
 \date{2025-06-02}
 
-\p{Continued learning speed solving for the Rubik's cube and recorded it in [[uts-016J]].}
+\p{learning speed solving Rubik's cube, see [[uts-016J]]. learn about pulp and its usage in faer; learn about Zig pointer types, align(64), and noalias.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W23.tree
+++ b/trees/2025-W23.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 23, 2025}
+\title{2025-W23}
 \date{2025-06-02}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W23-links]{
-\title{Link selections (2025-W23)}
+\title{🔗 2025-W23}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-06-08]{\mdnote{2025-06-08}{\tags{#agent #news #optimization #os #rust #sec #simd #web #zig}
 - [Vanishing zeroes for geometric algebra in Rust](https://dotat.at/@/2020-12-06-vanishing-zeroes-for-geometric-algebra-in-rust.html)
 - [A plan for SIMD](https://linebender.org/blog/a-plan-for-simd/)
@@ -141,5 +143,6 @@
     - [WebAIM: Up and Coming ARIA](https://webaim.org/blog/up-and-coming-aria/)
         - learn about aria features and roles, it also has demo
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W23.tree
+++ b/trees/2025-W23.tree
@@ -85,9 +85,6 @@
     - [Fuzzer Blind Spots (Meet Jepsen!)](https://tigerbeetle.com/blog/2025-06-06-fuzzer-blind-spots-meet-jepsen/)
     - [Jepsen: TigerBeetle 0.16.11](https://jepsen.io/analyses/tigerbeetle-0.16.11)
     - [The unreasonable effectiveness of fuzzing for porting programs](https://rjp.io/blog/2025-06-17-unreasonable-effectiveness-of-fuzzing) ([on HN](https://news.ycombinator.com/item?id=44311241)) ([on lobste.rs](https://lobste.rs/s/zgoytt))
-}}
-
-\subtree[2025-06-06-2]{\mdnote{2025-06-06}{\tags{#apl #game #lean #shader #tla #vulkan #web #zig}
 - [AI is a gamechanger for TLA+ users](https://buttondown.com/hillelwayne/archive/ai-is-a-gamechanger-for-tla-users/)
 - [In which I have Opinions about parsing and grammars](https://www.chiark.greenend.org.uk/~sgtatham/quasiblog/parsing/)
 - [Experimenting with no-build Web Applications](https://andregarzia.com/2025/06/experimenting-with-no-build-web-applications.html)

--- a/trees/2025-W24.tree
+++ b/trees/2025-W24.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 24, 2025}
+\title{2025-W24}
 \date{2025-06-09}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W24-links]{
-\title{Link selections (2025-W24)}
+\title{🔗 2025-W24}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-06-15]{\mdnote{2025-06-15}{\tags{#os #physics #raymarching}
 - [Q-learning is not yet scalable](https://seohong.me/blog/q-learning-is-not-yet-scalable/)
 - found [Todo.txt](http://todotxt.org/)
@@ -348,5 +350,6 @@
 - found [Black Hat Zig: Zig for offensive security.](https://www.reddit.com/r/Zig/comments/1l6tbph/black_hat_zig_zig_for_offensive_security/)
 - [Training a Rust 1.5B Coder LM with Reinforcement Learning (GRPO) | Oxen.ai](https://ghost.oxen.ai/training-a-rust-1-5b-coder-lm-with-reinforcement-learning-grpo/)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W24.tree
+++ b/trees/2025-W24.tree
@@ -3,6 +3,8 @@
 \title{2025-W24}
 \date{2025-06-09}
 
+\p{Wrote [[uts-016K]] about trying Zig's self-hosted x86 backend on Apple hardware.}
+
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}

--- a/trees/2025-W24.tree
+++ b/trees/2025-W24.tree
@@ -3,7 +3,7 @@
 \title{2025-W24}
 \date{2025-06-09}
 
-\p{Wrote [[uts-016K]] about trying Zig's self-hosted x86 backend on Apple hardware.}
+\p{started using Mac's dictation in agent coding. wrote [[uts-016K]] on Reddit. learn about the possibility to maintain a distro by a single person, and learn about Radicle, a sovereign code forge built on Git.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/2025-W25.tree
+++ b/trees/2025-W25.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 25, 2025}
+\title{2025-W25}
 \date{2025-06-16}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W25-links]{
-\title{Link selections (2025-W25)}
+\title{🔗 2025-W25}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-06-22]{\mdnote{2025-06-22}{\tags{#os #rust #yaml}
 - [model.yaml](https://simonwillison.net/2025/Jun/21/model-yaml/#atom-everything)
     - an open standard in YAML for defining crossplatform, composable AI models by LM Studio team
@@ -246,5 +248,6 @@
     - I think I've always been a journey programmer, and didn't know it as a feature
 - found [rgSQL: A test suite to help you build your own database engine](https://technicaldeft.com/posts/rgsql-a-test-suite-for-database-engines)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W26.tree
+++ b/trees/2025-W26.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 26, 2025}
+\title{2025-W26}
 \date{2025-06-23}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W26-links]{
-\title{Link selections (2025-W26)}
+\title{🔗 2025-W26}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-06-29]{\mdnote{2025-06-29}{\tags{#formal #lean #news #os #sci #sec #sqlite #zig}
 - #struct
     - [Bloom Filters by Example](https://llimllib.github.io/bloomfilter-tutorial/) ([on HN](https://news.ycombinator.com/item?id=44412370))
@@ -315,5 +317,6 @@
     - [Why Go Rocks for Building a Lua Interpreter](https://www.zombiezen.com/blog/2025/06/why-go-rocks-for-building-lua-interpreter/)
     - [writing a little gosh](https://flak.tedunangst.com/post/writing-a-gosh)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W27.tree
+++ b/trees/2025-W27.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 27, 2025}
+\title{2025-W27}
 \date{2025-06-30}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W27-links]{
-\title{Link selections (2025-W27)}
+\title{🔗 2025-W27}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-07-06]{\mdnote{2025-07-06}{\tags{#agent #docker #game #news #sec}
 - #env
     - ['It's too late': David Suzuki says the fight against climate change is lost](https://www.ipolitics.ca/2025/07/02/its-too-late-david-suzuki-says-the-fight-against-climate-change-is-lost/) ([on HN](https://news.ycombinator.com/item?id=44476774))
@@ -488,5 +490,6 @@
 - [SQL Noir: Learn SQL by Solving Crimes](https://www.sqlnoir.com/)
     - fun to play, but the challenge should be using the SQL to output the answer
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W28.tree
+++ b/trees/2025-W28.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 28, 2025}
+\title{2025-W28}
 \date{2025-07-07}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W28-links]{
-\title{Link selections (2025-W28)}
+\title{🔗 2025-W28}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-07-13]{\mdnote{2025-07-13}{
 - #scifi
     - [Are we Trek yet? – A guide for how close we are to Star Trek technology](https://arewetrekyet.com/) ([on HN](https://news.ycombinator.com/item?id=44658458))
@@ -334,5 +336,6 @@
     - [tinymcp: Let LLMs control embedded devices via the Model Context Protocol](https://github.com/golioth/tinymcp)
     - [Render your Jupyter notebooks in OpenGist](https://blog.fabiomanganiello.com/article/render-your-jupyter-notebooks-in-opengist)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W29.tree
+++ b/trees/2025-W29.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 29, 2025}
+\title{2025-W29}
 \date{2025-07-14}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W29-links]{
-\title{Link selections (2025-W29)}
+\title{🔗 2025-W29}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-07-20]{\mdnote{2025-07-20}{
 - #selfhost
     - [My Ultimate Self-hosting Setup](https://codecaptured.com/blog/my-ultimate-self-hosting-setup/) ([on HN](https://news.ycombinator.com/item?id=44612151)) ([on lobste.rs](https://lobste.rs/s/naiwvd))
@@ -318,5 +320,6 @@
 - #mac
     - [ByteAtATime/flare: Raycast-compatible launcher for Linux](https://github.com/ByteAtATime/flare)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W30.tree
+++ b/trees/2025-W30.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 30, 2025}
+\title{2025-W30}
 \date{2025-07-21}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W30-links]{
-\title{Link selections (2025-W30)}
+\title{🔗 2025-W30}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-07-26]{\mdnote{2025-07-26}{
 - [Combinatory Programming](https://blog.zdsmith.com/posts/combinatory-programming.html)
     - a nice intro to basic patterns and their motivations
@@ -76,5 +78,6 @@
         - [Free Online Text to Speech - Private AI Voice Generator | QuickEditVideo](https://quickeditvideo.com/tts/)
         - [SAM: Software Automatic Mouth](https://discordier.github.io/sam/)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W31.tree
+++ b/trees/2025-W31.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 31, 2025}
+\title{2025-W31}
 \date{2025-07-28}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W31-links]{
-\title{Link selections (2025-W31)}
+\title{🔗 2025-W31}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-08-03]{\mdnote{2025-08-03}{
 - [How do you backup your non-work-related data?](https://lobste.rs/s/ngo3ex/how_do_you_backup_your_non_work_related)
     - most suggests `restic`
@@ -258,5 +260,6 @@
     - [Advanced Rust macros with derive-deftly](https://diziet.pages.torproject.net/rust-derive-deftly/latest/guide/)
     - [rules_derive: deriving using macro_rules](https://matx.com/research/rules_derive)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W32.tree
+++ b/trees/2025-W32.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 32, 2025}
+\title{2025-W32}
 \date{2025-08-04}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W32-links]{
-\title{Link selections (2025-W32)}
+\title{🔗 2025-W32}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-08-06]{\mdnote{2025-08-06}{
 - #idea
     - [Digital hygiene: Emails](https://herman.bearblog.dev/digital-hygiene-emails/)
@@ -191,5 +193,6 @@
     - [Bag of words, have mercy on us](https://www.experimental-history.com/p/bag-of-words-have-mercy-on-us)
     - [Model Collapse and the Need for Human-Generated Training Data](https://glthr.com/model-collapse-and-the-need-for-human-generated-training-data) ([on HN](https://news.ycombinator.com/item?id=44806136))
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W34.tree
+++ b/trees/2025-W34.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 34, 2025}
+\title{2025-W34}
 \date{2025-08-18}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W34-links]{
-\title{Link selections (2025-W34)}
+\title{🔗 2025-W34}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-08-24]{\mdnote{2025-08-24}{
 - #sovereign
     - #kb
@@ -160,5 +162,6 @@
     - [A CRDT-based Messenger in 12 Lines of Bash Using a Synced Folder](https://holdtherobot.com/blog/crdt-messenger-in-12-lines-of-bash/)
         - how about an editor? edits can't be dealt with in the same manner
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W35.tree
+++ b/trees/2025-W35.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 35, 2025}
+\title{2025-W35}
 \date{2025-08-25}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W35-links]{
-\title{Link selections (2025-W35)}
+\title{🔗 2025-W35}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-08-25]{\mdnote{2025-08-25}{
 - #zig
     - [zg: Unicode text processing for Zig projects](https://codeberg.org/atman/zg)
@@ -61,5 +63,6 @@
     - a reply to *Replication of Quantum Factorisation Records with an 8-bit Home Computer, an Abacus, and a Dog*
 - [A Diagrammatic Calculus for a Functional Model of Natural Language...](https://arxiv.org/abs/2507.00782) #diagram #paper
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W36.tree
+++ b/trees/2025-W36.tree
@@ -1,14 +1,16 @@
 \import{macros}
 
-\title{Week 36, 2025}
+\title{2025-W36}
 \date{2025-09-01}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W36-links]{
-\title{Link selections (2025-W36)}
+\title{🔗 2025-W36}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-09-07]{\mdnote{2025-09-07}{
 - #zig
     - [Hitting Peak File IO Performance with Zig](https://steelcake.com/blog/nvme-zig/)
@@ -136,5 +138,6 @@
     - [Why developers question everything - Tim Hårek](https://timharek.no/blog/why-developers-question-everything/)
         - [On lobste.rs](https://lobste.rs/s/bibyfi/why_developers_question_everything)
 }}
-  }
+      }
+}
 }

--- a/trees/2025-W41.tree
+++ b/trees/2025-W41.tree
@@ -1,16 +1,19 @@
 \import{macros}
 
-\title{Week 41, 2025}
+\title{2025-W41}
 \date{2025-10-06}
 
 \scope{
   \put\transclude/toc{false}
   \put\transclude/expanded{false}
   \subtree[2025-W41-links]{
-\title{Link selections (2025-W41)}
+\title{🔗 2025-W41}
 
+    \scope{
+      \put\transclude/expanded{true}
 \subtree[2025-10-10]{\mdnote{2025-10-10}{
 - [GitHub stale bot considered harmful](https://drewdevault.com/2021/10/26/stalebot.html)
 }}
-  }
+      }
+}
 }

--- a/weeknote_candidates.py
+++ b/weeknote_candidates.py
@@ -1,0 +1,264 @@
+#!/usr/bin/env -S uv run
+# /// script
+# requires-python = ">=3.11,<3.12"
+# dependencies = []
+# ///
+
+"""Report daily material that may deserve native weekly-note prose.
+
+Usage:
+    just weeknote-candidates 2024-W42
+    just weeknote-candidates --year 2025 --format markdown
+
+This detector is deliberately read-only. It identifies candidate Markdown
+blocks using explicit signals: activity language, links to authored Forest
+trees, project names, and bibliography citations. A human or model curator
+decides what belongs in the native Forester weeknote; all daily source remains
+in its collapsed link collection unless it is deliberately curated later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from extract_week import find_entries, matching_brace
+
+
+ADDRESS_RE = re.compile(r"^\\subtree\[(?P<address>[^]]+)\]", re.MULTILINE)
+MDNOTE_RE = re.compile(r"\\mdnote\{[^}]+\}\{")
+BULLET_RE = re.compile(r"^(?P<indent>[ \t]*)-\s+(?P<text>.*)$")
+TREE_RE = re.compile(r"\[\[(?P<tree>[a-z][a-z0-9]*-[A-Z0-9]+)\]\]")
+CITATION_RE = re.compile(r"\\citef\{(?P<citation>[^}]+)\}")
+# AGENT-NOTE: keep this authorial-start rule conservative; the detector is a review queue, not a mover.
+# Match only the beginning of a Markdown bullet. Searching arbitrary prose
+# produced false activities from linked article titles ("Build It Yourself"),
+# quotes ("start with…"), and paper descriptions.  This is intentionally
+# conservative: it finds authorial action statements rather than trying to
+# infer authorship from every verb in collected material.
+AUTHORIAL_ACTION_RE = re.compile(
+    r"^(?:i\s+)?(?:"
+    r"add(?:ed|ing)?|build(?:ing)?|continu(?:e|ed|ing)|creat(?:e|ed|ing)|"
+    r"debug(?:ged|ging)?|deploy(?:ed|ing)?|develop(?:ed|ing)?|"
+    r"fix(?:ed|ing)?|implement(?:ed|ing)?|improv(?:e|ed|ing)|"
+    r"make a start on|made a start on|migrat(?:e|ed|ing)|"
+    r"recover(?:ed|ing)?|refactor(?:ed|ing)?|releas(?:e|ed|ing)|"
+    r"restor(?:e|ed|ing)|set up|setting up|start(?:ed|ing)?|submit(?:ted|ting)?|"
+    r"switch(?:ed|ing)?|updat(?:e|ed|ing)|work(?:ing)? on|work out|"
+    r"writ(?:e|es|ing|ten)|wrote|try(?:ing)? to|learn(?:ed|ing)?"
+    r")\b",
+    re.IGNORECASE,
+)
+READING_RE = re.compile(
+    r"\b(?:citation trace|learn(?:ed)?|read(?:ing)?|research|skim(?:med)?|study|survey)\b",
+    re.IGNORECASE,
+)
+PROJECT_RE = re.compile(r"\b[a-z0-9]+-land\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class Candidate:
+    """One script-detected curation candidate; never an automatic move instruction."""
+
+    week: str
+    date: str
+    address: str
+    kinds: tuple[str, ...]
+    reasons: tuple[str, ...]
+    tree_links: tuple[str, ...]
+    citations: tuple[str, ...]
+    text: str
+
+
+def mdnote_content(source: str) -> str:
+    """Return the Markdown body of one complete daily ``\\mdnote`` subtree."""
+
+    match = MDNOTE_RE.search(source)
+    if match is None:
+        raise ValueError("daily subtree does not contain an mdnote body")
+    opening_brace = match.end() - 1
+    return source[opening_brace + 1 : matching_brace(source, opening_brace)]
+
+
+def bullet_blocks(content: str) -> list[str]:
+    """Return Markdown bullet blocks, retaining each matched bullet's descendants."""
+
+    lines = content.splitlines()
+    starts: list[tuple[int, int]] = []
+    for index, line in enumerate(lines):
+        match = BULLET_RE.match(line)
+        if match:
+            starts.append((index, len(match["indent"].expandtabs(4))))
+
+    blocks: list[str] = []
+    for position, (start, indent) in enumerate(starts):
+        end = len(lines)
+        for next_start, next_indent in starts[position + 1 :]:
+            if next_indent <= indent:
+                end = next_start
+                break
+        blocks.append("\n".join(lines[start:end]).strip())
+    return blocks
+
+
+def authorial_actions(block: str) -> tuple[str, ...]:
+    """Return explicit action starts, never verbs inside a linked item or quote."""
+
+    actions: list[str] = []
+    for line in block.splitlines():
+        bullet = BULLET_RE.match(line)
+        if bullet is None:
+            continue
+        match = AUTHORIAL_ACTION_RE.match(bullet["text"])
+        if match:
+            actions.append(match.group(0).lower())
+    return tuple(dict.fromkeys(actions))
+
+
+def classify(block: str) -> tuple[tuple[str, ...], tuple[str, ...], tuple[str, ...], tuple[str, ...]]:
+    """Return kinds and deterministic evidence for one candidate block."""
+
+    actions = authorial_actions(block)
+    tree_links = tuple(dict.fromkeys(match["tree"] for match in TREE_RE.finditer(block)))
+    citations = tuple(dict.fromkeys(match["citation"] for match in CITATION_RE.finditer(block)))
+    projects = tuple(dict.fromkeys(match.group(0) for match in PROJECT_RE.finditer(block)))
+    reading = bool(READING_RE.search(block))
+
+    kinds: list[str] = []
+    reasons: list[str] = []
+    if actions:
+        kinds.append("activity")
+        reasons.extend(f"action:{action}" for action in actions)
+    if tree_links:
+        kinds.append("authored-tree")
+        reasons.extend(f"tree:{tree}" for tree in tree_links)
+    if projects:
+        kinds.append("project-work" if actions else "project-reference")
+        reasons.extend(f"project:{project}" for project in projects)
+    if citations:
+        kinds.append("bibliography-reading" if reading else "bibliography-reference")
+        reasons.append("reading-language" if reading else "citation")
+    return tuple(kinds), tuple(reasons), tree_links, citations
+
+
+def detect_week(path: Path) -> list[Candidate]:
+    """Detect candidates in one physical weekly file, preserving file order."""
+
+    week = path.stem
+    candidates: list[Candidate] = []
+    for entry in find_entries(path.read_text(encoding="utf-8")):
+        address_match = ADDRESS_RE.match(entry.source)
+        if address_match is None:
+            raise ValueError(f"could not read a daily address in {path}")
+        content = mdnote_content(entry.source)
+        accepted_blocks: list[str] = []
+        for block in bullet_blocks(content):
+            kinds, reasons, tree_links, citations = classify(block)
+            if not kinds or any(block in accepted for accepted in accepted_blocks):
+                continue
+            accepted_blocks.append(block)
+            candidates.append(
+                Candidate(
+                    week=week,
+                    date=entry.day.isoformat(),
+                    address=address_match["address"],
+                    kinds=kinds,
+                    reasons=reasons,
+                    tree_links=tree_links,
+                    citations=citations,
+                    text=block,
+                )
+            )
+    return candidates
+
+
+def selected_paths(trees_dir: Path, week: str | None, year: int | None) -> list[Path]:
+    """Return the requested flat week files in deterministic chronological order."""
+
+    if week is not None:
+        path = trees_dir / f"{week}.tree"
+        if not path.exists():
+            raise ValueError(f"weekly tree does not exist: {path}")
+        return [path]
+    paths = sorted(trees_dir.glob("????-W??.tree"))
+    if year is not None:
+        paths = [path for path in paths if path.stem.startswith(f"{year:04d}-")]
+    return paths
+
+
+def markdown_report(candidates: list[Candidate]) -> str:
+    """Render a compact human-review report without changing any source."""
+
+    lines = [f"# Weeknote curation candidates ({len(candidates)})"]
+    current_week = ""
+    for candidate in candidates:
+        if candidate.week != current_week:
+            current_week = candidate.week
+            lines.extend(["", f"## {current_week}"])
+        lines.extend(
+            [
+                "",
+                f"### {candidate.date} · {', '.join(candidate.kinds)}",
+                f"Reasons: {', '.join(candidate.reasons)}",
+                "```markdown",
+                candidate.text,
+                "```",
+            ]
+        )
+    return "\n".join(lines)
+
+
+def run_self_test() -> None:
+    """Exercise the conservative boundary between authored work and collected links."""
+
+    cases = [
+        ("authored project work", "- work on native-land build", {"activity", "project-work"}),
+        ("authored tree", "- wrote [[uts-002F]]", {"activity", "authored-tree"}),
+        ("citation reading", "- skimmed \\citef{lipman2022flow}", {"bibliography-reading"}),
+        ("linked article title", "- [Build It Yourself](https://example.test/)", set()),
+        ("quoted action", "- [article](https://example.test/)\n  - \"start with care\"", set()),
+    ]
+    for name, block, expected in cases:
+        kinds, _, _, _ = classify(block)
+        if set(kinds) != expected:
+            raise AssertionError(f"{name}: expected {expected}, found {set(kinds)}")
+    print(f"detector self-test passed ({len(cases)} cases)")
+
+
+def main() -> int:
+    """Print candidate evidence; intentional curation remains a later manual/model step."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    scope = parser.add_mutually_exclusive_group()
+    scope.add_argument("week", nargs="?", help="one ISO week, for example 2024-W42")
+    scope.add_argument("--year", type=int, help="all week files in one calendar year")
+    scope.add_argument("--test", action="store_true", help="run detector boundary tests and exit")
+    parser.add_argument("--trees-dir", type=Path, default=Path("trees"))
+    parser.add_argument("--format", choices=("json", "markdown"), default="markdown")
+    args = parser.parse_args()
+
+    if args.test:
+        run_self_test()
+        return 0
+
+    try:
+        candidates = [
+            candidate
+            for path in selected_paths(args.trees_dir, args.week, args.year)
+            for candidate in detect_week(path)
+        ]
+    except (OSError, ValueError) as error:
+        parser.error(str(error))
+
+    if args.format == "json":
+        print(json.dumps([asdict(candidate) for candidate in candidates], indent=2))
+    else:
+        print(markdown_report(candidates))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Consolidates the two same-date daily capture pairs into their canonical date nodes.

- preserves every unique URL
- retains each exact overlap once
- removes `2025-05-07-2` and `2025-06-06-2` without adding merge markers or aliases
- keeps the final entries as ordinary uninterrupted Markdown bullet lists

Validation:
- `uv run extract_week.py --all --check`
- duplicate-date and URL-preservation audit
- `just chk`
- `forester build --no-theme --quiet`
- `uv run til.py --dry-run`