### PR TITLE
Import reviewed post-Sep-2025 link collection

### DIFF
--- a/import_post_sep_2025_links.py
+++ b/import_post_sep_2025_links.py
@@ -1,0 +1,319 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Import the reviewed post-September-2025 X link collection into Forest.
+
+The reviewed manifest in cog-land fixes the source-only tag decisions and the
+15-link daily allocation.  This importer turns that manifest into flat weekly
+trees with one in-file, collapsed link collection per week.  It deliberately
+does not make network requests or infer tags from URLs, accounts, or outside
+knowledge.
+
+Usage:
+    just import-post-sep-2025-links /path/to/cog-land
+    just check-post-sep-2025-links /path/to/cog-land
+
+Use ``--refresh`` only to replace an earlier version of this generated import;
+it refuses to replace a weekly tree that does not retain this import's chrome.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from pathlib import Path
+from urllib.parse import urlsplit, urlunsplit
+
+
+MANIFEST = Path("projects/forest/post-sep-2025-raindrop-tag-sync-manifest-2026-08-22.csv")
+EXCLUSIONS = Path("projects/forest/post-sep-2025-forest-dedup-exclusions-2026-08-22.csv")
+ROOT_TREE = Path("trees/uts-0018.tree")
+TREES_DIR = Path("trees")
+EXPECTED_LINKS = 2_197
+EXPECTED_DAYS = 152
+MAXIMUM_DAILY_LINKS = 15
+EXPECTED_DEDUPLICATIONS = 1
+ROOT_MARKER = "\\subtree[2025]{"
+TAG_ORDER = (
+    "agent", "formal", "proof", "ebpf", "rust", "zig", "lean", "haskell", "ocaml", "clojure",
+    "racket", "elixir", "apl", "compiler", "gpu", "shader", "webgl", "benchmark", "render", "cg",
+    "visualization", "game", "sec", "web", "os", "git", "docker", "sqlite", "wasm", "tui",
+    "software", "sci", "context", "misc",
+)
+TAG_RANK = {tag: index for index, tag in enumerate(TAG_ORDER)}
+
+
+@dataclass(frozen=True)
+class Link:
+    url: str
+    title: str
+    source_date: str
+    target_date: str
+    tags: tuple[str, ...]
+    status_id: str
+    source_path: str
+
+
+def normalise_url(url: str) -> str:
+    """Normalise only stable URL identity details used by the reviewed audit."""
+
+    parts = urlsplit(url.strip())
+    return urlunsplit((parts.scheme.lower(), parts.netloc.lower(), parts.path.rstrip("/"), parts.query, ""))
+
+
+def x_status_id(url: str) -> str | None:
+    match = re.search(r"(?:x|twitter)\.com/[^/]+/status/(\d+)", url, re.I)
+    return match.group(1) if match else None
+
+
+def iso_week(day: str) -> str:
+    value = date.fromisoformat(day)
+    year, week, _ = value.isocalendar()
+    return f"{year:04d}-W{week:02d}"
+
+
+def monday(week: str) -> date:
+    year, number = week.split("-W")
+    return date.fromisocalendar(int(year), int(number), 1)
+
+
+def frontmatter(path: Path) -> dict[str, str]:
+    text = path.read_text(encoding="utf-8")
+    match = re.match(r"^---\n(.*?)\n---\n", text, re.S)
+    if not match:
+        raise ValueError(f"clip lacks YAML frontmatter: {path}")
+    values: dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        key, separator, value = line.partition(":")
+        if separator and not line.startswith((" ", "-")):
+            values[key] = value.strip().strip('"')
+    return values
+
+
+def markdown_title(title: str, url: str) -> str:
+    """Keep source titles literal while protecting Forest and Markdown syntax.
+
+    Numeric character references render as the original source character, but
+    cannot close the surrounding Forester argument or Markdown link early.
+    """
+
+    escaped = title or url
+    for character, entity in (
+        ("&", "&amp;"), ("\\", "&#92;"), ("{", "&#123;"), ("}", "&#125;"),
+        ("[", "&#91;"), ("]", "&#93;"), ("(", "&#40;"), (")", "&#41;"),
+        ('"', "&quot;"), ("%", "&#37;"),
+    ):
+        escaped = escaped.replace(character, entity)
+    return escaped
+
+
+def load_reviewed_links(cog_land: Path) -> list[Link]:
+    """Load the approved, source-text-only manifest and its original X titles."""
+
+    manifest = cog_land / MANIFEST
+    if not manifest.is_file():
+        raise ValueError(f"reviewed allocation manifest does not exist: {manifest}")
+    links: list[Link] = []
+    with manifest.open(newline="", encoding="utf-8") as handle:
+        for row in csv.DictReader(handle):
+            if row.get("source") != "x":
+                raise ValueError("reviewed manifest must contain only deduplicated X links")
+            source_path = cog_land / row["source-path"]
+            metadata = frontmatter(source_path)
+            if metadata.get("url") != row["url"] or metadata.get("tweet-id") != row["source-id"]:
+                raise ValueError(f"manifest no longer matches its clip: {row['source-path']}")
+            tags = tuple(tag for tag in row["tags"].split(",") if tag)
+            if not tags or any(tag not in TAG_RANK for tag in tags):
+                raise ValueError(f"manifest uses an unreviewed tag for {row['url']}")
+            links.append(Link(
+                url=row["url"], title=metadata.get("title", "").strip(), source_date=row["source-date"],
+                target_date=row["target-date"], tags=tags, status_id=row["source-id"],
+                source_path=row["source-path"],
+            ))
+    urls = [normalise_url(link.url) for link in links]
+    ids = [link.status_id for link in links]
+    if len(links) != EXPECTED_LINKS or len(urls) != len(set(urls)) or len(ids) != len(set(ids)):
+        raise ValueError("reviewed manifest is not the expected 2,197 unique X-link set")
+    return links
+
+
+def existing_identities(paths: list[Path]) -> tuple[set[str], set[str]]:
+    urls: set[str] = set()
+    status_ids: set[str] = set()
+    for path in paths:
+        for raw_url in re.findall(r'https?://[^\s)\]}"<>]+', path.read_text(encoding="utf-8")):
+            cleaned = raw_url.rstrip(".,;:")
+            urls.add(normalise_url(cleaned))
+            if status_id := x_status_id(cleaned):
+                status_ids.add(status_id)
+    return urls, status_ids
+
+
+def validate_dedup_audit(cog_land: Path, baseline_urls: set[str]) -> None:
+    """Require the reviewed one-row baseline exclusion to remain real and explicit."""
+
+    exclusions = cog_land / EXCLUSIONS
+    if not exclusions.is_file():
+        raise ValueError(f"Forest deduplication audit does not exist: {exclusions}")
+    with exclusions.open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    if len(rows) != EXPECTED_DEDUPLICATIONS:
+        raise ValueError("expected exactly one reviewed Forest-baseline deduplication")
+    row = rows[0]
+    if row.get("reason") != "forest-normalised-url" or normalise_url(row.get("url", "")) not in baseline_urls:
+        raise ValueError("the reviewed Forest-baseline duplicate is no longer present in the baseline")
+
+
+def tag_tree(links: list[Link]) -> dict[str, object]:
+    """Make a tag trie, so links sharing tag paths are merged visually once."""
+
+    root: dict[str, object] = {"children": {}, "links": []}
+    for link in sorted(links, key=lambda item: (item.tags, normalise_url(item.url))):
+        node = root
+        for tag in link.tags:
+            children = node["children"]
+            assert isinstance(children, dict)
+            node = children.setdefault(tag, {"children": {}, "links": []})
+        leaves = node["links"]
+        assert isinstance(leaves, list)
+        leaves.append(link)
+    return root
+
+
+def render_tag_tree(node: dict[str, object], depth: int) -> list[str]:
+    lines: list[str] = []
+    children = node["children"]
+    assert isinstance(children, dict)
+    for tag in sorted(children, key=TAG_RANK.__getitem__):
+        lines.append(f"{'    ' * depth}- #{tag}")
+        child = children[tag]
+        assert isinstance(child, dict)
+        lines.extend(render_tag_tree(child, depth + 1))
+    leaves = node["links"]
+    assert isinstance(leaves, list)
+    for link in leaves:
+        assert isinstance(link, Link)
+        lines.append(f"{'    ' * depth}- [{markdown_title(link.title, link.url)}]({link.url})")
+    return lines
+
+
+def daily_tree(day: str, links: list[Link]) -> str:
+    body = "\n".join(render_tag_tree(tag_tree(links), 0))
+    return f"\\subtree[{day}]{{\\mdnote{{{day}}}{{\n{body}\n}}}}"
+
+
+def weekly_tree(week: str, entries: dict[str, list[Link]]) -> str:
+    body = "\n\n".join(daily_tree(day, entries[day]) for day in sorted(entries))
+    return (
+        "\\import{macros}\n\n"
+        f"\\title{{{week}}}\n"
+        f"\\date{{{monday(week).isoformat()}}}\n\n"
+        "\\scope{\n"
+        "  \\put\\transclude/toc{false}\n"
+        "  \\put\\transclude/expanded{false}\n"
+        f"  \\subtree[{week}-links]{{\n"
+        "\\title{🔗}\n\n"
+        "    \\scope{\n"
+        "      \\put\\transclude/expanded{true}\n"
+        f"{body}\n"
+        "    }\n"
+        "  }\n"
+        "}\n"
+    )
+
+
+def root_addition(weeks: list[str]) -> str:
+    by_month: dict[str, list[str]] = defaultdict(list)
+    for week in weeks:
+        by_month[monday(week).strftime("%Y-%m")].append(week)
+    sections = ["\\subtree[2026]{", "\\title{Year 2026}", ""]
+    for month, month_weeks in sorted(by_month.items(), reverse=True):
+        month_name = date.fromisoformat(f"{month}-01").strftime("%B, %Y")
+        sections.extend([f"\\subtree[{month}]{{", f"\\title{{{month_name}}}", ""])
+        for week in sorted(month_weeks, reverse=True):
+            sections.extend([f"% Post-Sep-2025 link intake: {week}", f"\\transclude{{{week}}}", ""])
+        sections.extend(["}", ""])
+    sections.append("}")
+    return "\n".join(sections) + "\n\n"
+
+
+def is_generated_week_tree(path: Path, week: str) -> bool:
+    """Recognise only a previous generated target, never an arbitrary weeknote."""
+
+    text = path.read_text(encoding="utf-8")
+    return (
+        text.startswith("\\import{macros}\n\n" + f"\\title{{{week}}}\n")
+        and f"\\subtree[{week}-links]{{" in text
+        and "\\title{🔗}" in text
+        and "\\put\\transclude/expanded{true}" in text
+    )
+
+
+def plan(cog_land: Path) -> tuple[dict[Path, str], str, list[str]]:
+    links = load_reviewed_links(cog_land)
+    by_date: dict[str, list[Link]] = defaultdict(list)
+    for link in links:
+        by_date[link.target_date].append(link)
+    counts = [len(day_links) for day_links in by_date.values()]
+    if len(by_date) != EXPECTED_DAYS or max(counts) > MAXIMUM_DAILY_LINKS or min(counts) < 10:
+        raise ValueError("reviewed allocation no longer satisfies the 10–15-link daily policy")
+    by_week: dict[str, dict[str, list[Link]]] = defaultdict(lambda: defaultdict(list))
+    for day, day_links in by_date.items():
+        by_week[iso_week(day)][day].extend(day_links)
+    weeks = sorted(by_week)
+    target_paths = {TREES_DIR / f"{week}.tree" for week in weeks}
+    baseline_paths = [path for path in sorted(TREES_DIR.glob("*.tree")) if path not in target_paths]
+    baseline_urls, baseline_ids = existing_identities(baseline_paths)
+    validate_dedup_audit(cog_land, baseline_urls)
+    conflicts = [link for link in links if normalise_url(link.url) in baseline_urls or link.status_id in baseline_ids]
+    if conflicts:
+        raise ValueError(f"reviewed manifest collides with the current Forest baseline: {conflicts[0].url}")
+    return ({TREES_DIR / f"{week}.tree": weekly_tree(week, by_week[week]) for week in weeks}, root_addition(weeks), weeks)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--cog-land", required=True, type=Path, help="checkout containing the reviewed private manifest")
+    parser.add_argument("--check", action="store_true", help="validate the existing generated import without writing")
+    parser.add_argument("--refresh", action="store_true", help="replace an earlier generated version after checking its ownership")
+    args = parser.parse_args()
+    root = ROOT_TREE.read_text(encoding="utf-8")
+    planned_trees, addition, weeks = plan(args.cog_land.expanduser().resolve())
+    if ROOT_MARKER not in root:
+        raise ValueError("the live diary root no longer has the expected 2025 insertion marker")
+    if "\\subtree[2026]{" not in root:
+        expected_root = root.replace(ROOT_MARKER, addition + ROOT_MARKER, 1)
+    else:
+        expected_root = (
+            root[:root.index("\\subtree[2026]{")]
+            + addition
+            + root[root.index(ROOT_MARKER):]
+        )
+    stale = [path for path, content in planned_trees.items() if not path.is_file() or path.read_text(encoding="utf-8") != content]
+    root_is_current = root == expected_root
+    if args.check and (stale or not root_is_current):
+        targets = ", ".join(path.name for path in stale[:3])
+        raise ValueError(f"--check found a non-current import: {targets or 'uts-0018.tree'}")
+    if not args.check:
+        if "\\subtree[2026]{" in root and not root_is_current:
+            raise ValueError("refusing to overwrite a non-generated 2026 root arrangement")
+        for path, content in planned_trees.items():
+            if path.exists() and path.read_text(encoding="utf-8") != content and not (
+                args.refresh and is_generated_week_tree(path, path.stem)
+            ):
+                raise ValueError(f"refusing to overwrite a non-current generated file: {path}")
+        for path, content in planned_trees.items():
+            path.write_text(content, encoding="utf-8")
+        if root != expected_root:
+            ROOT_TREE.write_text(expected_root, encoding="utf-8")
+    print(f"{'validated' if args.check else 'imported'} {EXPECTED_LINKS:,} links into {len(weeks)} weekly trees and {EXPECTED_DAYS} daily nodes")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/justfile
+++ b/justfile
@@ -15,6 +15,12 @@ extract-week WEEK:
 extract-all-weeks:
     uv run extract_week.py --all
 
+import-post-sep-2025-links COG_LAND +PARAMS:
+    uv run import_post_sep_2025_links.py --cog-land {{COG_LAND}} {{PARAMS}}
+
+check-post-sep-2025-links COG_LAND:
+    uv run import_post_sep_2025_links.py --cog-land {{COG_LAND}} --check
+
 weeknote-candidates +PARAMS:
     uv run weeknote_candidates.py {{PARAMS}}
 

--- a/trees/2026-W19.tree
+++ b/trees/2026-W19.tree
@@ -1,0 +1,188 @@
+\import{macros}
+
+\title{2026-W19}
+\date{2026-05-04}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W19-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-05-04]{\mdnote{2026-05-04}{
+- #agent
+    - [this github has 2,000+ free gpt-image-2 prompts with preview images  16 language](https://x.com/EXM7777/status/2051768410640732220)
+    - [As promised, prompts below ✨ https://x.com/GlitterPixely/status/2052201228235309](https://x.com/GlitterPixely/status/2052201228235309361)
+    - [Character ideation and environment were created in Midjourney v8.1 + cleaned up](https://x.com/GlitterPixely/status/2052201230227714247)
+    - [The entire RAG industry is about to get cooked.  Researchers have built a new RA](https://x.com/HowToAI_/status/2051527272675651923)
+    - [OpenEnv is growing fast in tutorials. If you're looking to get started with RL e](https://x.com/SergioPaniego/status/2052774043531530367)
+    - [distill does this out of the box~ https://x.com/TGUPJ/status/2052774099101835313](https://x.com/TGUPJ/status/2052774099101835313)
+    - [Two weeks after release, Hy3 preview is #1 on @OpenRouter's weekly leaderboard w](https://x.com/TencentHunyuan/status/2051978552900538403)
+    - [In case you have doubts about the q2 quants inference of DS4 &#40;I noticed many don](https://x.com/antirez/status/2052494447703625901)
+    - [Sub-agents are a promising inference-time scaling primitive:  • Expand an agent'](https://x.com/apurvasgandhi/status/2052831719263461722)
+    - [IT IS HAPPENING!](https://x.com/badlogicgames/status/2052050141968761188)
+    - [We’ve agreed to a partnership with @SpaceX that will substantially increase our](https://x.com/claudeai/status/2052060691893227611)
+    - [Effective today, we are:  1&#41; Doubling Claude Code’s 5-hour rate limits for Pro,](https://x.com/claudeai/status/2052060693269008586)
+    - [when Claude Opus 6 tells you to &#92;&quot;stop spiraling and go to bed&#92;&quot; 😵‍💫 https://x.com](https://x.com/fabianstelzer/status/2051260931758272863)
+    - [https://github.com/geminixiang/mama 基於 Pi coding agent 的 Chat bot 核心是 fork from](https://x.com/geminixiang/status/2033970106997551119)
+}}
+
+\subtree[2026-05-05]{\mdnote{2026-05-05}{
+- #agent
+    - #benchmark
+        - [Introducing MTPLX V0.2 The Fastest MTP On Mac  Qwen 3.6 27B:   - 30-40&#37; Faster D](https://x.com/Youssofal_/status/2052469411001344180)
+    - [Here are a couple more projects that use libghostty: https://supacode.sh/ Supaco](https://x.com/mitchellh/status/2021610956334276844)
+    - [FUI exploration // 003  Secret agent manager dashboard  Made w/ code https://x.c](https://x.com/stevelauda_/status/2052909042104954963)
+    - [a couple of beers later...  who's willing to use a modern git collaboration plat](https://x.com/stylesshDev/status/2049679278397136938)
+    - [Automates research with researcher, reviewer, and writer agents  https://github.](https://x.com/tom_doerr/status/2051009756647530749)
+    - [Terminal Kanban board for parallel coding agents  https://github.com/fynnfluegge](https://x.com/tom_doerr/status/2051504267437977701)
+    - [Kanban board for managing Claude Code agents  https://github.com/hallucinogen/ag](https://x.com/tom_doerr/status/2051961191728091158)
+    - [Turns specifications into pull requests using parallel AI agent swarms  https://](https://x.com/tom_doerr/status/2052018455629492549)
+    - [Personal agent building compounding knowledge base  https://github.com/agno-agi/](https://x.com/tom_doerr/status/2052146896227992043)
+    - [Control-plane harness for Claude and Codex agents  https://github.com/0xNyk/lacp](https://x.com/tom_doerr/status/2052192775689392547)
+    - [2D IDE for managing AI agents across multiple machines  https://github.com/49Age](https://x.com/tom_doerr/status/2052744560627925065)
+    - [Transforms projects into navigable knowledge graphs for AI agents  https://githu](https://x.com/tom_doerr/status/2052790665789014350)
+    - [Infinite canvas for parallel Claude Code agents  https://github.com/Fallomai/ope](https://x.com/tom_doerr/status/2052836851161989563)
+    - [I spent the last two days getting personal agent ready for open source. Feel fre](https://x.com/trashpandaemoji/status/2050928222846476380)
+}}
+
+\subtree[2026-05-06]{\mdnote{2026-05-06}{
+- #agent
+    - #gpu
+        - #benchmark
+            - [Introducing nanowhale 🐳! A tiny DeepSeek model fully pretrained by an agent.  In](https://x.com/cmpatino_/status/2051343930373837125)
+        - [The numbers for Rapid MLX are insane  Probably the best way to run models on Mac](https://x.com/nummanali/status/2051044785998254270)
+    - #benchmark
+        - #visualization
+            - [Most people think @rerundotio is a visualization tool. In reality, it's a databa](https://x.com/pablovelagomez1/status/2049881696531853682)
+        - #web
+            - [Negentropy-claude-opus-4.7-9B and 4B are now LIVE!  HIGHLY EXPERIMENTAL, but ano](https://x.com/KyleHessling1/status/2052558536912384036)
+        - #docker
+            - [Claude Code used 3x fewer tokens with one change:  - Before: 10.4M tokens · 10 e](https://x.com/DailyDoseOfDS_/status/2052668450733228345)
+        - #software
+            - [Oh and I forgot something else.   Pi is now natively available in the CLI for co](https://x.com/Youssofal_/status/2052474443746914668)
+        - [Finally broke the 3k token per second input/prompt processing barrier for Qwen 3](https://x.com/banana_baeee/status/2052197755154739702)
+    - #cg
+        - [Describe a part → get a 3D model.  text-to-cad Open source harness that lets cod](https://x.com/GithubProjects/status/2051731247320449132)
+    - #game
+        - #git
+            - [6 AI agent orchestration tools worth trying at least once:  1. Superset Link - h](https://x.com/dhruvtwt_/status/2050966491731038598)
+    - #os
+        - #software
+            - [Agent Zero v1.12 is live. ⚡  We just gave Agent Zero a full Linux Desktop Runtim](https://x.com/Agent0ai/status/2050824159471587436)
+    - #git
+        - #docker
+            - [Scion is a new multi-agent orchestration tool that orchestrates agents &#40;Claude C](https://x.com/geminicli/status/2051725136974246266)
+    - #docker
+        - #software
+            - [One of the 79 skills shipped with Hermes is named &#92;&quot;claude-code.&#92;&quot; Look at the aut](https://x.com/aakashgupta/status/2052069900852809771)
+    - #context
+        - [Introducing SubQ - a major breakthrough in LLM intelligence.  It is the first mo](https://x.com/alex_whedon/status/2051663268704636937)
+        - [addicted to using boomerang mode &#40;aka reverse D-Mail&#41; in Pi these days.  ctrl+al](https://x.com/nicopreme/status/2050972317023687067)
+}}
+
+\subtree[2026-05-07]{\mdnote{2026-05-07}{
+- #agent
+    - #rust
+        - #gpu
+            - [用纯 Rust 实现 LLM 推理引擎，针对每种硬件×模型×量化组合定制 CUDA 内核，跑出比 vLLM 和 TensorRT-LLM 更高的推理速度。  h](https://x.com/QingQ77/status/2052675624456823262)
+    - #sec
+        - #software
+            - [𝚗𝚙𝚡 𝚍𝚎𝚎𝚙𝚜𝚎𝚌  We're introducing an open-source agent orchestrator for deep securi](https://x.com/rauchg/status/2051386798899888539)
+            - [deepsec is quite possibly one of the best security tools I've tried so far  we g](https://x.com/steventey/status/2051517293281358212)
+    - #sqlite
+        - [🤖 Kept hitting @github rate limits across my agents. Shipped two things:  – Repo](https://x.com/steipete/status/2051579838780072173)
+    - #wasm
+        - [omnifs: the universe, mounted on your filesystem &#40;sound on 🔊&#41;  starting with git](https://x.com/raulvk/status/2043415858035499496)
+        - [omnifs is now open source.  docker quickstart included. try it today, and tell m](https://x.com/raulvk/status/2044082732821623090)
+    - #tui
+        - #software
+            - [TUI observability for AI coding agents. Traces cost, tokens, tool failures, late](https://x.com/LLMpsycho/status/2052405465913459157)
+        - [I’m a big fan of MUIs: the Middle ground between GUIs and TUIs.  - Keyboard firs](https://x.com/raulvk/status/2045054543889682800)
+    - #software
+        - [My markdown notes editor &#40;replaced Obsidian for me&#41;.  Syncs with Dropbox, sharea](https://x.com/CasJam/status/2051300247167545462)
+        - [Meet Qwen3.6-27B-Claude-Opus-Reasoning-Distill-v2-int4-AutoRound. A massive 27B](https://x.com/HuggingModels/status/2051671777621967091)
+        - [用聊天软件控制本地 AI Coding Agent，不用一直守在电脑前看终端  cc-connect 可以把跑在你机器上的 Claude Code、Codex、](https://x.com/chiihan3/status/2052246032357154934)
+        - [herdr 0.5.0 is out!  - herdr is detachable now - you can leave your agents runni](https://x.com/lumendriada/status/2046653599321661925)
+        - [AI slop is good, actually. Slop is what enables fast parallel experimentation. T](https://x.com/mitchellh/status/2052397933522506079)
+    - #sci
+        - [arXiv Papers → LLM Artifacts  This is how I keep up with AI research now.  It's](https://x.com/omarsar0/status/2052062654810980618)
+}}
+
+\subtree[2026-05-08]{\mdnote{2026-05-08}{
+- #agent
+    - #web
+        - #os
+            - [Introducing Mirage, a unified virtual filesystem for AI agents!  6 weeks. 1.1M+](https://x.com/zechengzh/status/2052105012172792061)
+        - [Qwen 3.6 35b-a3b-UD_Q8_K_XL mlx runs on the browser. 10t ok/s. What can it be us](https://x.com/Brooooook_lyn/status/2050970427321905536)
+        - [Starting today, TinyFish Web Search and Fetch are free.  For every dev and agent](https://x.com/Tiny_Fish/status/2051337399465332950)
+        - [Here’s what I’d do if I was in charge of GitHub, in order:  1. Establish a North](https://x.com/mitchellh/status/2036866220449030168)
+        - [Just shipped pi-kanban — a web workspace for the pi coding agent.  Sessions, tod](https://x.com/nikiforovall/status/2052770995333747117)
+        - [HTML is the new markdown.   I've stopped writing markdown files for almost every](https://x.com/trq212/status/2052811606032269638)
+- #ebpf
+    - #rust
+        - #web
+            - [Your terminal has never looked this powerful.  Meet a Rust-based network inspect](https://x.com/DivyanshT91162/status/2052947261953561082)
+- #gpu
+    - [Self-hosted NVIDIA GPU monitoring dashboard  https://github.com/psalias2006/gpu-](https://x.com/tom_doerr/status/2052315147528523999)
+- #cg
+    - [Otra alternativa a CapCut que no te pone watermark y te roba la privacidad  &#91;Ope](https://x.com/ErickSky/status/2051707966126977093)
+    - [Finalizing that reading list tonight? 📋 Don't just tick a box—choose a resource](https://x.com/SmartBiology3D/status/2052025609367204091)
+    - [I just found the easiest way to design a custom home.  Drafted lets you draw any](https://x.com/hasantoxr/status/2051868316239896820)
+- #game
+    - #web
+        - #docker
+            - [someone built a fully self-hosted headless steam server that runs in a docker co](https://x.com/oliviscusAI/status/2052698653899309135)
+- #git
+    - #software
+        - [Self-hosted Git server with integrated CI/CD and Kanban  https://github.com/theo](https://x.com/tom_doerr/status/2052010844649619584)
+    - [Here's a demo showing off the rework of worktrees and blueprints https://x.com/c](https://x.com/caidanwilliams/status/2051434775685247362)
+}}
+
+\subtree[2026-05-09]{\mdnote{2026-05-09}{
+- #lean
+    - [A shallow embedding of Datalog in Lean. ~ Ramy Shahin. https://arxiv.org/abs/260](https://x.com/Jose_A_Alonso/status/2052034562608287891)
+- #gpu
+    - #benchmark
+        - #os
+            - [dflash-mlx v0.1.5 is out.  Big runtime + serving release since v0.1.4:  ► one CL](https://x.com/bstnxbt/status/2050981997749666214)
+    - #cg
+        - #os
+            - [Someone just open-sourced a desktop app that generates 3D models from images and](https://x.com/oliviscusAI/status/2052791108430909659)
+    - #software
+        - [Machine learning framework for Apple Silicon  https://github.com/Epistates/pmeta](https://x.com/tom_doerr/status/2052177498880770102)
+- #misc
+    - [My new favorite workflow  =-=-=-=-=-=  Pre-requisites  1. Setup Warp &#40;either clo](https://x.com/0xSero/status/2051327873999360448)
+    - [Warp - High level harness harness Droid - Main harness Pi        - Local model h](https://x.com/0xSero/status/2051392874252546187)
+    - [Introducing Shuffle. Get a random design in one click.  In open-slide 1.1.0, we](https://x.com/1weiho/status/2052763367744606443)
+    - [AMD acaba de anunciar un mini-PC brutal para 2026: Ryzen AI Halo con 128 GB de R](https://x.com/7uanF/status/2052822459200450803)
+    - [给 OpenPets 实现了 Pi Agent 的插件（使用 Hooks 而不是 MCP，MCP 会影响模型能力）。  OpenPets 是兼容 Codex p](https://x.com/9hills/status/2052700850372644882)
+    - [🚨PromptShare🚨 It’s crazy how PixVerse C1 is still underrated… While the potentia](https://x.com/CharaspowerAI/status/2051580177730175167)
+    - [@NoahChrein That's what we need iterated graphical decomposition spaces for: htt](https://x.com/DavidCorfield8/status/2052062671214653917)
+    - [Been thinking about sharing some fun, interactive science app ideas  Made this o](https://x.com/DilumSanjaya/status/2050981225175928895)
+    - [Taste-skill - gives your ai good taste. stops the ai from generating boring, gen](https://x.com/GithubProjects/status/2051791605624168771)
+    - [GraspXL update: new tabletop grasping motions of 500k+ objects for MANO, Allegro](https://x.com/Hui_Zhang_eth/status/2052016947798093929)
+}}
+
+\subtree[2026-05-10]{\mdnote{2026-05-10}{
+- #misc
+    - [iOS development  with expo, but the simulator lives in the cloud.  edit code → d](https://x.com/LandseerEnga/status/2051335474808287323)
+    - [Pues me está gustando fuerte este tema para VS Code basado en el de JetBrains.](https://x.com/MoureDev/status/2051655842164875538)
+    - [@badlogicgames Here you go then, just point Pi at it and will show you it's full](https://x.com/Prince_Canuma/status/2052873315883074035)
+    - [在手机上用 Discord 远程操控本地跑着的 Codex，批准、中断、恢复都行。  https://github.com/humeo/code-helm  C](https://x.com/QingQ77/status/2052927030304612822)
+    - [This is how they make a 535-pound bluefin tuna that sells for $3.24 million.  Ea](https://x.com/aakashgupta/status/2052237012313514458)
+    - [&#92;&quot;Switching to the @goose_oss harness beat alternatives by ~10&#37; in accuracy and w](https://x.com/alexjhancock/status/2051292974814831016)
+    - [As I said a few days ago, t/s it is not just a fixed number at a given context,](https://x.com/antirez/status/2052702342609252536)
+    - [agentOS by @rivet_dev is nifty, and not just because it's built on https://pi.de](https://x.com/badlogicgames/status/2051669524013854902)
+    - [People of https://pi.dev/. Today we are:  - moving the pi GH repo to earendil-wo](https://x.com/badlogicgames/status/2052337097315381517)
+    - [Tamux all the things! https://github.com/mkurman/zorai https://x.com/bidah/statu](https://x.com/bidah/status/2044550367833108730)
+    - [480 degree 67 step buddy induced stair dismount.  10/10 would dismount again! ht](https://x.com/clongmire42/status/2051813358945419651)
+    - [You can also check the architecture on this awesome tool by @andrew_n_carr   htt](https://x.com/cmpatino_/status/2051345819941359748)
+    - [Retrosite &#40;by @krynsky&#41; is a 100&#37; local app for making visual timelines from old](https://x.com/cocktailpeanut/status/2051680720502862172)
+    - [Little details in Zodex! https://x.com/frknksglu/status/2051592872663957784/vide](https://x.com/frknksglu/status/2051592872663957784)
+}}
+    }
+  }
+}

--- a/trees/2026-W20.tree
+++ b/trees/2026-W20.tree
@@ -1,0 +1,171 @@
+\import{macros}
+
+\title{2026-W20}
+\date{2026-05-11}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W20-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-05-11]{\mdnote{2026-05-11}{
+- #misc
+    - [View changes detail in https://zodex.dev/ ! https://x.com/frknksglu/status/20519](https://x.com/frknksglu/status/2051987593097797645)
+    - [the most interesting skills are not docs, they are programs  https://github.com/](https://x.com/irl_danB/status/2052718663245967702)
+    - [got bored and just decided to implement niri on macos https://x.com/maria_rcks/s](https://x.com/maria_rcks/status/2051055613967204418)
+    - [Hunk is very good. It has completely replaced any other local diff viewer for me](https://x.com/mitchellh/status/2052128048288567617)
+    - [I'm so in love with @antirez' ds4. Patched some slop on it to get better streami](https://x.com/mitsuhiko/status/2052508753472143614)
+    - [I think @antirez ds4.c is important! I wrote down my thoughts on why I built pi-](https://x.com/mitsuhiko/status/2052688947763941717)
+    - [Here's what 96 concurrent @NousResearch Hermes Agents &#40;using 382,745,618 tokens](https://x.com/mr_r0b0t/status/2050956694105059539)
+    - [Honestly it’s cool to see that there are companies where you can tell this kind](https://x.com/neogoose_btw/status/2051435315676750213)
+    - [You’ve been asking and we’ve been cooking. Our version control model is based on](https://x.com/nickgeracehacks/status/2051338949679792132)
+    - [It’s a free model I found online, but it’s really well optimized &#40;2,004 tris, ex](https://x.com/okawaiika/status/2050898132700131565)
+    - [terminal ambient is the best...  https://github.com/ozzyocak/ratherapia  #rustla](https://x.com/orhundev/status/2051581200561484122)
+    - [if you didn't check the current https://ataraxy-labs.com/ website then you are m](https://x.com/rs545837/status/2047743255224475662)
+    - [My biggest recent unlock has been switching from typing to speaking.  I started](https://x.com/s_streichsbier/status/2052680394848563653)
+    - [New beta release Finder too 😍 Muxy is more than just a terminal ⚡ https://x.com/](https://x.com/saeed_vz/status/2051251061315211623)
+}}
+
+\subtree[2026-05-12]{\mdnote{2026-05-12}{
+- #misc
+    - [Cooking the new mobile app... 🧑‍🍳 This time cross platform https://x.com/saeed_v](https://x.com/saeed_vz/status/2052656293299544220)
+    - [Adding @claudeai theme to Muxy... https://x.com/saeed_vz/status/2052753483456016](https://x.com/saeed_vz/status/2052753483456016387)
+    - [Someone just open-sourced an isometric Middle-earth map builder.  It's called Is](https://x.com/simplifyinAI/status/2052434243796529522)
+    - [@freshakafrancis this is not open source sorry, but there’s the github client wh](https://x.com/stylesshDev/status/2050193434976149797)
+    - [OpenCode just got a major upgrade.  Native GUI chat, switch to terminal anytime,](https://x.com/superdoteng/status/2051337107860308276)
+    - [Real-time terminal dashboard for PC power monitoring  https://github.com/GIN-SYS](https://x.com/tom_doerr/status/2051651012386050473)
+    - [Turns document collections into knowledge graphs  https://github.com/juanceresa/](https://x.com/tom_doerr/status/2051854290457636925)
+    - [Tracks battery usage of all connected Apple devices on Mac  https://github.com/l](https://x.com/tom_doerr/status/2051911528392061410)
+    - [Bulk organizes people, locations, and albums on self-hosted Immich  https://gith](https://x.com/tom_doerr/status/2051942037058932800)
+    - [WebGPU neural motion matching for bipeds and quadrupeds  https://github.com/swer](https://x.com/tom_doerr/status/2052081818757632124)
+    - [Open-source reverse engineering platform with rizin  https://github.com/rizinorg](https://x.com/tom_doerr/status/2052242209605288123)
+    - [Multi-region App Store manager for multiple Apple IDs  https://github.com/Lakr23](https://x.com/tom_doerr/status/2052292148129640549)
+    - [Zero-dependency spreadsheet engine written in TypeScript  https://github.com/pro](https://x.com/tom_doerr/status/2052311345865883968)
+    - [Converts images and PDFs to Markdown without OCR  https://github.com/NanoNets/do](https://x.com/tom_doerr/status/2052598745825415237)
+}}
+
+\subtree[2026-05-13]{\mdnote{2026-05-13}{
+- #rust
+    - [opensessions just hit 1000 stars  so to celebrate this, i've rewritten it in Rus](https://x.com/Palanikannan_M/status/2049927652249870544)
+- #render
+    - #cg
+        - [Prompt share: Cute 3D  💬Prompt: Cute 3D render of a &#91;subject&#93;, matte surface, kn](https://x.com/azed_ai/status/2051965725452239128)
+    - [Storyboard was created with GPT Image V2 on @AdobeFirefly, I use Chinese since i](https://x.com/GlitterPixely/status/2052201232589091219)
+- #os
+    - [Whatcable: macOS menu bar app that tells you, in plain English, what each USB-C](https://x.com/jedisct1/status/2051772502712422763)
+    - [Wow... someone built the AI note app Apple should have built.  It's called Blink](https://x.com/sentient_agency/status/2052689823170019433)
+    - [We can now reproduce issues directly in empheral crabboxes with WebVNC &#40;Linux/Wi](https://x.com/steipete/status/2051557150040711425)
+    - [Runs Linux apps on macOS with zero VM overhead  https://github.com/J-x-Z/cocoa-w](https://x.com/tom_doerr/status/2051419577247035471)
+    - [Sideloads iOS apps on macOS, Linux, and Windows  https://github.com/CLARATION/Im](https://x.com/tom_doerr/status/2052571837024850105)
+- #misc
+    - [Deep packet inspection without tcpdump or root access  https://github.com/domcyr](https://x.com/tom_doerr/status/2052771433676156980)
+    - [Browse and restore iPhone backups without iCloud lock-in  https://github.com/mom](https://x.com/tom_doerr/status/2052894575509864669)
+    - [v0.42.0 out now  - Properties now live in the Meta sidebar, with a redesigned UI](https://x.com/tryOctarine/status/2052650512563249511)
+    - [https://x.com/i/article/2050983909576294400](https://x.com/vmiss33/status/2050984556790939731)
+    - [PlayCanvas is making it possible to turn Gaussian splats into videogames. Today'](https://x.com/willeastcott/status/2051705650757935150)
+    - [Check out this splat by Walhar Gohar Mangi on SuperSplat: https://superspl.at/sc](https://x.com/willeastcott/status/2051705653509439608)
+}}
+
+\subtree[2026-05-14]{\mdnote{2026-05-14}{
+- #rust
+    - #zig
+        - [what!? is Bun moving from Zig to Rust???  https://github.com/oven-sh/bun/commit/](https://x.com/LukeParkerDev/status/2051431276205461635)
+        - [Zig has been great for Bun. This branch is a fun experiment, and not a decision](https://x.com/jarredsumner/status/2051595933704761618)
+    - #compiler
+        - #gpu
+            - [We open-sourced some amazing work on an experimental Rust compiler for GPU from](https://x.com/roeschinc/status/2052500245377118315)
+    - #gpu
+        - [Finally able to talk about what I've been heads-down on for 6 months at @nvidia](https://x.com/npashi/status/2052635742896304326)
+    - #web
+        - #software
+            - [Your terminal is about to replace your Markdown app.  Most developers still do t](https://x.com/NainsiDwiv50980/status/2051194703220199806)
+    - #os
+        - [Ahora puedes subir archivos a Google Drive, Dropbox, etc y NADIE podrá leerlos n](https://x.com/ErickSky/status/2052754359721623655)
+    - #tui
+        - [¿Y si tu agente de IA pudiera mejorarse solo, curarse y evolucionar sin que inte](https://x.com/ErickSky/status/2052951040228512242)
+    - #software
+        - [“No tokio”   Sounds like my directives in all my projects, which I insist use my](https://x.com/doodlestein/status/2051530037719883958)
+- #shader
+    - #gpu
+        - [Finally! Got GPU debugging to work for WebGL2 on MacOS, automated and AI-ready](https://x.com/hybridherbst/status/2052420104206393783)
+- #sec
+    - [Automates security testing for Android and iOS apps  https://github.com/MobSF/Mo](https://x.com/tom_doerr/status/2052068195045896327)
+- #software
+    - [Writer is now my favorite MD file viewer and editor. No Preview vs View. You can](https://x.com/edwardsanchez/status/2051477445598220329)
+    - [Introducing the new Hyperbrowser CLI.  Sandboxes. Browsers. Web automation. All](https://x.com/hyperbrowser/status/2052820277961359854)
+    - [we have `bun run` and the package.json scripts!   which is actually pretty diffi](https://x.com/jarredsumner/status/2052255591343759549)
+    - [Curated library of diverse robot models for MuJoCo  https://github.com/google-de](https://x.com/tom_doerr/status/2052536999500755365)
+}}
+
+\subtree[2026-05-15]{\mdnote{2026-05-15}{
+- #zig
+    - #web
+        - #os
+            - [Introducing zero-native  Build native desktop + mobile apps with web UI and Zig](https://x.com/ctatedev/status/2052907884728467699)
+    - #os
+        - [Not bad! https://x.com/steeve/status/2050892227824533939/photo/1](https://x.com/steeve/status/2050892227824533939)
+    - [Why Anthropic's changes to Zig are not going to be merged upstream https://ziggi](https://x.com/jedisct1/status/2051566785778884661)
+    - [In celebration of @rolldown_rs 1.0 🎉  Announcing `comptime` — a Zig-inspired bui](https://x.com/lukeed05/status/2052480459863658752)
+- #web
+    - #tui
+        - #software
+            - [I built an HTTP debugging proxy that runs in your terminal.  Introducing httpmon](https://x.com/gr1m0/status/2051641768530047256)
+    - #software
+        - [Built Diffdeck &#40; Open Source &#41;,  What: - Local diff in browser - Drop in replace](https://x.com/ParthJadhav8/status/2051693501147119647)
+        - [diffs&#91;dot&#93;com](https://x.com/pierrecomputer/status/2051702726245949649)
+    - [Lightweight network IP scanner with a web dashboard  https://github.com/aceberg/](https://x.com/tom_doerr/status/2052185108308713638)
+    - [Optimizes images locally in the browser  https://github.com/civilblur/mazanoke h](https://x.com/tom_doerr/status/2052471357166776504)
+- #sqlite
+    - [Released 🚦RepoBar 0.4.0.  This one makes the GitHub menu a lot smarter: persiste](https://x.com/steipete/status/2051088325100831046)
+- #wasm
+    - #software
+        - [Sharing progress.  JZ: JS→WASM  • Functional JS subset • No runtime, no GC  • Co](https://x.com/dmitryiv_/status/2050811348905255141)
+- #tui
+    - #software
+        - [Just released a new killer feature for Muxy that will boost your workflow! 😍  No](https://x.com/saeed_vz/status/2052870086403195113)
+    - [Howcode 0.1.4 just landed.   &#92;&quot;Just Chat&#92;&quot; mode, several UI/UX improvements, file-](https://x.com/Howaboua/status/2051097673415983264)
+}}
+
+\subtree[2026-05-16]{\mdnote{2026-05-16}{
+- #agent
+    - [Anthropic just dropped a 25-minute video showing everything new in Claude Code.](https://x.com/0x_kaize/status/2054298898902966377)
+    - [don't get me wrong, i love building startups  but every time i'm about to launch](https://x.com/ConnorKowallo/status/2054548708155412499)
+    - [People of Pi! I have just pushed a massive update to the pi-codex-conversion ext](https://x.com/Howaboua/status/2053430851845664944)
+    - [Howcode + Agent Pages FTW &amp;lt;3 This whole idea about giving your agents a canva](https://x.com/Howaboua/status/2055563454593855870)
+    - [Claude Code agent view is great! So I built one for Codex, OpenCode, Droid and P](https://x.com/JinjingLiang/status/2054114570948808754)
+    - [My Deepseek V4 Pro agent &#40;inside codex&#41; has been pursuing goal for more than 13](https://x.com/Michaelzsguo/status/2055317248923848713)
+    - [Your agent keeps duplicating code?  This skill helps you clean up https://github](https://x.com/Rasmic/status/2054719892457136231)
+    - [Codex /goal builds it.  Claude Code /goal review and refines it.  Hermes /goal m](https://x.com/Saboo_Shubham_/status/2054260705365475609)
+    - [发现个 Claude Code 的神级 Skill，画图颜值真的吊打 Mermaid 和 https://app.diagrams.net/！  firewor](https://x.com/VincentLogic/status/2053705949848944970)
+    - [run `claude agents` for a control plane in your terminal!    after, hit `&amp;lt;-`](https://x.com/_catwu/status/2053999857799672111)
+    - [I built this in my room.  No crew. No camera.  GPT Image 2 + Seedance 2.  Save t](https://x.com/abxxai/status/2054172585622155531)
+    - [Oxford researcher did a full deep dive on China’s “proxy station economy” for Cl](https://x.com/adxtyahq/status/2055720900583186845)
+    - [I’ve been working on dunk.  It’s a terminal diff reviewer where you mark issues](https://x.com/amix3k/status/2053773348719444360)
+    - [Agent views are the new UI primitive for managing fleets of agents.  But I want](https://x.com/arnestrickmann/status/2054071599222202499)
+    - [Multi-Token Prediction &#40;MTP&#41; for Qwen on LLaMA.cpp!  +40&#37; performance! 90&#37; accep](https://x.com/atomic_chat_hq/status/2054743353112088809)
+}}
+
+\subtree[2026-05-17]{\mdnote{2026-05-17}{
+- #agent
+    - [triangle company created a new &#92;&quot;system&#92;&quot; programming language &#92;&quot;for agents&#92;&quot; called](https://x.com/badlogicgames/status/2055639156437475499)
+    - [we built the first sane way to debug your agent locally.   you can see your trac](https://x.com/benhylak/status/2054987683928383872)
+    - [coming very soon to hunk® - post notes back to your agent https://x.com/bentlege](https://x.com/bentlegen/status/2055674184454337002)
+    - [Codex 5.5 is AGI for me.  Before going to bed last night I asked Codex to autono](https://x.com/cjzafir/status/2054268350910578911)
+    - [New in Claude Code: agent view.  One list of all your sessions, available today](https://x.com/claudeai/status/2053940934736228454)
+    - [Claude Code 2.1.139 added /goal  You set a completion condition and Claude keeps](https://x.com/dani_avila7/status/2053945243582488728)
+    - [Built dozens of ad-hoc agent harnesses this year. All replaced by https://fluefr](https://x.com/dok2001/status/2053680582547141006)
+    - [@andersonbcdefg Just use Claude Code from codex with ntm, it completely sidestep](https://x.com/doodlestein/status/2054744925523091847)
+    - [@dexhorthy @realsigridjin Yes, this is how my ntm tool works. I’m baffled by peo](https://x.com/doodlestein/status/2054807988225913294)
+    - [Aithy is live - A local agent on Bun, DSPy + RLM that makes small models hit har](https://x.com/dosco/status/2054626122516898110)
+    - [Introducing a 100&#37; free coding agent with DeepSeek v4 Pro  Choose any model, all](https://x.com/jahooma/status/2054055871240610027)
+    - [Fun artifact from Claude -- repo coming. https://x.com/jasonkneen/status/2053282](https://x.com/jasonkneen/status/2053282825722343752)
+    - [卧槽！刚发现一个能读取微信聊天记录的工具，私域运营神器啊！  wx-cli，让 AI 可以自由读取微信消息。  1. 消息随便翻：不用点开微信那个难用的搜索框，](https://x.com/jinchenma_ai/status/2053039222244962728)
+    - [people loved my Codex /goal share  so I built 7 production grade templates cover](https://x.com/kloss_xyz/status/2055477217552142782)
+    - [@brianjyip @charlieholtz @sriramk @badlogicgames Pi works in https://thecommande](https://x.com/krzyzanowskim/status/2033279510058082582)
+}}
+    }
+  }
+}

--- a/trees/2026-W21.tree
+++ b/trees/2026-W21.tree
@@ -1,0 +1,192 @@
+\import{macros}
+
+\title{2026-W21}
+\date{2026-05-18}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W21-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-05-18]{\mdnote{2026-05-18}{
+- #agent
+    - [@grashalm_ @badlogicgames this one https://github.com/nicobailon/pi-mcp-adapter](https://x.com/krzyzanowskim/status/2042952648534499555)
+    - [Introducing cmux Vault:  cmux now has a right sidebar with a vault pane where yo](https://x.com/lawrencecchen/status/2055248017025114609)
+    - [anthropic just made herdr the only usable agent manager for Claude Code after th](https://x.com/lumendriada/status/2054626174366519542)
+    - [OMG 😱   Claude+higgsfield  Prompt 👇 https://x.com/markproduct/status/20534779071](https://x.com/markproduct/status/2053477907113320800)
+    - [/goal is f*cking insane.  You can literally turn your AI agents into 24/7 employ](https://x.com/milesdeutscher/status/2054617939123605898)
+    - [I strongly believe there are entire companies right now under heavy AI psychosis](https://x.com/mitchellh/status/2055380239711457578)
+    - [If you don't have a 128GB mac, I also have a pi-llamacpp extension that just con](https://x.com/mitsuhiko/status/2053228285635498149)
+    - [@maddada @robinebers I pointed pi to codex and asked it to build a version of it](https://x.com/mitsuhiko/status/2053255199259611404)
+    - [Unironically bash only pi btw is quite fun:  $ pi -nes --tools bash --append-sys](https://x.com/mitsuhiko/status/2055593093307494413)
+    - [OpenCode x Qwen 3.6 Plus - free, again  Last time y’all treated our capacity lik](https://x.com/opencode/status/2055068702538612784)
+    - [Pi Agent vs OpenCode token usage  A lot of people recommended Pi Agent so I deci](https://x.com/pseudokid/status/2053441662014353805)
+    - [Whole day with Pi agent just used 10&#37; of my $20 Codex weekly quota  All gpt 5.5,](https://x.com/pseudokid/status/2054083721524084771)
+    - [The hardest thing about agents and backends is durability. @workflowsdk fixes th](https://x.com/rauchg/status/2044858872842826102)
+    - [Yesterday I realized that some of you might be confused about the AI gap between](https://x.com/scaling01/status/2055239876300190025)
+    - [Unsloth released MTP &#40;Multi-Token Prediction&#41; version of Qwen 3.6 27B and 35B A3](https://x.com/stableAPY/status/2054136118648434941)
+}}
+
+\subtree[2026-05-19]{\mdnote{2026-05-19}{
+- #agent
+    - #benchmark
+        - #sec
+            - [People freaking out over my AI spend. What nobody sees: Part of what excites me](https://x.com/steipete/status/2055405041843052792)
+        - #web
+            - [HTML vs Markdown for agent memory: Which is cheaper?  Before we ran the benchmar](https://x.com/kevinnguyendn/status/2055123503582679236)
+    - #cg
+        - [🚀 Introducing Articraft, a coding agent for articulated 3D asset creation.  Arti](https://x.com/RayLi234/status/2055345165779562870)
+        - [JustHireMe V0.1.31 is out.  🔗 Github: https://github.com/vasu-devs/JustHireMe 📥](https://x.com/Vasu_Devs/status/2055034724851347615)
+    - [&amp;gt; be github &amp;gt; invent copilot &amp;gt; you are literally the first one &amp;gt; you](https://x.com/thekitze/status/2054804667432120600)
+    - [I can't help but feel personally burned by the Claude Code changes announced tod](https://x.com/theo/status/2054731856248283318)
+    - [To prevent &#92;&quot;programmatic use&#92;&quot;, Claude Code may now request webcam access to assu](https://x.com/theo/status/2055793010370306556)
+    - [Runs Claude agents 24/7 inside tmux  https://github.com/Jedward23/Tmux-Orchestra](https://x.com/tom_doerr/status/2053437526682096089)
+    - [Enables Claude Max usage in third-party coding assistants  https://github.com/ry](https://x.com/tom_doerr/status/2053661709898793246)
+    - [Improves LLM reasoning accuracy without training  https://github.com/algorithmic](https://x.com/tom_doerr/status/2053761993295696054)
+    - [Orchestrates AI agents across 1000+ integrations  https://github.com/simstudioai](https://x.com/tom_doerr/status/2053978097360294384)
+    - [Sends and receives emails programmatically for AI agents  https://github.com/che](https://x.com/tom_doerr/status/2054531115071717499)
+    - [Turns real software into agent environments  https://github.com/cmu-l3/gym-anyth](https://x.com/tom_doerr/status/2054843236842123625)
+    - [Agent view is the best Claude Code native way to manage multiple sessions, kind](https://x.com/trq212/status/2053979505346425179)
+    - [Anthropic's Claude billing changes hit June 15. We wrote up what it means for Ze](https://x.com/zeddotdev/status/2055014283797307477)
+}}
+
+\subtree[2026-05-20]{\mdnote{2026-05-20}{
+- #agent
+    - #formal
+        - #rust
+            - [TLDR: Find and replace any unsafe code in your Rust project that isn't totally u](https://x.com/doodlestein/status/2055055444129747125)
+            - [Unfortunately, I don't use Zig now. Every 1.5-5x human DX productivity boost fro](https://x.com/zack_overflow/status/2053941110003933450)
+    - #proof
+        - #rust
+            - [@Nekrolm All this will get better. The code was doing the same thing before in Z](https://x.com/jarredsumner/status/2054984043708740093)
+    - #compiler
+        - [Explicit effects is one of the features that can make programming with agents mo](https://x.com/debasishg/status/2055529372988395807)
+        - [Zero - Vercel's new programming language for agents  It keeps effects explicit,](https://x.com/hd_nvim/status/2055484533974163516)
+    - #gpu
+        - #benchmark
+            - [NVIDIA just unleashed SANA-WM and it’s an absolute MONSTER for the future of ope](https://x.com/BrianRoemmele/status/2055492991918518692)
+        - [Two open-source MLX inference servers worth knowing about if you run LLMs on Mac](https://x.com/AlexJonesax/status/2053468341122007422)
+        - [Woow Nvidia has just released a 2.6B open-source world model 🔥  You can turn a s](https://x.com/itsPaulAi/status/2055402817871872250)
+    - #cg
+        - [Check out Ariticraft 🦾 - a highly efficient agentic system that generates articu](https://x.com/elliottszwu/status/2055372957493379325)
+        - [open-sourcing a 3D gen toolkit for Claude Code  input image → environment, meshe](https://x.com/neilsonks/status/2055013782771134479)
+        - [Generate an interactive 3D world ✨  I opened this project in Cursor and uploaded](https://x.com/venturetwins/status/2055352443299664125)
+    - #game
+        - #docker
+            - [📣 Introducing Trizen: an ultra-performant game engine and editor built on @three](https://x.com/MrCollison/status/2053532392963310065)
+    - #os
+        - #software
+            - [一个专为 AI 编码设计的 macOS 终端，把工作区管理、分屏和 AI agent 启动流程整合到一起。支持横竖分屏，一键启动 Claude Code、Cod](https://x.com/geekbb/status/2055655509059928551)
+        - [Real-time Claude AI usage monitor for macOS  https://github.com/AThevon/TokenEat](https://x.com/tom_doerr/status/2054939816802844883)
+    - #git
+        - #software
+            - [you guys keep waiting for Codex ios app, here im using this app to run multiple](https://x.com/damnGruz/status/2053610962297782371)
+}}
+
+\subtree[2026-05-21]{\mdnote{2026-05-21}{
+- #agent
+    - #rust
+        - #benchmark
+            - [I finally finished my Rust version of Mario Zechner's &#40;@badlogicgames&#41; excellent](https://x.com/doodlestein/status/2024526138102435934)
+        - #git
+            - [I have one big problem with agentic engineering: I want agents to operate autono](https://x.com/itsclelia/status/2053716807748567329)
+        - #software
+            - [Found it.  @OpenAI  is quietly building realtime voice mode into Codex.  You tal](https://x.com/DevAdventur3s/status/2055765342484590774)
+        - [Claude Code 被 Bun 的 bug 折磨，然后 Claude 把 Bun 重写了，重写完的 Bun 又回过头继续跑 Claude Code。  Bu](https://x.com/_kaichen/status/2055085251219919354)
+        - [Another &#92;&quot;Rust is the best language for coding agents&#92;&quot; take: https://zackoverflow](https://x.com/carllerche/status/2054228012292522364)
+        - [new project: tau, the nanogpt of agent harnesses.  hackable, 5049 lines in pure](https://x.com/elliotarledge/status/2053127859753939122)
+        - [The plan for tomorrow: dogfood Bun’s Rust port on Claude Code internally and sta](https://x.com/jarredsumner/status/2054520545954476468)
+        - [My team is hiring to make Bun and Claude Code faster.  Runtime internals, epoll/](https://x.com/jarredsumner/status/2054656310629879942)
+        - [@xeophon yeah I’ll just send their feedback to Claude to fix](https://x.com/jarredsumner/status/2054888486310936965)
+        - [@mycoliza this will be fixed before the rust rewrite makes it into a versioned r](https://x.com/jarredsumner/status/2055840930746573091)
+        - [@bunjavascript @ClaudeDevs @bcherny Jarred stop making memes and finish the rust](https://x.com/trq212/status/2054416391365967942)
+        - [Bun's Rust rewrite is pretty impressive, but the code is..... well, I'm no Rust](https://x.com/valigo/status/2054009502652108967)
+    - #render
+        - #web
+            - [https://plannotator.ai/ 🤝 @nicopreme   HTML explainers are better when you can i](https://x.com/plannotator/status/2053923479062450607)
+            - [Plannotator 0.19.14 released today  Plan/Annotate: - Visual Explainer skill + HT](https://x.com/plannotator/status/2054048840391479373)
+        - [GPT image 2 storyboard prompt:  Create a director-style PREVIS action storyboard](https://x.com/abxxai/status/2054172597869494387)
+}}
+
+\subtree[2026-05-22]{\mdnote{2026-05-22}{
+- #agent
+    - #rust
+        - #zig
+            - [Zig authors don't permit AI-written commits. Bun was bought by Anthropic, the gu](https://x.com/murage_kibicho/status/2053825834452943039)
+            - [@jarredsumner &#92;&quot;Zig also welcome&#92;&quot;😬 https://x.com/realNirajK/status/20548530450503](https://x.com/realNirajK/status/2054853045050359887)
+        - #software
+            - [@LukasHozda Not accurate. If you read the .zig and the .rs files side by side yo](https://x.com/jarredsumner/status/2055752448099434948)
+    - #sec
+        - #web
+            - [Hermes Agent vs OpenClaw using Qwen 35B Local Model  We asked agents to scrape G](https://x.com/atomicbot_ai/status/2055405319455715373)
+    - #software
+        - [oh noooooo, Anthropic won't allow me to use my Claude Max plan via CLI... I'm so](https://x.com/0xBOYD/status/2054929481828069463)
+        - [Present mode in open-slide just got a huge upgrade! 🔦  You can now choose how yo](https://x.com/1weiho/status/2055565189907644910)
+        - [You can now cut Claude Code's tool calls by 94&#37; with just one command.  This MCP](https://x.com/HowToAI_/status/2054180502060630053)
+        - [🌟Introducing🎻Violin — an Open-source Video Translation Skill.  📹Video is the dom](https://x.com/KevinQHLin/status/2055023321218154619)
+        - [man this is just sad to see  @sama: - Pay $200. Use product  Anthropic: - To cla](https://x.com/MaxRovensky/status/2055072853255495854)
+        - [Upgrading Agent — here's what's new 🧵  🤝 Agent Teams Multi-agent, multi-stage pa](https://x.com/MiniMaxAgent/status/2054563552103727439)
+        - [Install ntn, the Notion CLI.  It brings the entire Notion API to your terminal,](https://x.com/NotionDevs/status/2054594852818764178)
+        - [BIG one for devs today. Introducing the Notion Developer Platform:  - Notion CLI](https://x.com/NotionHQ/status/2054625030970220834)
+        - [Introducing Zenbu.js - The framework for hackable software  I wanted the ability](https://x.com/RobKnight__/status/2053867901028110592)
+        - [We just open-sourced Simulang, a JavaScript library that gives you and your codi](https://x.com/SimularAI/status/2055106756007629120)
+    - #sci
+        - [My first personal agent that’s actually helpful  For the past two weeks, I’ve ha](https://x.com/fsilavong/status/2055038267142074668)
+}}
+
+\subtree[2026-05-23]{\mdnote{2026-05-23}{
+- #agent
+    - #web
+        - [The agents can now &#92;&quot;see&#92;&quot; your slides - without needing a browser.  open-slide v1](https://x.com/1weiho/status/2053496256648094179)
+        - [Most &#92;&quot;agent browser&#92;&quot; tools = Playwright + stealth patches. Flagged in headless.](https://x.com/browseract/status/2054819936640680100)
+        - [If you use pi, try pi-agent-browser-native.  It makes agent-browser a native pi](https://x.com/fitchmultz/status/2054515092914594006)
+        - [LLM Wikis + HTML Artifacts are insanely powerful.  You should seriously consider](https://x.com/omarsar0/status/2052850591584383177)
+        - [html spec, activated https://x.com/plannotator/status/2052851731998941380/video/](https://x.com/plannotator/status/2052851731998941380)
+        - [mcporter 0.11.0 is live  I use mcporter mainly as more stable browser automation](https://x.com/steipete/status/2054986075232199038)
+        - [Vision-first browser agent for natural language automation  https://github.com/m](https://x.com/tom_doerr/status/2053970389026390330)
+        - [Runs Claude Code in a browser without SSH  https://github.com/rohitg00/tailclaud](https://x.com/tom_doerr/status/2055387342865637605)
+        - [正式开源 html-anything 🚀 1:1 让你感受全网爆火 Claude code 作者提的 HTML 效果！  你的 Agent 现在可以将任何数据转](https://x.com/tuturetom/status/2054860276088860819)
+    - #sqlite
+        - [the three-tier memory of Hermes agent.  AI agents forgets everything when your s](https://x.com/akshay_pachaar/status/2054861039804772827)
+    - #software
+        - [Released `pi-agent-codebase-workflows` for @earendilworks @badlogicgames pi: ski](https://x.com/TinoWening/status/2054850652690325721)
+        - [Cloudflare's Code Mode post argued agents are more efficient with code than a me](https://x.com/YoniBraslaver/status/2055260079700791544)
+        - [What @ashtom has done with @EntireHQ is magical   The Entire CLI hooks into your](https://x.com/nummanali/status/2054882669968638172)
+        - [Introducing: Superset CLI 🎮  Drive Superset from within the terminal, or sit bac](https://x.com/superset_sh/status/2054300997393248712)
+        - [It's crazy what you can do with a well written CLAUDE.md :&#41; https://x.com/theo/s](https://x.com/theo/status/2055794103858971123)
+}}
+
+\subtree[2026-05-24]{\mdnote{2026-05-24}{
+- #agent
+    - #web
+        - #git
+            - [Alright folks from the Pi world, my caveman Pi setup and a bit about the workflo](https://x.com/Howaboua/status/2053792465295937844)
+        - #software
+            - [用对比实验验证 SKILL.md 到底有没有用  https://github.com/darkrishabh/agent-skills-eval  agent](https://x.com/QingQ77/status/2053652309721206834)
+            - [Every single Chrome browser now has an LLM built-in, and almost nobody is buildi](https://x.com/colinarms/status/2054249593685393889)
+- #compiler
+    - #cg
+        - [Just released asimov-sim-lab 0.1.0 on PyPI.  @asimovinc team is doing something](https://x.com/AbdelStark/status/2053824346875941323)
+- #benchmark
+    - #cg
+        - [Pixal3D by Tencent.  3D models from images with unprecedented accuracy.  - Expli](https://x.com/wildmindai/status/2054323907054698735)
+    - [TurboQuant has drawn a lot of attention recently, but the accompanying evals did](https://x.com/_EldarKurtic/status/2053809592061030546)
+    - [How to benchmark local models -> https://bench-loop.com/  1. Pull a model 2. Run](https://x.com/outsource_/status/2054356316705915325)
+    - [2.3x faster.  Ran @UnslothAI Qwen3.6 MTP variants on a DGX Spark &#40;UD-Q6_K_XL&#41;:](https://x.com/stevibe/status/2054611290434527412)
+- #cg
+    - #game
+        - [Game devs: stop hunting for assets that almost fit your vision. Autodesk Flow St](https://x.com/adskflowstudio/status/2053872954413563962)
+    - #web
+        - [What if you could visit anywhere on Earth and feel like you are really there - f](https://x.com/willeastcott/status/2055315913537143043)
+    - [受全网浏览近千万的 3D 生物结构视觉启发，我制作了三星堆 3D 文物展览  我认为历史文物可视化是有着巨大商业价值的，因为当下国内博物馆制作的 3D 参观依然](https://x.com/Saccc_c/status/2054776532976238858)
+    - [Played around with generating the internal anatomy of a creature &#40;skeletons and](https://x.com/gaborpribek/status/2053879878693380346)
+    - [some quick tests for Tencent new open sourced 3D generation Pixal3D https://x.co](https://x.com/jtydhr88/status/2054510724588687702)
+    - [兄弟们！答应你们晚上开源，它来了  image to 3D模型目前只对接了线上：https://www.tripo3d.ai/ 你们也可以改其他家，或者本地模型](https://x.com/servasyy_ai/status/2053430277020770561)
+    - [Good.  ComfyUI just got native MoGe support - 3D geometry from monocular images.](https://x.com/wildmindai/status/2054916137402368333)
+}}
+    }
+  }
+}

--- a/trees/2026-W22.tree
+++ b/trees/2026-W22.tree
@@ -1,0 +1,163 @@
+\import{macros}
+
+\title{2026-W22}
+\date{2026-05-25}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W22-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-05-25]{\mdnote{2026-05-25}{
+- #formal
+    - #zig
+        - [Zig 0.16’s `Io` is an explicit capability passed like `Allocator` that decouples](https://x.com/debasishg/status/2053750095137698078)
+- #gpu
+    - [#Vibejam: Here it is! I just open-sourced the WebGPU procedural terrain engine I](https://x.com/HLS_dev/status/2052774999312810064)
+    - [Coming to MLX 🚀](https://x.com/Prince_Canuma/status/2054619040736280986)
+    - [Thank you to Kate for the comprehensive review of MTPLX.   She’s tested multiple](https://x.com/Youssofal_/status/2055457097819521396)
+    - [Biggest benefit of MTPLX is variable temperature.   Coding, creative writing, et](https://x.com/Youssofal_/status/2055496233817399322)
+    - [@goyal__pramod check out https://brrrviz.com/ for more gpu visuals 🤙](https://x.com/brrrkyle/status/2053834871529672753)
+    - [We released experimental MTP Qwen3.6 Unsloth GGUFs!  Qwen3.6 27B MTP now runs at](https://x.com/danielhanchen/status/2054537306732941412)
+    - [Luce PFlash now run @poolsideai’s Laguna-XS.2 &#40;33B-A3B MoE&#41; on a single RTX 3090](https://x.com/davideciffa/status/2054909843949957208)
+- #game
+    - #web
+        - [@TRA4669 Very cool! Any details how you approched it? This is main reason why I](https://x.com/mrEmphonic/status/2053024762964615278)
+    - #os
+        - [Tiny Glade, an indie game with one of the best GI solutions shipping in any game](https://x.com/yiningkarlli/status/2055072183404384388)
+    - [@TylerFCloutier The point of Bun was to frighten Node into a series of awesome i](https://x.com/MatthewParrott/status/2055852981199737329)
+    - [Lots of feedback and bug reports coming in from here and Reddit, game jam is ove](https://x.com/taylor_sntx/status/2054996682455031814)
+- #docker
+    - #os
+        - #tui
+            - [Holy shit. An Indian solo dev built the one terminal tool every developer has be](https://x.com/heynavtoor/status/2054124510786511258)
+    - [LocalStack Community MURIÓ.  Ahora te obligan a crear cuenta y te congelan las a](https://x.com/ErickSky/status/2053514828837158928)
+    - [4ga Boards 是实时看板项目管理工具，有暗色模式、可折叠列表、高级 Markdown 编辑，还能同时编辑卡片和筛选看板不丢失本地修改。  https:/](https://x.com/QingQ77/status/2054177268587446618)
+}}
+
+\subtree[2026-05-26]{\mdnote{2026-05-26}{
+- #lean
+    - [Recordings and slides from Software Verification in Lean 2026 are now available.](https://x.com/leanprover/status/2055346639657996479)
+- #gpu
+    - #render
+        - #cg
+            - [I'm so excited to announce a new terminal emulator! 🎉 Meet &#92;&quot;Ratty&#92;&quot;🐀  🧀 A GPU-ren](https://x.com/orhundev/status/2053778226816643521)
+    - #git
+        - #os
+            - [macOS 上想要一个好用的终端和 Git 工具？OpenOwl 把终端、Git 操作和代码编辑器塞进同一个原生窗口，不用来回切软件。  https://git](https://x.com/QingQ77/status/2055873696561287319)
+    - #software
+        - [oMLX deserves so much more attention than it gets.  &#40;My own NVFP4 implementation](https://x.com/Ex0byt/status/2053556942069485641)
+        - [Google has killed the GPU mafia 🤯  VS Code now connects directly to Google Colab](https://x.com/HowToAI_/status/2053772065149423648)
+    - [@ivanfioravanti I created https://github.com/samuelfaj/lightning-mlx to test exp](https://x.com/devindolar/status/2054301249537712379)
+    - [Why in the Apple MLX ecosystem, is everyone building a new engine copying from o](https://x.com/ivanfioravanti/status/2054299788229628042)
+    - [Mac 推理速度翻倍🚀  这个 MTPLX 是 MLX + MTP 的整合解决方案，专门针对 Apple Silicon 进行了模型推理优化，使用加入了定制 M](https://x.com/nash_su/status/2055508599909306570)
+    - [最近二十天我都在折腾一件事——怎么让 Qwen3.6-27B 在我的 Mac 上跑得又快又好。  一开始我用 Unsloth Q5，18 tok/s，风扇呼啦呼](https://x.com/nicekate8888/status/2055309100020596915)
+- #misc
+    - [@ClaudeDevs of what use is the weekly reset when it resets today anyways? lol. h](https://x.com/0x1Gerrad/status/2055360615800050068)
+    - [I am raising 20 Trillion tokens for open source RL.   Built on huggingface, and](https://x.com/0xSero/status/2054831789126869367)
+    - [“Cursor adoption produces substantial but transient velocity gains alongside per](https://x.com/0xglitchbyte/status/2033923909410586849)
+    - [大家怎么看 superpowers、gsd、gstack、openspec 这些专注于 Coding Workflow 的项目？  我会从中汲取一些 有用的 s](https://x.com/9hills/status/2053484210120527954)
+    - [What we expected from God.. https://x.com/Abbietrends/status/2053851935405486187](https://x.com/Abbietrends/status/2053851935405486187)
+    - [Jesus Amazon next time the STL creator writes a book just send it to me and bill](https://x.com/AdamRackis/status/2054721688265212312)
+}}
+
+\subtree[2026-05-27]{\mdnote{2026-05-27}{
+- #misc
+    - [Qwen3.6-27b absolutely flying on a M5Max with MTP enabled &amp;amp; oMLX inference.](https://x.com/AlexJonesax/status/2053549442234490977)
+    - [New batch of Codex ready Mac Minis rolling out on https://hyperbox.sh/ tonight](https://x.com/AlexReibman/status/2055152102641688586)
+    - [In the age of AI slop, some of us are still making things by hand, I promise ❤️](https://x.com/CameronFoxly/status/2054976947806241214)
+    - [CloakBrowser gets around every bot detection test. I wonder what the next &#92;&quot;bot d](https://x.com/ChaseWillden/status/2053927165583134741)
+    - [https://x.com/i/article/2053705681614536704](https://x.com/ChrisHayduk/status/2053807198870880743)
+    - [Players can race against a Gundam in Forza Horizon 6 https://x.com/Dexerto/statu](https://x.com/Dexerto/status/2055415428919541896)
+    - [Since many of you loved the introduction to category theory, why not going a lit](https://x.com/DiracGhost/status/2054673379848765734)
+    - [@0xSero https://fluxer.app/ looks promising, self-hostable instances soon.   htt](https://x.com/ElkimXOC/status/2054088284200910956)
+    - [https://x.com/i/article/2053374872806649857](https://x.com/ExpLang_Cn/status/2053378032459813233)
+    - [Introducing npx claude-p  A dropin replacement for claude -p https://x.com/FUCOR](https://x.com/FUCORY/status/2054684877467873465)
+    - [Someone just open-sourced a real-time map of the entire planet that tracks:  - C](https://x.com/HowToAI_/status/2055573463025553525)
+    - [Clean Opencode uses 13k for &#92;&quot;Hi&#92;&quot;. Pi loaded with skills and extension tools uses](https://x.com/Howaboua/status/2053574757761634454)
+    - [&#92;&quot;Very economical emotional damage&#92;&quot; LOL  bunx devragio https://x.com/Howaboua/sta](https://x.com/Howaboua/status/2054856759764820038)
+    - [hello, I updated my site, feels more, me. https://ja.mt/ https://x.com/JaceThing](https://x.com/JaceThings/status/2053219696250417640)
+    - [🚨 Codex quoats will reset &#92;&quot;this evening&#92;&quot; Turn on /fast mode, use it all!!](https://x.com/JinjingLiang/status/2055451044373790943)
+}}
+
+\subtree[2026-05-28]{\mdnote{2026-05-28}{
+- #misc
+    - [https://x.com/i/article/2053897403866992640](https://x.com/LLMJunky/status/2053901819009794364)
+    - [The first localmaxxing free rental and it’s qwen 27b on 8x6000 pro 😂  By @selim_](https://x.com/LottoLabs/status/2055085237173154115)
+    - [First link is botched but thread is good. Found in the ACT discord](https://x.com/NoahChrein/status/2055812621316555079)
+    - [Our recent work on Pedagogical RL is out!](https://x.com/NoahZiems/status/2055059419298177203)
+    - [@ramxcodes Or try this,   https://www.getwarden.org/  This will prevent it from](https://x.com/ParthJadhav8/status/2053092426555015432)
+    - [So true. https://x.com/PlanetOfMemes/status/2053290062540906730/video/1](https://x.com/PlanetOfMemes/status/2053290062540906730)
+    - [将本地代码变更拆分成逻辑章节并提供浏览器 UI 逐章审查，避免在大量 diff 中迷失重点  https://github.com/ReviewStage/st](https://x.com/QingQ77/status/2053302504503517583)
+    - [在两台机器之间通过 WebSocket 安全传输文件和文件夹，无需任何配置、云服务或 SSH 密钥。  https://github.com/aeroxy/dr](https://x.com/QingQ77/status/2053797264649298335)
+    - [discomorphism https://x.com/RaceJohnson/status/2055815818357940325/photo/1](https://x.com/RaceJohnson/status/2055815818357940325)
+    - [Solarpunk is a movement that imagines a sustainable and optimistic future where](https://x.com/Rainmaker1973/status/2053748046312206517)
+    - [I gave Pi a voice 🎙️  Shipped `@p8n.ai/pi-listens` v0.1.2 — a voice layer for @b](https://x.com/RavinBarthwal/status/2053077076245352751)
+    - [Great Resource to Learn Harness Engineering  https://walkinglabs.github.io/learn](https://x.com/RoundtableSpace/status/2054958667288510759)
+    - [I think @UnslothAI hit it out of the park with its Qwen3.6-27B MYP GGUF. Lots of](https://x.com/TeksEdge/status/2055145489105137768)
+    - [Someone built a website that reverse-engineers the X algorithm and breaks it dow](https://x.com/abhijitwt/status/2055622048177864947)
+    - [@ClaudeDevs token trap https://x.com/akankshaluvcats/status/2055363068385996884/](https://x.com/akankshaluvcats/status/2055363068385996884)
+}}
+
+\subtree[2026-05-29]{\mdnote{2026-05-29}{
+- #misc
+    - [it's not the same subscription if it doesn't let me use claude -p. that was my p](https://x.com/andersonbcdefg/status/2054721558141403242)
+    - [This is your annual reminder that we don’t need to speculate about whether we wi](https://x.com/andrewgwils/status/2054945551053930986)
+    - [I am the best OpenAI Codex Advertising, even if I would not sponsor a single vid](https://x.com/antirez/status/2054928217790660860)
+    - [Freaking love using cmdcmd: https://github.com/peterp/cmdcmd https://x.com/appfa](https://x.com/appfactory/status/2055802872592249032)
+    - [damn i love building stuff like this  turns out all it took to make a childhood](https://x.com/badfriend/status/2054879863228756344)
+    - [recommended reading. don't get confused by the title.  https://blog.k10s.dev/im-](https://x.com/badlogicgames/status/2053747834696995181)
+    - [&#92;&quot;done right&#92;&quot;  okidoki.  https://openclaw.ai/blog/openai-models-in-openclaw-done-](https://x.com/badlogicgames/status/2055035160836354213)
+    - [people of https://pi.dev/. i'm removing all tools from pi witbout replacement.](https://x.com/badlogicgames/status/2055303818057769330)
+    - [sneak peak of the new https://pi.dev/ no tools mode. you're gonna love it. you c](https://x.com/badlogicgames/status/2055345897328758899)
+    - [recommended reading.  this is our field's version of &#92;&quot;i hoped AI would be able t](https://x.com/badlogicgames/status/2055737604234973205)
+    - [Req is all you need #myelixirstatus https://benreinhart.com/blog/req-is-all-you-](https://x.com/benjreinhart/status/2054249153031713145)
+    - [What did I do to my claude code https://x.com/benswerd/status/205577568006830130](https://x.com/benswerd/status/2055775680068301308)
+    - [i cannot speak more highly of Lumen  it is the best terminal diff viewer i've tr](https://x.com/braelyn_ai/status/2055031261685788763)
+    - [🚨 ChatGPT is the best frontend model of the world   They pretty much solved it t](https://x.com/chetaslua/status/2053860163593838943)
+    - [Codiff: A beautiful, extremely fast local diff viewer  I review SO MUCH code loc](https://x.com/cnakazawa/status/2055281240748826832)
+}}
+
+\subtree[2026-05-30]{\mdnote{2026-05-30}{
+- #misc
+    - [My take on the bun stuff https://lobste.rs/s/lapqbz/bun_s_rust_rewrite_has_been_](https://x.com/croloris/status/2054998960553472111)
+    - [You can even make your own custom directives  Available for 12 renderers includi](https://x.com/ctatedev/status/2052392964932976697)
+    - [New proposal: https://mdxg.org/  Markdown Experience Guidelines  A spec for how](https://x.com/ctatedev/status/2053921664304631932)
+    - [Now available  --portless support for Emulate  Clean URLs for your API emulators](https://x.com/ctatedev/status/2054094206407225384)
+    - [Big day for Lucebox! Codex, Hermes and OpenClaw now run locally on our speculati](https://x.com/davideciffa/status/2053462872974307709)
+    - [我现在都懒得用 tmux 了，直接用 https://herdr.dev/ 或 https://muxy.app/ 更方便，适合懒人。](https://x.com/dingyi/status/2055528179830571472)
+    - [open-sourced here → https://github.com/eduwass/tmux-palette/ bun, zero deps, ~30](https://x.com/eduwass/status/2054344699805126693)
+    - [I wrote up some things about my experience playing with jj  mostly a braindump,](https://x.com/ellie_huxtable/status/2054330584286323090)
+    - [Critique of the 𝕏 algorithm is welcome.   There will be monthly updates of the l](https://x.com/elonmusk/status/2055293386123567441)
+    - [Well, switched from Bun to Node.js for our website CI/CD pipeline... 🥲  We think](https://x.com/ferron_web/status/2055024104189628762)
+    - [纯前端项目，14×14 网格上随便放建筑、树、地形，总共 75 个手绘风素材。渲染用了分层缓存，不动的瓦片不重绘，只刷新正在操作的部分，静态画面几乎零开销。触屏](https://x.com/geekbb/status/2055509566444704106)
+    - [Full reflections in blog form if you don’t like tweet threads!  https://naml.us/](https://x.com/geoffreyirving/status/2055241787208302867)
+    - [I left DeepMind to join the UK AI Security Institute as a Research Director in D](https://x.com/geoffreyirving/status/2055241788873470010)
+    - [It's a crime that more people have not read these beautiful blogs!   Beautiful v](https://x.com/goyal__pramod/status/2053465838959677954)
+    - [HOLY JESUS THIS IS AMAZING https://x.com/goyal__pramod/status/205400603655866390](https://x.com/goyal__pramod/status/2054006036558663906)
+}}
+
+\subtree[2026-05-31]{\mdnote{2026-05-31}{
+- #misc
+    - [Yann LeCun says LLMs are strongest in domains where language itself is the subst](https://x.com/haider1/status/2055322313843687523)
+    - [We made a fake repo with fake bounties, and the bots are applying fake PRs, so w](https://x.com/heyandras/status/2054512710017298463)
+    - [Here are 10 GitHub repos that quietly print money while you sleep.  1. Cal. com](https://x.com/heynavtoor/status/2055532691706265605)
+    - [+1,009,257 -4,024  Honestly don't know how we ended up here... https://x.com/hug](https://x.com/hugorcd/status/2054860448869277762)
+    - [DHH introduced me to Quickshell, so I had to make this quick select app Iron Man](https://x.com/iamdothash/status/2053882286131585069)
+    - [@badlogicgames I still don't like codex' way of exposing &#92;&quot;non-native&#92;&quot; tools. The](https://x.com/ianpascoe_/status/2055038704557944964)
+    - [One man’s trash is another squad’s battle platform 🚲 https://x.com/intotheunwell](https://x.com/intotheunwell/status/2054806631603437970)
+    - [Seedance 2.0. Unlimited. May 8–27.  10 days. Unlimited.  $0.11 per video. https:](https://x.com/itsPolloAI/status/2052722981986804031)
+    - [Your iOS Simulator now has a camera.   SimCam streams your Mac webcam into any s](https://x.com/itshanrw/status/2053429591054995894)
+    - [MTPLX is keeping up, engine still alive and great results!  So far so good!  M3](https://x.com/ivanfioravanti/status/2054945211634061365)
+    - [MTPLX 0.3.5  mtplx-qwen36-27b-optimized-speed &#40;it's 4bit&#41; AIME 25 test on M3 Ult](https://x.com/ivanfioravanti/status/2055017804940664999)
+    - [https://freebuff.com/](https://x.com/jahooma/status/2046417058381140023)
+    - [why: I am so tired of worrying about &amp;amp; spending lots of time fixing memory l](https://x.com/jarredsumner/status/2053058171338682875)
+    - [GPT 5.5 is surprisingly good at doing low poly threeJS models in code. https://x](https://x.com/jasonkneen/status/2055581491963277529)
+    - [SSH Keys Manager：集中浏览、复制、生成和整理 SSH 密钥及 SSH 配置条目的工具  👉 https://github.com/Stmol/s](https://x.com/jaywcjlove/status/2053476582770020782)
+}}
+    }
+  }
+}

--- a/trees/2026-W23.tree
+++ b/trees/2026-W23.tree
@@ -1,0 +1,180 @@
+\import{macros}
+
+\title{2026-W23}
+\date{2026-06-01}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W23-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-06-01]{\mdnote{2026-06-01}{
+- #misc
+    - [general Intelligence requires rethinking exploration  https://arxiv.org/abs/2211](https://x.com/jennyzhangzt/status/2055449869830246893)
+    - [/goal advice: Use plan mode to come up with a plan then instead of approving the](https://x.com/jpschroeder/status/2054289048231883176)
+    - [LMFAO.  Opus 4.7 just wrote me a fix for a bug, wrote tests, wired it all, it al](https://x.com/keithwhor/status/2055654006744400023)
+    - [Native Audio in OpenTUI via MiniAudio built-in.  Like, after the weekend or so.](https://x.com/kmdrfx/status/2052909908475916502)
+    - [by the way I use pi-profiles to handle work/private accounts separate https://pi](https://x.com/krzyzanowskim/status/2054489639239434523)
+    - [I made an interactive demo showing clamp&#40;&#41; in action and comparing it to traditi](https://x.com/kyrylo/status/2054503457256808561)
+    - [Needle Inspector Update 📡  &amp;gt; You can now step into ANY property and inspect i](https://x.com/marcel_wiessler/status/2055280725738537134)
+    - [mimalloc: A new, high-performance, scalable memory allocator for the modern era](https://x.com/matt_dz/status/2055101614764052974)
+    - [You can now add pi-code-previews as a dependency to your favorite extensions to](https://x.com/matt_leong/status/2054278382549078301)
+    - [wrap-up:  we built Pi-Serini because we wanted to know what happens when you sto](https://x.com/mattjustram/status/2054219969534238821)
+    - [Three.js &#40;TSL&#41; + WebGPU で ttyrec プレイヤーを実装。  VT100 互換端末で NetHack のプレイ録画を再生しました。 ・](https://x.com/meby_central/status/2055026511976300867)
+    - [Three.js &#40;TSL&#41; + WebGPU で端末ダンジョン。  壁一面が端末画面になった迷路のデモ。 ・壁が VT100互換端末として動作 ・NetHac](https://x.com/meby_central/status/2055451960132895218)
+    - [https://x.com/i/article/2054562106515804160](https://x.com/mem0ai/status/2054580022049198513)
+    - [diff-kit answers the question: what if Linear built an alternative UI for Github](https://x.com/michael_chomsky/status/2053509367740219449)
+    - [And finally Stanford bunny 🐇 and dragon 🐉 . OBJ parser learning section is compl](https://x.com/mlistudio/status/2053170410737246514)
+}}
+
+\subtree[2026-06-02]{\mdnote{2026-06-02}{
+- #misc
+    - [i’ve been playing around with flue, and have been really enjoying it  i’ve creat](https://x.com/momito/status/2053573800814399838)
+    - [thank you chatgpt  this is very helpful https://x.com/nicdunz/status/20556584693](https://x.com/nicdunz/status/2055658469370298682)
+    - [my favorite ways to &#92;&quot;write requirements&#92;&quot; with AI  1. /grill-me by @mattpocockuk](https://x.com/nurijanian/status/2055333397611077881)
+    - [BIG NEWS! 📢 The PlayCanvas Editor Frontend is now Open Source! Read More: https:](https://x.com/playcanvas/status/1950571895474036836)
+    - [From zero to cozy💚 https://x.com/protopop/status/2054959333897580875/video/1](https://x.com/protopop/status/2054959333897580875)
+    - [people of pi, i hated pi. i am not a fan of those lightweight concepts  but i no](https://x.com/q_yeon_gyu_kim/status/2053698203363737670)
+    - [evaluating omo in codex   Summer, the season of rewriting  this all possible tha](https://x.com/q_yeon_gyu_kim/status/2055908867138376138)
+    - [PSA: Please stop trying to install Omarchy on top of CachyOS 🫠](https://x.com/ryanrhughes/status/2055000065538744714)
+    - [Say what you want, but for people building products on Bun, this is bad news for](https://x.com/simonklee/status/2054873677536039219)
+    - [I built a whole distributed caching layer over gh. Still run into limits. https:](https://x.com/steipete/status/2053683890196201621)
+    - [I was wondering why the OpenClaw repo got so large, turns out the CHANGELOG md f](https://x.com/steipete/status/2054863606685036952)
+    - [🩹 clawpatch 0.1.0 is live:  Clawpatch maps codebases into semantic feature slice](https://x.com/steipete/status/2055364630709448970)
+    - [In physical systems, symmetries can create long-lived waves &#40;Goldstone modes&#41; th](https://x.com/t_andy_keller/status/2055306144986320945)
+    - [playing with https://zero-native.dev/ tonight, this thing is crazy   got a nativ](https://x.com/tarunsachdeva/status/2053655602463756659)
+    - [experimenting with new weapon types - this one is a homing energy shrapnel with](https://x.com/taylor_sntx/status/2046236995324715117)
+}}
+
+\subtree[2026-06-03]{\mdnote{2026-06-03}{
+- #misc
+    - [“We train a transformer with a growable KVM cache and show it performs competiti](https://x.com/teortaxesTex/status/2055075395079172466)
+    - [so should bun even have its own parsers and bundler anymore or should it just bu](https://x.com/thdxr/status/2054975898097525015)
+    - [this perspective sacrifices nvidia and keeps AI labs the winner while saying it'](https://x.com/thdxr/status/2054992656376234472)
+    - [@victormustar @huggingface @ClementDelangue @evalstate @mervenoyann @badlogicgam](https://x.com/the_ultralazr/status/2055226641186513317)
+    - [If you think a website can’t be vibe coded from just a design reference image, y](https://x.com/thebuggeddev/status/2053856714265629047)
+    - [Called it, they are gonna use Cursor’s data to leapfrog](https://x.com/theo/status/2055465492836659216)
+    - [this is what AGENTIC UI development looks like  profiling @expensify performance](https://x.com/thymikee/status/2053876957125792213)
+    - [Codex /goal now has a native Kanban board.  Starting a /goal run now fires up a](https://x.com/tolibear_/status/2053859040556360116)
+    - [Automates iOS App Store submissions with AI  https://github.com/blitzdotdev/blit](https://x.com/tom_doerr/status/2054292118181482941)
+    - [Patches iOS apps without jailbreaking  https://github.com/Naituw/IPAPatch https:](https://x.com/tom_doerr/status/2054295972570693681)
+    - [Unifies iOS and Android device management  https://github.com/pranshuchittora/si](https://x.com/tom_doerr/status/2054307584547467372)
+    - [100M parameter TTS runs on CPU  https://github.com/kyutai-labs/pocket-tts https:](https://x.com/tom_doerr/status/2054484940473893292)
+    - [Codex skills for UE5 Blueprints, C++, and UI  https://github.com/UnrealXu/Unreal](https://x.com/tom_doerr/status/2055464014717608183)
+    - [What? https://x.com/waozixyz/status/2055261532997464563/photo/1](https://x.com/waozixyz/status/2055261532997464563)
+    - [喜欢，给 tmux 的 command palette https://x.com/wey_gu/status/2054571895404773656/vide](https://x.com/wey_gu/status/2054571895404773656)
+}}
+
+\subtree[2026-06-04]{\mdnote{2026-06-04}{
+- #os
+    - [Your private stenographer.  Steno is an open-source macOS app that records, tran](https://x.com/GithubProjects/status/2054086749421457506)
+    - [用原生 macOS 界面管理本地 SSH 密钥和配置文件，避免频繁在终端中操作。  https://github.com/Stmol/ssh-keys-mana](https://x.com/QingQ77/status/2054192369797394522)
+    - [https://machinen.dev/ - boot once, run everywhere.  A MicroVM that runs on hardw](https://x.com/appfactory/status/2055345084892090844)
+    - [released pi-cua-driver.  Pi can now drive native macOS apps in the background us](https://x.com/eSaadster/status/2054592044824215704)
+    - [#Omarchy Linux + https://pi.dev/ + @FrameworkPuter = I love computers again.  Th](https://x.com/iamtyrichards/status/2054777405919612947)
+    - [I was so fed up with Finder...  That I started building my own native macOS file](https://x.com/leodev/status/2055604491244732863)
+    - [Veil for macOS is now live.  It keeps your screen private and distraction-free b](https://x.com/maomao000211/status/2053345375977939117)
+    - [Holy fucking cow, I now have my own Linux userland on my own iPad, after a decad](https://x.com/rcarmo/status/2055607913809379593)
+    - [excited to share what we’ve been working on  recording beautiful iOS demos is st](https://x.com/sashabirukoff/status/2054668597562396994)
+    - [Offline voice-to-text for macOS with local AI  https://github.com/Beingpax/Voice](https://x.com/tom_doerr/status/2053653987191042252)
+    - [Turns terminal apps into native macOS applications  https://github.com/mattroben](https://x.com/tom_doerr/status/2054334550361170367)
+    - [I have been really wanting to try out @heyclicky but it was macOs only and not o](https://x.com/uzairakrum/status/2053552812500693315)
+- #misc
+    - [@badlogicgames I know I said I don't use extensions, but I wanted to play with c](https://x.com/xonecas/status/2054681104381014498)
+    - [@eladgil BS.  Attention was born in Montréal  PyTorch in NYC. AlphaGo in London](https://x.com/ylecun/status/2053495035031609808)
+    - [Big diff go brrrrr https://x.com/zeddotdev/status/2054954463979315472/video/1](https://x.com/zeddotdev/status/2054954463979315472)
+}}
+
+\subtree[2026-06-05]{\mdnote{2026-06-05}{
+- #proof
+    - #rust
+        - #zig
+            - [My opinion on the Bun migration  The decision to auto-generate a Rust migration](https://x.com/fromdevoid/status/2055016521890447621)
+        - #lean
+            - [We can now fully rewrite most software in @leanprover and prove it correct:  - C](https://x.com/leonardoalt/status/2055290989149818978)
+        - #compiler
+            - [I'm applying this new UB exorcism skill now to the Bun Rust code. This is going](https://x.com/doodlestein/status/2055474612691935413)
+- #rust
+    - [github diffs survived 15 years untouched. we couldn't.  12 tabs. 0 signal. diffs](https://x.com/Palanikannan_M/status/2054274439983079507)
+    - [everyone, i uave great news! https://x.com/badlogicgames/status/2055917209197670](https://x.com/badlogicgames/status/2055917209197670516)
+    - [Thanks to the Rust rewrite, I now learn why Bun is fast  First find: it uses a t](https://x.com/boshen_c/status/2054961475819864539)
+    - [OK, my huge undefined behavior exorcism audit on the Bun Rust port is complete,](https://x.com/doodlestein/status/2055854220209803698)
+    - [Here's my GitHub repository with example rewrite from Python to Rust using AI: h](https://x.com/jangiacomelli/status/2054925788453986387)
+    - [@thdxr We will continue to have our own. Bun’s is faster than everything else I’](https://x.com/jarredsumner/status/2054983725046497777)
+    - [had this idea over the weekend and somehow ended up building a smol self hosted](https://x.com/kayleecodez/status/2054073009372336574)
+    - [you know what's intimidating?  I've seen way worse rust code than whatever is in](https://x.com/neogoose_btw/status/2054980412909490228)
+    - [we are impacted by bun stability more than almost anyone, anything they're doing](https://x.com/thdxr/status/2054958808535896189)
+    - [the good thing about the bun rust port:   there will be a dozen ai and rust hate](https://x.com/xeophon/status/2054871935201235379)
+- #render
+    - #web
+        - [Introducing `pi-visual` an extension for @badlogicgames 's pi that allows you to](https://x.com/polyMatto/status/2055158680153182593)
+    - #software
+        - [Thanks to a great plugin by WilliamLiu-1997 on Github, you can now render Gaussi](https://x.com/garrettkjohnson/status/2054780614583406738)
+}}
+
+\subtree[2026-06-06]{\mdnote{2026-06-06}{
+- #rust
+    - #zig
+        - #compiler
+            - [I don’t want to generalize that way - zig is a great language &amp; we owe a lot of](https://x.com/jarredsumner/status/2055412921845555446)
+        - #game
+            - [Most of the Zig &#92;&quot;hate&#92;&quot; I've seen is just fun n' games. But even so, having an an](https://x.com/ForrestPKnight/status/2055296231690154308)
+        - [Bun v1.3.14 releases tomorrow.   If we do merge the Rust rewrite, this would be](https://x.com/jarredsumner/status/2053808438644445230)
+        - [@mitchellh Yes, Zig made Bun possible. Bun went from me coding in a smelly room](https://x.com/jarredsumner/status/2055048100944003348)
+        - [@thdxr people are making so many incorrect assumptions  that anyone at Anthropic](https://x.com/jarredsumner/status/2055796104302858694)
+        - [It isn't unexpected that the focus of the Bun Rust rewrite is on the anti-Zig si](https://x.com/mitchellh/status/2055039647924007222)
+    - #compiler
+        - [The bun rewrite is some of the most impressive harness engineering I've seen. @j](https://x.com/FUCORY/status/2055675961195089964)
+    - #benchmark
+        - #os
+            - [there will be a blog post about this. on what this means for bun, benchmarks, me](https://x.com/jarredsumner/status/2053063524826620129)
+    - #render
+        - #web
+            - [We were curious what rendering Bun's rust rewrite would look like if we used our](https://x.com/fat/status/2055062500996202579)
+    - #web
+        - #os
+            - [This might be the future of self-hosted music apps.  Kopuz is a lightweight open](https://x.com/Techjunkie_Aman/status/2053455964943331479)
+            - [Linux music apps are suddenly getting REALLY good again.  Kopuz v0.5.5 just adde](https://x.com/Techjunkie_Aman/status/2054285243465777459)
+        - #software
+            - [Bun Rust  Fixed memory usage from 6.5 → 5.8MB Basic HTTP server from 9.0 → 6.0MB](https://x.com/saltyAom/status/2055787626632990739)
+    - #os
+        - [¿Cansado de apps de chat pesadas, lentas y que te espían?  Olvídate de Electron.](https://x.com/ErickSky/status/2053947518820499646)
+    - #tui
+        - [https://github.com/code-yeongyu/oh-my-openagent  this thing used to be in openco](https://x.com/q_yeon_gyu_kim/status/2055908869780738100)
+    - #software
+        - [Just stick with Deno or Node. I don’t want my runtime to be an ad for your compa](https://x.com/atalocke/status/2055092389539143842)
+}}
+
+\subtree[2026-06-07]{\mdnote{2026-06-07}{
+- #rust
+    - #zig
+        - #game
+            - [@glcst Choosing Zig was the right call early on. I had to write tons and tons of](https://x.com/jarredsumner/status/2053829772262912196)
+- #shader
+    - #render
+        - [Vibe Coding Metahuman with ThreeJS : Towards a Full Body  The app now has a firs](https://x.com/alightinastorm/status/2055838078833504298)
+- #sec
+    - #web
+        - [Every 3rd website you visit runs Nginx.  18,959,833 of them can be hijacked righ](https://x.com/hetmehtaa/status/2054894513509007865)
+    - #software
+        - [codex plugin that can be run on a schedule, inventories dependency manifests, ch](https://x.com/joe_lgtm/status/2054584048002138257)
+    - [@ryanvogel https://github.com/AikidoSec/safe-chain  @AikidoSecurity made a thing](https://x.com/SIGKITTEN/status/2054225163483316662)
+- #software
+    - [Tu OpenClaw estaba mudo... hasta ahora.  VoxClaw le da VOZ REAL a tu agente de I](https://x.com/ErickSky/status/2053496690972225950)
+    - [Why does VRAM usage jump when MTP is enabled?  From my Qwen3.6-35B-A3B-MTP runs](https://x.com/ItsmeAjayKV/status/2054992898266206600)
+    - [Codex is now a video editor  All you need is @HyperFrames_  + @HeyGen  plugins](https://x.com/Rames_Jusso/status/2055804906339279342)
+    - [CLI, API, MCP, SDK — LFG! https://www.notion.com/product/dev https://x.com/akoth](https://x.com/akothari/status/2054623046233939976)
+    - [Athas, a lightweight code editor. https://x.com/athasdev/status/2053573621449109](https://x.com/athasdev/status/2053573621449109929)
+    - [@Will_I_AmLegend I enjoyed reading this Reddit post https://x.com/jarredsumner/s](https://x.com/jarredsumner/status/2055632074770649363)
+    - [GPT-5.5 made a compatibility bridge so i can use Hermes as a Codex server in Kit](https://x.com/kxm43/status/2053889510296142225)
+    - [If you're wondering how I get those colorized ping outputs. I use grc &#40;Generic C](https://x.com/sysxplore/status/2054112956762280225)
+- #sci
+    - [If you've been struggling learning category theory, you might want to check out](https://x.com/DiracGhost/status/2053971882911703435)
+    - [Of course, the text 'Spin Geometry' by Lawson and Michelson is a classic, but if](https://x.com/DiracGhost/status/2055438553597768001)
+}}
+    }
+  }
+}

--- a/trees/2026-W24.tree
+++ b/trees/2026-W24.tree
@@ -1,0 +1,197 @@
+\import{macros}
+
+\title{2026-W24}
+\date{2026-06-08}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W24-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-06-08]{\mdnote{2026-06-08}{
+- #zig
+    - #compiler
+        - [The Zig compiler project rejects AI contributions for very concrete reasons.  -](https://x.com/croloris/status/2055369225779233043)
+        - [I wrote these words 7 months ago.  I am more grateful today for Andrew's leaders](https://x.com/jorandirkgreef/status/2055242144932089883)
+    - [Remember when Jarred said that Bun was only possible in a highly specialized sno](https://x.com/joshmanders/status/2054924506758594740)
+    - [ZML is written is Zig and it’s a big part of why we’re doing extraordinary thing](https://x.com/steeve/status/2053586859666596136)
+- #webgl
+    - #cg
+        - #game
+            - [The web isn't for documents it’s a game engine🚀 Built a mobile-first 3D pipeline](https://x.com/AdamRhmni/status/2053790138409312592)
+    - #web
+        - #os
+            - [mochi 是 Bun 运行时上的浏览器自动化库。它不是随机填指纹字段，而是用 48 条规则的 DAG 从一个 &#40;profile, seed&#41; 对派生所有指纹表](https://x.com/QingQ77/status/2054222570275143764)
+- #web
+    - #software
+        - [You can just build things with threejs!  This weekend I'm building a modular thr](https://x.com/rfitzpatrick_io/status/2053082967564775681)
+    - [Cabinet’s philosophy is that you shouldn’t save your work in uncomfortable MD fi](https://x.com/HilaShmuel/status/2053141450460701031)
+    - [Vibe coding procedural leg animations in three.js running in browser https://x.c](https://x.com/TRA4669/status/2052805923345772764)
+    - [@Tim_Damasc ~10 hours of back and forth about probably 40-50 different areas  I](https://x.com/TRA4669/status/2053156300813455868)
+    - [Anthropic is pushing HTML artifacts as the future of AI workflows.  What they're](https://x.com/godofprompt/status/2055664651057418704)
+    - [Security things from the last few days: - CopyFail &#40;linux pwn'd&#41; - CopyFail 2/Di](https://x.com/theo/status/2054445127662477581)
+    - [Curated frontend GIS libraries for web mapping  https://github.com/joewdavies/aw](https://x.com/tom_doerr/status/2054064335115231464)
+- #tui
+    - [Interactive TUI for scanning and removing large files  https://github.com/legost](https://x.com/tom_doerr/status/2054458010878013730)
+- #software
+    - #context
+        - [Good news, the 3.44&#37; is showing my context window! It appears Grok CLI doesn't h](https://x.com/mr_r0b0t/status/2055025393598451953)
+}}
+
+\subtree[2026-06-09]{\mdnote{2026-06-09}{
+- #agent
+    - #rust
+        - #compiler
+            - [Rust is a good language for agents because the compiler checks against memory sa](https://x.com/_Felipe/status/2056565109858713725)
+            - [Ok this is pretty cool  &amp;gt; https://zero.coey.dev/  &amp;gt; https://github.com/aco](https://x.com/acoyfellow/status/2055657964854296800)
+    - #gpu
+        - #benchmark
+            - [Some progress on jax-js this weekend!  - New matmul benchmarks - Real-time TTS d](https://x.com/ekzhang1/status/2056243423066124430)
+    - #render
+        - #cg
+            - [built a mini 3d asset gen factory over this weekend inspired by Articraft &#40;https](https://x.com/scottstts/status/2055986960729010592)
+        - [i don't hate terminals but i hate complexity of tmux/zellij  har session managem](https://x.com/yigitkonur/status/2056105605715378387)
+    - #web
+        - #os
+            - [https://github.com/kcosr/agent-runner](https://x.com/kcosr/status/2055485127317164491)
+        - [I'm testing how good Pi agent + Qwen3.6-27B is at playing chess. For the first t](https://x.com/TraffAlex/status/2056355130769916172)
+    - #software
+        - [People of pi: `pi-agent-codebase-workflows` v0.3.0 is out.  Main addition: `safe](https://x.com/TinoWening/status/2056088042402914529)
+    - [This is bigger than YOU think.  Hermes Agent now works with xAI Grok Subscriptio](https://x.com/Saboo_Shubham_/status/2055837534245294130)
+    - [Kimi K2.6 is 6x cheaper per token than Claude Opus 4.7.   But per task? It's onl](https://x.com/bridgemindai/status/2056059645655961848)
+    - [Is anyone doing feature flag development with agents?  Not tried it, but in theo](https://x.com/mattpocockuk/status/2056263621294866499)
+    - [Introducing pi-cost:  Cost dashboard for the pi coding agent — overview, project](https://x.com/nikiforovall/status/2055905078159048963)
+    - [Ever wondered what's actually loaded into your pi session?  pi-inspect - a tiny](https://x.com/nikiforovall/status/2056066480752480524)
+    - [`agent-memory` by @neo4j is the best open-source repository for building a unifi](https://x.com/pauliusztin_/status/2056272402414211175)
+    - [People of https://pi.dev/, I've just pushed some new updates to my PR agent that](https://x.com/prathamdby/status/2056504800418914571)
+}}
+
+\subtree[2026-06-10]{\mdnote{2026-06-10}{
+- #formal
+    - #proof
+        - #rust
+            - [Rocq is the dad of OCaml, OCaml is the dad of Rust  We updated our project &#92;&quot;rocq](https://x.com/FormalLand/status/2056408552814600437)
+- #gpu
+    - #web
+        - #software
+            - [🚀 Localmaxxers, run Qwen3.6-27B in your browser!  100&#37; WebGPU • Fully Local • Ze](https://x.com/TeksEdge/status/2056256198673080637)
+- #cg
+    - #visualization
+        - [⚡️After weeks of hard work, we're thrilled to fully open-source HY World 2.0 tod](https://x.com/DylanTFWang/status/2056288596995539015)
+    - #tui
+        - [Excited to announce the new era of terminal apps! 🎉   🐀 ratSCAD — CAD for the te](https://x.com/orhundev/status/2056298525445488794)
+    - [This is the Arduino of humanoid robotics.  We open-sourced a Unitree G1-level hu](https://x.com/eckartal/status/2056017977167032761)
+- #git
+    - [@MerrillLutsky Graphite is great, but it's far from a JJ-native forge. Stacked d](https://x.com/mitchellh/status/1930334341097500929)
+- #misc
+    - [🎹 Launching DSK ai Synth — a free online synthesizer with an infinite AI-powered](https://x.com/DSK_Music/status/2055849033264984550)
+    - [Which European cloud provider do you suggest?](https://x.com/Hamzeml/status/2056396377492492403)
+    - [说真的，多终端管理tmux 我现在基本不碰了。  🔗 https://herdr.dev/ 和 🔗 https://muxy.app/ 这俩工具一用，直接把 t](https://x.com/NFTCPS/status/2055643140154183887)
+    - [brb rewriting bun in lisette https://lisette.run/](https://x.com/_laurynas/status/2056343066449981500)
+    - [This is the best site on the internet to learn harness engineering  https://walk](https://x.com/_vmlops/status/2055887618303570151)
+    - [My trick for fixing the broken viewing angles in Gaussian Splatting works. It al](https://x.com/alexfredo87/status/2055836060215627880)
+    - [recommended reading.  https://blog.cloudflare.com/cyber-frontier-models/](https://x.com/badlogicgames/status/2056442002959450600)
+    - [As a by-product of building OpenPencil, I've open-sourced twirlwind — a CSS-to-T](https://x.com/dan_note/status/2055681681449693465)
+    - [It's still very buggy, but I did a WebGPU port of Runebender for ComfyUI. https:](https://x.com/eliheuer/status/2056521185912037863)
+}}
+
+\subtree[2026-06-11]{\mdnote{2026-06-11}{
+- #misc
+    - [I can't believe no one has hooked this up to codex/claude code yet except for me](https://x.com/elliotarledge/status/2055813341751500835)
+    - [pi-oracle 0.7.0 is out 🚀  Now supports Grok Heavy alongside ChatGPT.  - /oracle-](https://x.com/fitchmultz/status/2056055922930471211)
+    - [浏览器里的拖拽式网络架构图工具，画服务器、代理、数据库之间的数据流向，让用户无需编码即可拖拽搭建网络架构图。  https://github.com/ShadowArcanist/netviz](https://x.com/geekbb/status/2055988201227956364)
+    - [Gitlawb Playground is live! 🟢  BUILD ANY APPS FOR FREE  powered by OpenClaude, O](https://x.com/gitlawb/status/2056380435102683245)
+    - [🧪 Experiment in building a minimal programming language. Focus on parsing and ex](https://x.com/huozhi/status/2056111378977759429)
+    - [A quickshell dynamic wallpaper reacting to cliamp visstream https://x.com/iamdot](https://x.com/iamdothash/status/2055742294867726684)
+    - [New blog post: Bun's problem may be developing in the open https://00f.net/2026/](https://x.com/jedisct1/status/2056032806971584683)
+    - [plz gimme this one upgrade then i will stop crashing on ur couch plz can i borro](https://x.com/justinmk/status/2055660465867440142)
+    - [Behind Scenes of the P2P revolution 🕳️🥊  Become a peer at https://keet.io/ https](https://x.com/keet_io/status/1551510316286107648)
+    - [Things you can do with Rive scripting @rive_app . paper airplane https://x.com/o](https://x.com/ouroborobo/status/2056265623240393086)
+    - [Have your autoresearch model phone-a-friend with pi-lifeline  https://github.com](https://x.com/robzolkos/status/2056237451501244915)
+    - [STT on Muxy 🚀 Update to the latest Beta https://x.com/saeed_vz/status/2054669515](https://x.com/saeed_vz/status/2054669515313578111)
+    - [Two of my favorite tools were merged together, Obsidian and DuckDB.  @mehd_io cr](https://x.com/sspaeti/status/2056296562758651934)
+    - [Codex usage limits are back to normal. For ~2 hours we had some issues where the](https://x.com/thsottiaux/status/2056144502088437799)
+}}
+
+\subtree[2026-06-12]{\mdnote{2026-06-12}{
+- #rust
+    - #git
+        - #tui
+            - [Wow, shell startup screen is now useful! 💯  🌀 splashboard — A customizable termi](https://x.com/orhundev/status/2056058700180173155)
+    - [The people dunking on Bun’s Rust port  are having a hard time coming up with a s](https://x.com/jarredsumner/status/2056528045226533109)
+- #zig
+    - #software
+        - [⚡ Zig: Async I/O with std IO today.  Zig 0.16 introduced a standard I/O abstract](https://x.com/brk0v/status/2055908056135848040)
+- #shader
+    - #webgl
+        - #web
+            - [Terminals corridor  Demo and Source Code: https://t.co/9ifjMqlCRW  #threejs #web](https://x.com/sabosugi/status/2056077302824329453)
+- #visualization
+    - #git
+        - [Terminal UI for visualizing readable Git commit graphs  https://github.com/trasta298/keifu](https://x.com/tom_doerr/status/2055970334298255621)
+- #web
+    - #software
+        - [https://duckdb.org/2026/05/12/quack-remote-protocol](https://x.com/mehd_io/status/2054435693623968235)
+    - [Why open a browser just to search the web?  Connect TinyFish's free Search to a](https://x.com/Tiny_Fish/status/2056423110401008123)
+    - [I used claude to build me a &#92;&quot;Hey Siri&#92;&quot; from scratch entirely on my M4 Pro MacBoo](https://x.com/aryanranderiya/status/2056325510431686836)
+    - [couldn't help myself and also started cooking this sick diff viewer  same codeba](https://x.com/eduwass/status/2055747683659157541)
+- #os
+    - [Releasing my first kernel on @huggingface: MaxSim  Late-interaction retrieval &#40;C](https://x.com/ErikKaum/status/2056338682416701455)
+- #software
+    - [I ditched Cmux in favor of @aarondfrancis https://soloterm.com/ and it became my](https://x.com/DanielGri/status/2056446097007243411)
+    - [If you are looking for more indepth in gossip protocols you can use these reposi](https://x.com/Hi_Mrinal/status/2056367751871263111)
+    - [Going live, doing a full feature build using:  - /grill-with-docs - /handoff - /](https://x.com/mattpocockuk/status/2056309866801594424)
+- #misc
+    - [I am still thinking about this, if bun will have it... https://x.com/wiedymi/status/2056306237403443703/photo/1](https://x.com/wiedymi/status/2056306237403443703)
+}}
+
+\subtree[2026-06-13]{\mdnote{2026-06-13}{
+- #agent
+    - [Alright Pi people, smart btw by yours truly.  - runs with all the skills/tools/e](https://x.com/Howaboua/status/2057227219244613924)
+    - [This could be huge. Microsoft's new SkillOpt trains skills without changing mode](https://x.com/aisearchio/status/2058995203818881046)
+    - [first week in years I haven't reached for tmux  completely switched to herdr by](https://x.com/andrewqu/status/2057329913024356438)
+    - [Do you want to review a 1-million-line PR?    @jarredsumner did not make it easy](https://x.com/aravindputrevu/status/2055043886150520958)
+    - [LobeHub 新一次 Launch ，我们做了一个 CAO （Chief Agent Operator）🤯  这次 Launch 算是最近 3 个月迭代以来的](https://x.com/arvin17x/status/2056381182154330272)
+    - [NEW from Datadog:  it's Lapdog! Ever wondered what your AI agent was actually do](https://x.com/astuyve/status/2056772052636319955)
+    - [People of https://pi.dev/ are now tokenmaxxing to make Dario and Sama happy.](https://x.com/badlogicgames/status/2060117440730656918)
+    - [want to port from language A to language B but don't have a massive test suite?](https://x.com/badlogicgames/status/2060528107606442251)
+    - [My total input:  “use obliteratus…” “do it!” “test it yourself” “ask more questi](https://x.com/elder_plinius/status/2044463620323676306)
+    - [Everyone's bottleneck in voice AI is the same: retrieval. The agent thinks, netw](https://x.com/garrytan/status/2060354064056201707)
+    - [been using this all week, have needed this for like a year  nice work Nathan](https://x.com/irl_danB/status/2057212105997316134)
+    - [There is now a fuzzer running 24/7 for every language parser in Bun, ranging fro](https://x.com/jarredsumner/status/2058540017417675137)
+    - [I’ve just released MiMo V2.5-Coder. If you have 128 GB of RAM, this is one of th](https://x.com/jedisct1/status/2058827764237525231)
+    - [it looks funny, I can't disagree  But I don’t get why the fun stands in using ag](https://x.com/joko76ers/status/2060446083315052886)
+    - [https://github.com/webxos/lack  Slack for agents. https://x.com/lack2026/status/2057175733806510243/photo/1](https://x.com/lack2026/status/2057175733806510243)
+}}
+
+\subtree[2026-06-14]{\mdnote{2026-06-14}{
+- #agent
+    - #rust
+        - [pibot is now running fully local, using parakeet for STT, qwen3-tts for TTS, and](https://x.com/badlogicgames/status/2060268257739677713)
+        - [What I Built  Clauge is a cross-platform desktop app &#40;Rust + Tauri, ~25MB, sub-s](https://x.com/claugeAi/status/2058681672749518979)
+    - #benchmark
+        - #web
+            - [BenchLocal v0.2.7 is out!  A benchmark tool for AI agents... that had no interfa](https://x.com/stevibe/status/2056351461613957160)
+    - #game
+        - [awesome work by the PI team 👏   I think we’re still in the very early days of ex](https://x.com/Vtrivedy10/status/2056590116794364115)
+    - #git
+        - #software
+            - [i built a CLI for running multiple git worktrees without losing my mind.  it cre](https://x.com/ccssmnn/status/2056480619622793280)
+        - [🧠 Just write Git as Memory — store AI agent memory directly in Git refs No exter](https://x.com/femtowin/status/2056659569745813833)
+        - [herdr 0.6.1. is out!  this one ships a bunch of fixes, better agent detection, c](https://x.com/lumendriada/status/2057877552744546496)
+    - #context
+        - [recommended viewing by @helloiamleonie !](https://x.com/badlogicgames/status/2060323691800461552)
+    - [&amp;gt; cmux Valut Agent とのやり取りを全文検索したり再表示したりできる機能があったのか](https://x.com/lollipop_onl/status/2058471712447234415)
+    - [Local agents, local models, local control.  Excited to collaborate with @atomic_](https://x.com/nanobot_project/status/2056755416038850875)
+    - [Every time GitHub has an outage our team is paged. Incidents at Vercel get autom](https://x.com/rauchg/status/2059612940307714540)
+    - [harness is dead tokenmaxxing is dead  steal his minimal setup lmao  my friend be](https://x.com/realsigridjin/status/2059835656592097565)
+    - [Folks: when you write skills, ask your agent to be token efficient, relax gramme](https://x.com/steipete/status/2058917897590673525)
+    - [Asking two agents in different harnesses to debug your code  &#40;from andirockk on](https://x.com/venturetwins/status/2057296003842412890)
+    - [Terminal Threads are live in Zed v1.3.5!    You can now run claude, amp, pi, or](https://x.com/zeddotdev/status/2057146889661788657)
+}}
+    }
+  }
+}

--- a/trees/2026-W25.tree
+++ b/trees/2026-W25.tree
@@ -1,0 +1,173 @@
+\import{macros}
+
+\title{2026-W25}
+\date{2026-06-15}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W25-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-06-15]{\mdnote{2026-06-15}{
+- #agent
+    - #rust
+        - #zig
+            - [Prototype it in TypeScript, then convert it to Rust &#40;or Zig&#41;.  This is agent-ci'](https://x.com/appfactory/status/2059380305870410066)
+        - #git
+            - [现在大多数Terminal AI agent 就是个 LLM 套壳——read、write、bash 三板斧，遇到错误要调试、subagent 并发协调，跟 I](https://x.com/FakeMaidenMaker/status/2057558799028981930)
+        - #software
+            - [🦀 alint : a language-agnostic repo linter written in Rust.  ESLint lints your co](https://x.com/ayushagarwal027/status/2054864832562974880)
+            - [Parse PDFs at lightspeed &#40;this video is at 1x&#41;   Absolute cinema https://x.com/j](https://x.com/jerryjliu0/status/2060401682610262424)
+        - [Started building a Rust port of pi coding agent → pie.  I needed something beyon](https://x.com/dxhuang/status/2057468157087162798)
+        - [🫧 My first open-source project!  q-body — A2A protocol agent in Rust. Its soul l](https://x.com/liumin640883/status/2058722256881438879)
+        - [Introducing `hitch`  Share your terminal with an agent, in one command  Agents w](https://x.com/maxktz/status/2059697052607562026)
+    - #sec
+        - #software
+            - [We just launched @Vigolium a high-fidelity vuln scanner in Go, fully open source](https://x.com/j3ssie/status/2058229682336915908)
+            - [what he said and also ->  1&#41; @bunjavascript install hardening: `bunfig.toml` enf](https://x.com/zacharyr0th/status/2053967908553036076)
+    - #web
+        - [Finally... wrote the blog post about my minimal Pi setup:  1/ DeepSeek v4 Pro wi](https://x.com/DeepakNesss/status/2060410946569527379)
+        - [pi agent 因为 kimi code 又火起来了。  因为 pi 实在太精简了，要搭配一些插件才好用。  以下是我常用的  - context-mode](https://x.com/ZeroZ_JQ/status/2059153461967749363)
+    - #software
+        - [New: Pi is now built into the Entire CLI.  Previously available as an external a](https://x.com/EntireHQ/status/2057568897868444011)
+        - [seeing so much love for herdr lately that i can’t stop building.  so here’s a sn](https://x.com/lumendriada/status/2058238905195889048)
+        - [i'm excited to open source Active Graph: an event-sourced reactive graph runtime](https://x.com/yoheinakajima/status/2057099245430222926)
+    - #sci
+        - [recommended reading.](https://x.com/badlogicgames/status/2057812929462841796)
+}}
+
+\subtree[2026-06-16]{\mdnote{2026-06-16}{
+- #agent
+    - #zig
+        - #sqlite
+            - [Built a native macOS task manager for coding agents using Zero Native from @ctat](https://x.com/jpudysz/status/2056619453354283062)
+    - #web
+        - [💥 https://resend.com/auth.md](https://x.com/zenorocha/status/2057939650514203058)
+- #formal
+    - #sec
+        - [Many people have claimed that with AI-assisted bug finding, secure code &#40;and hen](https://x.com/VitalikButerin/status/2056354141832626487)
+    - [this is incredibly dangerous  - leaking github source code makes github easier t](https://x.com/aidenybai/status/2056970090009297104)
+- #cg
+    - #game
+        - #web
+            - [We’re open-sourcing Stem Studio, our 3JS game engine today.  This is a browser-b](https://x.com/markpinc/status/2060099876621271321)
+- #game
+    - [Autodesk’s fine has bankrupted our small studio.  A few months ago, we made a se](https://x.com/TheScholastics/status/2058963651403436523)
+    - [SCOPE is a new FPS world model for controllable game video. It turns gamepad inp](https://x.com/aisearchio/status/2058753635358798011)
+    - [any lack of polish now gets equated to ai slop  all fields: software bugs, bad m](https://x.com/thdxr/status/2058362746056355856)
+- #misc
+    - [fff 挺好，但是就是疯狂crash。  默默卸载了pi-fff，碰到某些文件名尤其是CJK的，就很容易崩溃。  https://fff.dmtrkovalenko.dev/](https://x.com/9hills/status/2056529090350662088)
+    - [新一代Mass平台 https://elss.ai/ 正式上线，主流模型大促销。    GPT系列包括 GPT 5.5 低至 0.3 折  Claude系列包括](https://x.com/DashiGCC/status/2059997600326021238)
+    - [https://x.com/i/article/2057390405101248513](https://x.com/EEEEYHN/status/2057397813999456759)
+    - [Github HACKED.   The internal repository has been breached.  Hacker group claims](https://x.com/Grummz/status/2056910225282859432)
+    - [Looking for alpha testers for https://foravo.dev/  A European alternative to](https://x.com/Hamzeml/status/2057026076706996606)
+    - [I'm going to go ahead and suggest we bump this number up.   🫩 ← npm users https:](https://x.com/JinjingLiang/status/2056751743166210068)
+    - [Bun が C++ を使いはじめたってポータブルな SIMD 実装として highway を使いはじめたってだけか… そんなこと言ったら Bun は最初から W](https://x.com/Linda_pp/status/2060337037983805727)
+}}
+
+\subtree[2026-06-17]{\mdnote{2026-06-17}{
+- #misc
+    - [diffs&#91;dot&#93;com speed secrets revealed!  https://pierre.computer/writing/on-render](https://x.com/SlexAxton/status/2060446823945310491)
+    - [Open-sourcing Hy-MT2 today 🌱Three model sizes, 33 languages:  🪄1.8B: 440MB, runs](https://x.com/TencentAI_News/status/2057400913061650805)
+    - [Might be a dumb question, but how are devs on personal machines supposed to catc](https://x.com/ZackKorman/status/2056705703809618048)
+    - [Looks like a massive GitHub Actions exploitation campaign going on. Example comm](https://x.com/abh1sek/status/2057490674954727913)
+    - [what good is an &#92;&quot;industry standard&#92;&quot; saying the frontmatter must be valid YAML, w](https://x.com/badlogicgames/status/2056645440624333259)
+    - [someone at the foundation doesn't seem to like me. first they stopped sponsorshi](https://x.com/badlogicgames/status/2057391656379269272)
+    - [recommended reading.  https://nolanlawson.com/2026/05/25/using-ai-to-write-better-code-more-slowly/](https://x.com/badlogicgames/status/2059190700827140495)
+    - [@mattlam_ everything goes. it's kinda like religion for me. i'm not a believer,](https://x.com/badlogicgames/status/2059417691975217522)
+    - [this is going to be super duper interesting!  i wonder what sparse attention met](https://x.com/badlogicgames/status/2059434370838970453)
+    - [People of https://pi.dev/: innovating without limits.](https://x.com/badlogicgames/status/2059974867961741575)
+    - [look at the little robot brain running fully local and it's super low latency. &#40;](https://x.com/badlogicgames/status/2060493652825092207)
+    - [In the next version of Uniwind Pro, you’ll be able to apply styles directly to R](https://x.com/brentlok_/status/2056639384162603247)
+    - [https://x.com/i/article/2057407217054199808](https://x.com/bridge_surf/status/2057416247319618039)
+    - [scenes at GitHub HQ right now: https://x.com/cgtwts/status/2056900593218937299/video/1](https://x.com/cgtwts/status/2056900593218937299)
+    - [A short demo of how I use these extensions that I created for myself in Pi   - p](https://x.com/championswimmer/status/2060489640688144545)
+}}
+
+\subtree[2026-06-18]{\mdnote{2026-06-18}{
+- #misc
+    - [https://x.com/i/article/2058216086764720128](https://x.com/davidcrawshaw/status/2058219628120461810)
+    - [Qwen3.6-27b and 35b MXFP4 MXFP8 CRACK is out now with MTP. Enjoy uncensored spee](https://x.com/dealignai/status/2058653981090705676)
+    - [@hasante_ Yes, we have Socket Firewall https://socket.dev/blog/introducing-socket-firewall](https://x.com/feross/status/2057662587727429987)
+    - [If pi /goal ever retried itself into oblivion after a provider hiccup — v0.1.13](https://x.com/fitchmultz/status/2059273142129037624)
+    - [This is bad.  Those repos likely contain the GitHub infrastructure: the next sup](https://x.com/fortysevenfx/status/2056963454225744305)
+    - [How did GBrain become SOTA on LongMemEval?   I use my 300k markdown file knowled](https://x.com/garrytan/status/2060225116735512835)
+    - [基于 Cloudflare 构建支持自定义域名的自托管 AI 邮件客户端。  用 Cloudflare 做的自托管邮件系统，能用自己的域名收发邮件。有域名管理、](https://x.com/geekbb/status/2059502860027543971)
+    - [1/ We are sharing additional details regarding our investigation into unauthoriz](https://x.com/github/status/2056949168208552080)
+    - [New in Hatchet 1.22.3: Our TypeScript SDK is now compatible with Bun! 🪓 https://](https://x.com/hatchet_dev/status/2056442856387047763)
+    - [yt-dlp plans to drop support for Bun Reason: it is vibe-coded https://t.co/m5vB4](https://x.com/hd_nvim/status/2057843081441903062)
+    - [thingamajig built with @threejs https://x.com/hive_echo/status/2056603762387755352/video/1](https://x.com/hive_echo/status/2056603762387755352)
+    - [xAI open-sourced the algorithm that scores every tweet on X.  19 engagement sign](https://x.com/hyperbrowser/status/2056452361384853922)
+    - [Since a bunch of people asked about Bun’s usage of unsafe, here’s some slop   ht](https://x.com/jarredsumner/status/2057587641277984935)
+    - [@50onice &amp;gt; don’t share publicly  This is not accurate. It’s always been a pub](https://x.com/jarredsumner/status/2058338616485798114)
+    - [ghostty but with smooth scrolling https://x.com/kdrag0n/status/2056661414266425574/video/1](https://x.com/kdrag0n/status/2056661414266425574)
+}}
+
+\subtree[2026-06-19]{\mdnote{2026-06-19}{
+- #misc
+    - [GCC16 supports contracts in C++. Among other things, you can specify in code you](https://x.com/lemire/status/2056365013443465624)
+    - [@iamsahaj_xyz pi-autoresearch to let it try stuff out and optimize something  pi](https://x.com/leostera/status/2058206809370796036)
+    - [for anyone switched to gpt from claude and really dislikes how gpt always talks](https://x.com/lumendriada/status/2059705590209819048)
+    - [one thing to know about aikido is we maintain a ton of free resources and tools](https://x.com/madelinelawren/status/2056982210411213111)
+    - [one week after launching marka.md, v1.5 is out 🐙  new: context tray  stage multi](https://x.com/mattenarle/status/2058949240223936836)
+    - [What the hell is happening Microsoft?!!?? https://x.com/medusa_0xf/status/2057004994851950609/photo/1](https://x.com/medusa_0xf/status/2057004994851950609)
+    - [https://github.com/Michaelliv/pi-dynamic-workflows](https://x.com/micLivs/status/2060115517013160355)
+    - [¡Si eres programador, necesitas esta aplicación! Abre un emulador de iOS o Andro](https://x.com/midudev/status/2057445421325136301)
+    - [Supply chain attacks and OSS sustainability go hand in hand. I've semi-seriously](https://x.com/mitchellh/status/2057567975826395606)
+    - [🎉pi-inspect 0.5.0 is out:  - enable/disable pi customizations - share your setup](https://x.com/nikiforovall/status/2057039908758282355)
+    - [Introducing codedb v0.2.5818.    ~1μs per lookup. 50,000x faster than grep. 12x](https://x.com/rachpradhan/status/2059184341989945477)
+    - [People of Pi, https://github.com/rcarmo/piclaw/releases/tag/v2.5.1 just released](https://x.com/rcarmo/status/2060284447191114186)
+    - [anthropic is insane  random korean kids shipped oh-my-opencode with ultrawork ha](https://x.com/realsigridjin/status/2060214573941276921)
+    - [I heard y'all like TUIs and email. https://x.com/rockorager/status/2058174763684536719/video/1](https://x.com/rockorager/status/2058174763684536719)
+    - [@JinjingLiang or use pmg that blocks any install for you that are malicious and](https://x.com/safedepio/status/2054069420268663036)
+}}
+
+\subtree[2026-06-20]{\mdnote{2026-06-20}{
+- #render
+    - [Liquid DOM implements its own high performance SDF-based rendering engine for ca](https://x.com/AndrewPrifer/status/2056923987222114393)
+- #os
+    - [Are you ready for a fast, lightweight tool for macOS and linux, &#40;maybe windows&#41;](https://x.com/productdevbook/status/2060061443681046914)
+    - [Transforms kernel metrics into a cyberpunk skyline  https://github.com/5c0/metropolis http](https://x.com/tom_doerr/status/2057654887681257890)
+- #misc
+    - [Every screen recorder is basically a copy of this open-source project. If you se](https://x.com/sahilcodex/status/2058760660713144475)
+    - [npm user?  ➡️ One small change to stay safe, FREE  Add these aliases  ➡️ pkg ins](https://x.com/sebastienlorber/status/2057733567484953019)
+    - [it'd be nice if the next time github actions is down i can resume work without g](https://x.com/sinasanm/status/2059298517156528489)
+    - [I'm late to the party, but cmux is great. https://github.com/manaflow-ai/cmux  current split](https://x.com/steipete/status/2058093406874689770)
+    - [This seems more ideological than technical.](https://x.com/steipete/status/2058101804202602949)
+    - [Hit GitHub's rate limit one too many times, so I built octopool: a Cloudflare Wo](https://x.com/steipete/status/2059989719870558309)
+    - [I smell a takedown in 3...2...1 https://clawd.rip/](https://x.com/steipete/status/2060294413377519808)
+    - [🥳Introducing Recordly v1.3.0!  Recordly is your open-source tool for making app](https://x.com/webadderall/status/2058470066967208170)
+    - [PHALANX v3.3: https://github.com/webxos/phalanx https://x.com/when_robots_cry/status/2056881782604103690/photo/1](https://x.com/when_robots_cry/status/2056881782604103690)
+    - [Github knew for hours, they delayed telling you and they wont be honest in the f](https://x.com/xploitrsturtle2/status/2056927898771067006)
+    - [today i'm launching https://rag.computer/  an open source RAG platform built o](https://x.com/yoginth/status/2057836842628833480)
+    - [https://x.com/i/article/2056775057989337088](https://x.com/zachlloydtweets/status/2056780898675167656)
+}}
+
+\subtree[2026-06-21]{\mdnote{2026-06-21}{
+- #rust
+    - #compiler
+        - #web
+            - [A Rust dev built a Python compiler in 90 days. 13K lines of no_std Rust. ~170KB](https://x.com/ayushagarwal027/status/2059711362109001817)
+        - [Rust promises zero-cost abstractions. But how well does it actually deliver? 🦀](https://x.com/ayushagarwal027/status/2058860955417899507)
+    - #game
+        - [Rust + Behavior Trees = bonsai 🌳  A clean, modular way to build AI logic for gam](https://x.com/ayushagarwal027/status/2057023524934754366)
+    - #tui
+        - [Manage your life from the terminal 🔥  🕴️ tuxedo — A terminal todo manager with V](https://x.com/orhundev/status/2060039792864145724)
+    - [Rust reverse engineering is about to get a lot easier. 🦀  I'm thrilled to announ](https://x.com/34r7hm4n/status/2057129854072713323)
+    - [换了电脑之后不想再装巨大臃肿的 Logi Options+ 了，用 Rust&#40;GPUI&#41; 搓一个超轻量级 OpenLogi 接管下 HID++ https://](https://x.com/AprilNEA/status/2060337015267434858)
+    - [Electrobun 2.0 will also be decoupled from Bun due to the rust rewrite.  It’s a](https://x.com/YoavCodes/status/2058064720553222567)
+    - [Rust + scoped errors = finally feels right. 🦀  scoped-error is a new crate that](https://x.com/ayushagarwal027/status/2058624070334202208)
+    - [qwen3-tts via mlx-c in Rust lookin good now! https://x.com/badlogicgames/status/](https://x.com/badlogicgames/status/2060531447656595658)
+    - [One of the reasons I am so excited about this is that this kind of &#92;&quot;dumb&#92;&quot; mechan](https://x.com/glcst/status/2058142768870858757)
+    - [Large-scale AI migration is changing how we think about rewrites.  Looking back](https://x.com/jiahan_c/status/2055089181240782913)
+    - [For years, Rust binaries made reversing a nightmare. Modern decompilers only sup](https://x.com/mahal0z/status/2057147401987637300)
+    - [@34r7hm4n You can get access to it now! It's available directly on angr main, an](https://x.com/mahal0z/status/2057147424343199976)
+    - [I've just shipped two new episodes of rust from zero series. 🦀  The videos are ,](https://x.com/me256ow/status/2057919314444115988)
+    - [total c++ victory https://x.com/peach2k2/status/2058925076066582571/photo/1](https://x.com/peach2k2/status/2058925076066582571)
+}}
+    }
+  }
+}

--- a/trees/2026-W26.tree
+++ b/trees/2026-W26.tree
@@ -1,0 +1,199 @@
+\import{macros}
+
+\title{2026-W26}
+\date{2026-06-22}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W26-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-06-22]{\mdnote{2026-06-22}{
+- #rust
+    - #zig
+        - [Zig is most likely going to win over more C++ devs, than Rust ever has.  Mainly](https://x.com/oxcrowx/status/2058007032863846578)
+- #shader
+    - #software
+        - [new effect added on my three.js shader editor 😮‍💨 https://x.com/brice_deg/status/2059339626448323039/video/1](https://x.com/brice_deg/status/2059339626448323039)
+    - [sin instalador de 20 GB, sin precompilar shaders, un solo ejecutable de 200 mb,](https://x.com/__microdancing/status/2059242561105986028)
+    - [Turns out the same shader makes great text fill too  Aurora 0.4.0 adds AuroraTex](https://x.com/tornikegomareli/status/2055074436345115118)
+- #sec
+    - #web
+        - #software
+            - [🚨 MistEye TI Alert 🚨  Based on recent intelligence, multiple high-frequency npm](https://x.com/SlowMist_Team/status/2056963406754939096)
+        - [🚨 BREAKING: Active supply chain attack across npm, PyPI, and Crates.​io.  Socket](https://x.com/SocketSecurity/status/2058565153138844043)
+        - [Alleged GitHub internal source code and ~4,000 private repositories are reported](https://x.com/TodayCyberNews/status/2056908222884405647)
+    - [GitHub’s report today confirms that the compromised Nx Console extension was use](https://x.com/jeffbcross/status/2057236396658811020)
+- #software
+    - [People of https://pi.dev/. Supply-chain hardening release. Last week the](https://x.com/badlogicgames/status/2057108413113340039)
+    - [the one thing @mitsuhiko taught me: merged client &amp;amp; server logs. very useful](https://x.com/badlogicgames/status/2059014545889165401)
+    - [I've never seen CLI tools let you upgrade to a build based on a PR before. That](https://x.com/carllerche/status/2060437864501199333)
+    - [GitHub is investigating unauthorized access to their internal repos.  If you're](https://x.com/deriq_eth/status/2056946761306869839)
+    - [TeamPCP just did an interview where they were asked what defenders should do to](https://x.com/feross/status/2057581884025282927)
+    - [Do you know that using GitHub CLI &#40;gh&#41; may expose you to supply-chain attacks?](https://x.com/jiahan_c/status/2059117171553550710)
+    - [mermaid visualizer is getting better on https://t.co/JNwEg0prxT  - embedded a co](https://x.com/joelbqz/status/2056846422016655388)
+}}
+
+\subtree[2026-06-23]{\mdnote{2026-06-23}{
+- #zig
+    - #compiler
+        - [yuku-toolchain/yuku: High-performance JavaScript/TypeScript compiler and toolcha](https://x.com/jsterlibs/status/2057736988661354638)
+    - #os
+        - [Okay so this is fun: - used Codex to generate a reversed TableDef file for Metal](https://x.com/steeve/status/2057954628726050985)
+    - [Zig Build System Reworked https://ziglang.org/devlog/2026/#2026-05-26](https://x.com/jedisct1/status/2059555278777901454)
+- #web
+    - #software
+        - [experimenting with mux-ing ghostty-web in a browser. each pane connects to a rea](https://x.com/cablelounger/status/2056854275980931551)
+    - [GitHub just got hacked, a single VS Code extension did it.  → Nx Console &#40;2.2M i](https://x.com/Star_Knight12/status/2056977944334266428)
+    - [⚙️ epoll vs io_uring vs sync I/O  Great walkthrough of serving files over HTTP i](https://x.com/brk0v/status/2060620174210871569)
+    - [Good news for all Cloudflare users! First-party MSW integration is out. Seamless](https://x.com/kettanaito/status/2059559154226798695)
+    - [If you want to experiment with similar things, but with local VMs on your mac in](https://x.com/morew4rd/status/2058327773429837932)
+    - [1-bit diffusion running in your browser with WebGPU 🤯](https://x.com/pcuenq/status/2059537290746093738)
+    - [Wow, it actually *is* DOM &#40;See me using Chrome DevTools to inspect the DOM&#41;  HTM](https://x.com/steren/status/2058216560955974100)
+- #wasm
+    - #software
+        - [👀 Cloudflare's wrangler CLI &#40;~20m installs/week&#41; has a new dependency... a ~600k](https://x.com/MattIPv4/status/2060347620657070288)
+- #tui
+    - #software
+        - [quien is a TUI and CLI domain intelligence toolkit for checking sites in the ter](https://x.com/terminaltrove/status/2059369209033880010)
+    - [用 Go 写的轻量级 Slack TUI 客户端，替代臃肿的官方桌面应用  https://github.com/gammons/slk  slk 用 Go 和 bubble](https://x.com/QingQ77/status/2057790577530257658)
+- #software
+    - [Sự Cố Bảo Mật #GitHub  Đây là một sự cố nghiêm trọng, vì lần này không phải user](https://x.com/ntdland2019/status/2056903007695143253)
+}}
+
+\subtree[2026-06-24]{\mdnote{2026-06-24}{
+- #agent
+    - #proof
+        - [i have seen enough proof now that using a coding agent is a deep skill  it's con](https://x.com/thdxr/status/2060553984947950017)
+    - #rust
+        - [Dynamic workflows and adversarial code review was part of what made it possible](https://x.com/jarredsumner/status/2060050578026189172)
+    - #gpu
+        - #software
+            - [https://github.com/webxos/microcuda   MicroCUDA is a lightweight framework that](https://x.com/webxos/status/2059646376749760862)
+    - #software
+        - [Cursor is not an code editor anymore. Zed language servers and agents crash all](https://x.com/athasdev/status/2060674731464970632)
+    - [I made a thing with Claude to straighten out messy Unreal Engine Blueprints with](https://x.com/iBrews/status/2061275516645036502)
+    - [omo in opencode or lazycodex  they are basically the only one solution for legac](https://x.com/justsisyphus/status/2061324513707692083)
+    - [@onusoz it’s not that hard man. just wrangle ptys, fd ownership, terminal resize](https://x.com/lumendriada/status/2061427223488344082)
+    - [If you want to know what giveaway LLM design is, this is it: thin colored border](https://x.com/mitchellh/status/2060893206359994592)
+    - [I love Pi agent, so much so I made a full 1:1 Python port and called it Harn &#40;fr](https://x.com/secemp9/status/2061339057318187482)
+    - [3 new agent harness that use the SLACK style interface for agents: Slock https:/](https://x.com/webxos/status/2049240183057338456)
+- #cg
+    - [最近一直在捏模型,希望这个能快上架steam,刚好作为人体的学习材料  明天开始mocap和retarget,做几个怪物的rig  环境最近在探索一个AI生成的](https://x.com/DLKFZWilliam2/status/2061117459130909020)
+- #misc
+    - [Perfect pitch was thought to be impossible to learn as an adult. But recent rese](https://x.com/HTechInc/status/2049899816650486008)
+    - [A new era of https://hiisi.app/  25.0528 121.5990 https://x.com/LukasHozda/statu](https://x.com/LukasHozda/status/2061140656039264642)
+    - [This is crazy performant wow https://x.com/PurzBeats/status/2060944225017995611/](https://x.com/PurzBeats/status/2060944225017995611)
+}}
+
+\subtree[2026-06-25]{\mdnote{2026-06-25}{
+- #rust
+    - #gpu
+        - #render
+            - [Someone is building a browser engine in Rust from scratch. 🦀  Aurora: GPU render](https://x.com/ayushagarwal027/status/2061358886200947106)
+    - [Rewriting everything in Rust is an overhyped mistake https://x.com/0xglitchbyte/](https://x.com/0xglitchbyte/status/2060208634647163255)
+- #misc
+    - [WeaveFFI v0.7.0: A custom c_prefix is now honored by all eleven language generat](https://x.com/WeaveFFI/status/2061126739150135513)
+    - [recommended reading.  &amp;gt; On that last point, this technology is horrific for a](https://x.com/badlogicgames/status/2061104408201412903)
+    - [These days I copy a VM instead of creating a git branch. https://x.com/davidcraw](https://x.com/davidcrawshaw/status/2061221007214759945)
+    - [Bazel is seriously underappreciated. Clone of Google’s internal Blaze, it’s cros](https://x.com/eeuoss/status/2061154755372875827)
+    - [🆔名称：OpenBiliClaw  📁简介：通用个性化内容推荐 Agent——本地运行、跨平台理解你、只为你一个人构建  ➡️地址：https://github](https://x.com/headbuff00/status/2060230403903177156)
+    - [theme switch with sugar-high https://x.com/huozhi/status/2061156404132528146/vid](https://x.com/huozhi/status/2061156404132528146)
+    - [I wrote a small piece on how RAG works yesterday.  I learn best by building, so](https://x.com/me256ow/status/2060732539032273241)
+    - [https://x.com/i/article/2060725963839680513](https://x.com/melvynx/status/2060726350982332442)
+    - [opus 4.8 is shit ultracode looks interesting  codex is the best and tibo says le](https://x.com/q_yeon_gyu_kim/status/2061281883456246243)
+    - [Codex just found a “workaround” of not having sudo on my pc… https://x.com/sluon](https://x.com/sluongng/status/2060746160558543217)
+    - [@0xblacklight i only really understood it when i saw an example of someone  - us](https://x.com/thdxr/status/2060589635294618003)
+}}
+
+\subtree[2026-06-26]{\mdnote{2026-06-26}{
+- #agent
+    - [Please, stop running your agents in tmux.  I just found out about Zellij and ter](https://x.com/0xIlyy/status/2061933638288015578)
+    - [Please, stop running your agents in Zellij.  I just found out about Herdr and te](https://x.com/0xIlyy/status/2062329341539676366)
+    - [Checkpoints in https://opencomputer.dev/ are like git branches, but for entire com](https://x.com/IgorZIJ/status/2063929256564986293)
+    - [Hermes deploys several instances of codex using lazycodex with the ulw-loop   Th](https://x.com/WiFiMoneyGuy/status/2064072463705665652)
+    - [Here is the problem with vibe coding multiple agents at once :  the HUMAN CONTEX](https://x.com/_MaxBlade/status/2063683652635021574)
+    - [codemode](https://x.com/badlogicgames/status/2061571822450086106)
+    - [wonderful!](https://x.com/badlogicgames/status/2061753074234851336)
+    - [It’s called Loop Engineering. https://x.com/daniel_mac8/status/2063721956034195785/photo/1](https://x.com/daniel_mac8/status/2063721956034195785)
+    - [mythos will be bad ON PURPOSE on ai &#92;&quot;frontier llm research&#92;&quot; tasks, this is very](https://x.com/eliebakouch/status/2064399902684139852)
+    - [&#92;&quot;Would you like to leave Claude a tip?&#92;&quot; https://x.com/mgoin_/status/2061603899895599461/photo/1](https://x.com/mgoin_/status/2061603899895599461)
+    - [🚨OpenAI está regalando $1.200 GRATIS para usar Codex  Solo necesitas un repo púb](https://x.com/nicos_ai/status/2062476098840019079)
+    - [This is more or less what the majority of our large dev team at work has come to](https://x.com/src_rip/status/2057268834004848870)
+    - [I just got bullied by AGI https://x.com/venturetwins/status/2064414107743526954/photo/1](https://x.com/venturetwins/status/2064414107743526954)
+    - [Just let Claude Fable 5 rawdog your CAD software  One @adamdotnew prompt and it](https://x.com/zachdive/status/2064793406145269919)
+}}
+
+\subtree[2026-06-27]{\mdnote{2026-06-27}{
+- #agent
+    - #formal
+        - #benchmark
+            - [I was talking with an old friend at dinner last night, he described gpt fatigue](https://x.com/irl_danB/status/2061929789355962493)
+    - #rust
+        - #web
+            - [People of Pi! 55 releases in, Pi-Codex-Conversion is now at 2.0. Rust rewrite, P](https://x.com/Howaboua/status/2064328347958575494)
+        - [1/8 🐝 Hive is now open source. A unified agent memory + context compression stac](https://x.com/DJLougen/status/2061475875435000206)
+    - #elixir
+        - [Announcing https://deflua.com/ 🎉  The new home for Lua, the pure-Elixir Lua](https://x.com/davydog187/status/2062540335679422641)
+    - #gpu
+        - [«La IA local no sirve para hacer nada...»  ✅ 100&#37; IA local &#40;inferencia con llama](https://x.com/Manz/status/2063967868853616797)
+    - #render
+        - #web
+            - [imma go use this for the big pi refactor in anger. it looks really helpful.](https://x.com/badlogicgames/status/2062302800835436820)
+    - #game
+        - #sec
+            - [I see now. My opinions on Opus 4.8 are NOT valid. Unlike GPT 5.5, is heavily tra](https://x.com/VictorTaelin/status/2061065540580307120)
+    - #sec
+        - #web
+            - [--- name: fable-safe-prompt description: Rewrite a user's prompt to reduce the c](https://x.com/DavidOndrej1/status/2064851042563465600)
+            - [🚿 FABLE-5 SYS PROMPT LEAK 🚿  HOWDY, FRENS!! 🤗 Coming in at a WHOPPING ~120,000 c](https://x.com/elder_plinius/status/2064478648057610422)
+    - #os
+        - [Introducing Monako Glass 👓  The world's first wearable Linux computer in glasses](https://x.com/candyyueliu/status/2062178835689623592)
+        - [🙏 Daily prayer 🙏  Thank you lord for giving me the restraint to not build my own](https://x.com/onusoz/status/2061665899351093390)
+    - #git
+        - #software
+            - [Since @OpenAIDevs are leaving us CLI users behind, here is a CLI tool that allow](https://x.com/kcosr/status/2061519115479638279)
+    - #docker
+        - #software
+            - [OpenClaw is a great idea. But it's missing multiplayer for teams.  That's why I](https://x.com/hunvreus/status/2062562465809154175)
+    - #software
+        - [Agents need better tools for reversing! I'm releasing declib &#40;previously libbs&#41;,](https://x.com/mahal0z/status/2062211817493926268)
+}}
+
+\subtree[2026-06-28]{\mdnote{2026-06-28}{
+- #agent
+    - #web
+        - #os
+            - [I adopted Crabbox to test and validate my pi extension projects on different pla](https://x.com/fitchmultz/status/2061879325407015082)
+        - [https://github.com/c4pt0r/pie pie is moving fast: tui / skill / web ui / agents hub &#40;n](https://x.com/dxhuang/status/2062160446598058185)
+        - [Okena is probably my second most used app. &#40;First is a browser.&#41; Can’t imagine r](https://x.com/honzasladek/status/2061541792713945514)
+        - [Introducing cmux history:  cmux now has support for reopening closed terminals/b](https://x.com/lawrencecchen/status/2061767722619572569)
+    - #software
+        - [v0.44.0 out now!  - Ask Octarine harness written from the ground up to be more a](https://x.com/tryOctarine/status/2062095532538069221)
+- #ebpf
+    - #web
+        - #software
+            - [zeroserve: a zero-config web server you can script with eBPF  https://t.co/V3zql](https://x.com/heyang_zhou/status/2063274812647289046)
+- #elixir
+    - #compiler
+        - [Elixir v1.20 released! Now officially a gradually typed language: Elixir type ch](https://x.com/josevalim/status/2062248428898254957)
+- #gpu
+    - #software
+        - [NVIDIA just dropped Nemotron-3.5-ASR: one 0.6B model, 40+ languages, streaming.](https://x.com/mudler_it/status/2063207757692441056)
+    - [parakeet.cpp now runs on Apple Metal. https://x.com/mudler_it/status/2061591539269202346/video/1](https://x.com/mudler_it/status/2061591539269202346)
+- #benchmark
+    - [On https://paperswithcode.co/, you can see Mythos 5 getting beaten by a 4B open-sou](https://x.com/NielsRogge/status/2064435426308321309)
+    - [so @morgallant has optimized FTS tokenization throughput to 423 MiB/s and open-s](https://x.com/Sirupsen/status/2061602263223709856)
+- #cg
+    - #game
+        - [淘到一个狠项目。 Godot，一个 11.2 万 stars 的开源游戏引擎，MIT 协议，全免费。 Unity 一年订阅费够你雇一个程序员，但这玩意儿直接全免](https://x.com/laowangbabababa/status/2061779482143518738)
+- #misc
+    - [It reached #1 on Hacker News 😀 https://x.com/0xkato/status/2063247080722665763/photo/1](https://x.com/0xkato/status/2063247080722665763)
+    - [Fable is AGI https://x.com/AndyMasley/status/2064406028410552326/photo/1](https://x.com/AndyMasley/status/2064406028410552326)
+}}
+    }
+  }
+}

--- a/trees/2026-W27.tree
+++ b/trees/2026-W27.tree
@@ -1,0 +1,159 @@
+\import{macros}
+
+\title{2026-W27}
+\date{2026-06-29}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W27-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-06-29]{\mdnote{2026-06-29}{
+- #misc
+    - [Session detail — usage &amp;amp; tool traces  https://github.com/evotai/evot https://t.co/W](https://x.com/BohuTANG/status/2064713313867759638)
+    - [harehare/mq - A jq-like Markdown query language for command-line processing #dev](https://x.com/ChrisShort/status/2063470556620472553)
+    - [Fun interactive science app ideas | Part 5  Built a periodic table app that visu](https://x.com/DilumSanjaya/status/2061490330361589849)
+    - [Unbelievable https://x.com/DimitrisPapail/status/2064415276968333548/photo/1](https://x.com/DimitrisPapail/status/2064415276968333548)
+    - [Focus vs. Multitasking!!    Source - Thank you @DailyLoud https://t.co/M7CHsFgVR](https://x.com/Fuel_YourGrowth/status/2064341744825889182)
+    - [Building TUIs in Dart has never been easier, thanks to @norbertkozsir https://t.](https://x.com/OrestesGaolin/status/2062998413856108733)
+    - [Instant purchase.  A beautiful homage to the tools we use every day.](https://x.com/_rbart_/status/2064014222581739934)
+    - [feeling the AGI  https://www.0xsid.com/blog/meta-account-takeover-fiasco](https://x.com/badlogicgames/status/2061528497953067098)
+    - [🎨 hunk v0.15.0 is out:  - supports git --color-moved - transparent backgrounds -](https://x.com/bentlegen/status/2064320428718301415)
+    - [@Mori55_ Well spotted! Indeed I recently went to Mount Aso but, I also trail ran](https://x.com/daviddalbusco/status/2063841086695481693)
+    - [Look mum, I made it to the HN front page 🎉  Also cool, the site didn't go down b](https://x.com/daviddalbusco/status/2063847927957561590)
+    - [asked claude fable 5 to design a humanoid robot  2 hours and 1.4m tokens later,](https://x.com/earthtojake/status/2064535702138990855)
+    - [asked claude fable 5 to design a qdd actuator  it also animated the gearbox and](https://x.com/earthtojake/status/2064883158441672706)
+    - [asynq is actually really cool. https://x.com/electr1fy0/status/2063591104457613425/photo/1](https://x.com/electr1fy0/status/2063591104457613425)
+}}
+
+\subtree[2026-06-30]{\mdnote{2026-06-30}{
+- #misc
+    - [I've left most of what I want to say in the VoidZero blog post. But worth repeat](https://x.com/evanyou/status/2062533668233756677)
+    - [idk who created this website, but it's awesome and i love it.   https://t.co/gkt](https://x.com/evisdrenova/status/2061660624002883586)
+    - [Want to try GStack /office-hours for your product idea as quickly as possible? I](https://x.com/garrytan/status/2061568169354129640)
+    - [Github 24h 95star，X 16k View，感谢支持😛 听取各位精神股东建议，云微重构了前端 UI，优化了容器更新机制等。云微支持：  - 微信云](https://x.com/gloridust1024/status/2061463233530302696)
+    - [Meet Gemma 4 12B!  A unified, encoder-free multimodal model designed to bring hi](https://x.com/googlegemma/status/2062202706882883696)
+    - [OMG!!! Huge thank you to @OpenAI for sponsoring me on @GitHub! 🙌  I use Codex so](https://x.com/hd_nvim/status/2063761091373518959)
+    - [reject gui wrappers embrace traditional tui with improvements 🐏](https://x.com/herdrdev/status/2064355463546736977)
+    - [My spiciest take: 🌶️   You only need prod.   Other environments are optional, an](https://x.com/housecor/status/2061421531360608506)
+    - [Liquid Glass for GPUI. https://x.com/huacnlee/status/2064276845927997601/photo/1](https://x.com/huacnlee/status/2064276845927997601)
+    - [⛳️Out today: a hole new Ballgame Demo.   Available now on Steam for PC &amp;amp; Mac](https://x.com/humancomputerco/status/2061552297768030574)
+    - [Added the greatest and fastest search tool you'll find in a diff viewer that wor](https://x.com/iamsahaj_xyz/status/2062251733955621352)
+    - [Working on Getting Start with Ziglang tutorial. @ziglang https://x.com/invisal89/status/2063210733421175030/video/1](https://x.com/invisal89/status/2063210733421175030)
+    - [This talk is derived from the blog post but more focused on the claude parts tha](https://x.com/jarredsumner/status/2063856461768499376)
+    - [blog post tomorrow](https://x.com/jarredsumner/status/2064507408068845926)
+}}
+
+\subtree[2026-07-01]{\mdnote{2026-07-01}{
+- #misc
+    - [Experimenting with graph layouts. https://graph-playground.aisloppy.com/ https://t.co/C48GnxQp4](https://x.com/jessald/status/2063764721803653306)
+    - [第一次用app store connect cli，我瘫坐在椅子上，仿佛看到了原子弹爆炸🤯 https://x.com/jhao941/status/2063897701276864840/photo/1](https://x.com/jhao941/status/2063897701276864840)
+    - [https://x.com/i/article/2063575121747488768](https://x.com/josedonato__/status/2063699907563729258)
+    - [🚨 BREAKING: this guy is single-handedly killing WisprFlow.  Dictate, tell the AI](https://x.com/just_unmute/status/2061530000130732212)
+    - [guh.nvim vs octo.nvim  in case you haven't moved to codeberg 🙄  https://t.co/Hm8](https://x.com/justinmk/status/2064119528649269277)
+    - [1. npm install -g npq 2. alias npm=npq 3. 🎉  if you follow me and don't know wha](https://x.com/liran_tal/status/2063518615882666493)
+    - [Experimenting today with:  - /to-prd to create a PRD - /goal to implement - &#92;&quot;aut](https://x.com/mattpocockuk/status/2064328721230647608)
+    - [https://github.com/Michaelliv/pi-generative-ui](https://x.com/micLivs/status/2062290310147817961)
+    - [I was using cmux, but I didn't like the tab management. Also, lately it has been](https://x.com/nwtseira/status/2062021470503764411)
+    - [if a mobile term has no native integration with @herdrdev, its not an AI native](https://x.com/odd_joel/status/2063246276691472845)
+    - [this looks proper schizo https://yon-lang.org/](https://x.com/onehappyfellow/status/2063627246095495425)
+    - [nbpipe: Run Sequences of Jupyter Notebooks as a Workflow https://github.com/ngafar/nbpipe](https://x.com/pycoders/status/2062536607949865009)
+    - [A little home for your scratch pads &#40;Cmd+N&#41; soon on V1 https://x.com/saeed_vz/status/2063631647472304501/photo/1](https://x.com/saeed_vz/status/2063631647472304501)
+    - [@AaronLCannon &#92;&quot;I owe you an honest explanation. I *was* at the meeting, but not](https://x.com/samuelcook/status/2063430345140101381)
+}}
+
+\subtree[2026-07-02]{\mdnote{2026-07-02}{
+- #misc
+    - [I just open sourced my &#92;&quot;Is this slop?&#92;&quot; simple test https://x.com/sethrosen/status/2064317842787299741/photo/1](https://x.com/sethrosen/status/2064317842787299741)
+    - [Our back and neck massager helps with relaxing after a long day. Shop Now](https://x.com/shopatvalcero/status/2060333181354524794)
+    - [昨天分享了3D Map Skill，很多朋友问效果是怎么做出来的 👀先放最终效果： 💬 GPT-Prompt 🎨 Figma-Design 🤖 Codex-Im](https://x.com/songsummer920/status/2064548999458414730)
+    - [I told codex to use https://github.com/steipete/sag/ whenever I'm distracted and it needs](https://x.com/steipete/status/2061574752574283858)
+    - [Here's a simple loop: Tell codex to maintain your repos, wake up every 5 minutes](https://x.com/steipete/status/2064998499780084154)
+    - [Now that, that's an IDE https://x.com/thorstenball/status/2064332334187397403/photo/1](https://x.com/thorstenball/status/2064332334187397403)
+    - [Hi. Over the last 24 hours we had three separate small incidents that affected C](https://x.com/thsottiaux/status/2062329981548802523)
+    - [Local-first Kubernetes dashboard without cluster-side install  https://t.co/W2qs](https://x.com/tom_doerr/status/2061144893443993840)
+    - [Our chaos cluster caught a real OpenRaft bug this week. A node panicked while ca](https://x.com/tonboio/status/2061807636618887339)
+    - [https://x.com/i/article/2061104570663587840](https://x.com/valigo/status/2061166774465302785)
+    - [holy shit it's true https://x.com/vimtor/status/2064031366778327142/photo/1](https://x.com/vimtor/status/2064031366778327142)
+    - [🧮 Physics that never leaves the graphics card. Kevin Levron's &#40;@soju22&#41; Three.js](https://x.com/webgl_webgpu/status/2063667750967595455)
+    - [Which of the 64 animal archetypes defines your unique personality?](https://x.com/x64personality/status/2057726491782521231)
+    - [A fun post about the renaissance we've been seeing in terminal UIs, and some of](https://x.com/yminsky/status/2061445412033016114)
+}}
+
+\subtree[2026-07-03]{\mdnote{2026-07-03}{
+- #rust
+    - #elixir
+        - [I maintain several Elixir packages with Rust/Rustler bindings, and more are comi](https://x.com/dan_note/status/2061785556367901055)
+    - #tui
+        - [Today I found a tool for managing Markdown docs! 🔥  🦉 owl-write — A TUI for mana](https://x.com/orhundev/status/2063217245048701327)
+    - [I put together a minimalistic pure-Rust, CPU-only implementation of the recent L](https://x.com/Love2Code/status/2063282076552425617)
+    - [Introducing Voltius — a modern SSH/SFTP client built with Rust. ~30MB, no accoun](https://x.com/VoltiusApp/status/2061837341417750615)
+    - [🦀 Rust: Cloudflare from NGINX/OpenResty to Tokio-based Rust services  • shared c](https://x.com/brk0v/status/2063873495197536662)
+    - [Another series from a former Scala developer who switched to Rust. I wonder how](https://x.com/matej_cerny/status/2063863530860769641)
+    - [JUST IN: How Josh helps Rust manage code across multiple repositories   &amp;gt;&amp;gt;](https://x.com/rustaceans_rs/status/2062849302393758062)
+- #render
+    - #web
+        - [Kami v1.7 is out. Your AI writes well. Now your slides look good too.  Markdown](https://x.com/HiTw93/status/2064500116787257514)
+    - [diffshub&#91;dot&#93;com  rendering the new Omarchy 4 branch, almost instantly, no blank](https://x.com/pierrecomputer/status/2064058071245009243)
+- #os
+    - #tui
+        - [gtab 让你在 macOS 上用一条命令保存和恢复 Ghostty 终端标签页布局。  https://github.com/Franvy/gtab  Ghostty 终端](https://x.com/QingQ77/status/2061635160244617486)
+    - [Mac users! A proper .dmg installer for Voltius is finally here, replacing the ra](https://x.com/VoltiusApp/status/2062420724422259189)
+    - [I haven’t had time to dive deeply into all the WWDC changes yet but I’m seeing p](https://x.com/mitchellh/status/2064386445167767705)
+    - [My new macOS app just launched 🎉🥳  Here’s your new favorite macOS app: https://t](https://x.com/soltwagner/status/2061735970920427744)
+- #misc
+    - [Open multiple files in a row from Zed's file finder by pressing the right arrow](https://x.com/zeddotdev/status/2064024259895177315)
+}}
+
+\subtree[2026-07-04]{\mdnote{2026-07-04}{
+- #rust
+    - #web
+        - [People of Pi! If you wanna try giving Gippity in Pi NO TOOLS apart from bash and](https://x.com/Howaboua/status/2062966630578356474)
+    - #tui
+        - [New terminal file manager in town! 🚓  📁 elio — A batteries-included file manager](https://x.com/orhundev/status/2063556190743781663)
+- #zig
+    - #gpu
+        - [Gooey - the GPU powered UI lib written in Zig is 127k lines of code and now is d](https://x.com/duanebester/status/2061883012581589292)
+- #webgl
+    - #web
+        - [what if I could disappear  built on https://lootai.net/ @Lootainet with WebG](https://x.com/xbh_artist/status/2063996174617735455)
+- #sec
+    - [Open-source Burp Suite alternative for security research  https://t.co/ykiSfMtFk](https://x.com/tom_doerr/status/2063822298335924426)
+- #web
+    - #sqlite
+        - #software
+            - [C++ can power real backend apps.  Pico is a small Vix.cpp runtime app showing HT](https://x.com/vix_cpp/status/2063973675074740513)
+    - [every &#92;&quot;pretty code block&#92;&quot; tool gives you a screenshot. can't copy it, breaks on](https://x.com/larsitodev/status/2062856435034358169)
+    - [moshi moshi😼  have you tried the new file browser with syntax highlighting? http](https://x.com/odd_joel/status/2064328626531942598)
+    - [.@herdrdev is cool. I am tired of doing back and forth with github in the browse](https://x.com/onusoz/status/2062215852850835489)
+    - [Designs visual network architectures entirely within the browser  https://x.com/iok](https://x.com/tom_doerr/status/2061475194401616142)
+- #tui
+    - [i started using moshi instead of termius before i even started working on herdr.](https://x.com/lumendriada/status/2062879444344119703)
+- #software
+    - [Foundation Models has a CLI https://x.com/Jchammond_/status/2064206029370630529/photo/1](https://x.com/Jchammond_/status/2064206029370630529)
+    - [While trying to come up with a name for a new tiling library I found that there'](https://x.com/OrestesGaolin/status/2063297879968534728)
+}}
+
+\subtree[2026-07-05]{\mdnote{2026-07-05}{
+- #agent
+    - [herdr 很不错，但是一直想要一个基于 Session 管理的。最近发现了 agent-deck，用了用，感觉不错。  以 session 为管理核心，包括s](https://x.com/9hills/status/2067842557699313854)
+    - [Qwen 3.6 a3b 35b on your phone, you are welcome, I need a gb300 to continue my w](https://x.com/DJLougen/status/2066177437344416059)
+    - [Adjusted the UI and some Backend stuff, it comes with a demo and the Qwen a3b 35](https://x.com/DJLougen/status/2066964872848457766)
+    - [claude code and codex can now drive iOS features on a live device.  no scripts.](https://x.com/LandseerEnga/status/2066634638366593408)
+    - [In loving memory of Fable,  Here is an AVBD simulation engine built from scratch](https://x.com/Luckyballa/status/2065920454297305438)
+    - [Before Fable 5 was pulled, we used it to prompt this landing page.  It was ahead](https://x.com/MengTo/status/2066035231782740092)
+    - [ITS ALWAYS THE SIMPLEST FEATURES THAT HIT THE HARDEST.   dynamic resizing coming](https://x.com/_MaxBlade/status/2065803029220110703)
+    - [built contentbit: open source schema-validated content blocks for Markdown.  LLM](https://x.com/agonist42/status/2065067830626681043)
+    - [Wtf. You just stole my work. Claude Mythos has nothing to do with that. Original](https://x.com/anton_skv/status/2066676736641609792)
+    - [Why don't people talk about pr-review-toolkit?  https://github.com/anthropics/claude-code/tree/main/plugins/pr-review-toolkit  It's ab](https://x.com/apeatling/status/2066757319690756273)
+    - [Understanding the code is now a key bottleneck in agentic coding.  Amp now shows](https://x.com/beyang/status/2066921225470050766)
+    - [@apeatling it’s been superseded by /code-review and /simplify. most of the agent](https://x.com/eatpraydiehard/status/2067025311792083448)
+    - [Since when does Codex just stop current task when you run out of limits?  In the](https://x.com/egorkabantsov/status/2066441305438187713)
+    - [为 Pi coding agent 提供纯算法化的会话压缩，无需 LLM 调用  https://github.com/sting8k/pi-vcc](https://x.com/geekbb/status/2067534030040396221)
+}}
+    }
+  }
+}

--- a/trees/2026-W28.tree
+++ b/trees/2026-W28.tree
@@ -1,0 +1,181 @@
+\import{macros}
+
+\title{2026-W28}
+\date{2026-07-06}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W28-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-07-06]{\mdnote{2026-07-06}{
+- #agent
+    - #benchmark
+        - #render
+            - [what if your agent could generate HTML diagrams ... on the terminal?  sideshow-t](https://x.com/bentlegen/status/2066965315108454515)
+        - [I've published Qwable 3.6 27b to HF  Qwable = Qwen + Fable.  Based on Qwen 27B w](https://x.com/MiaAI_lab/status/2066820134967099766)
+        - [CNVS went viral for the wrong reason...   the Ui is beautiful, but the CNVS cros](https://x.com/_MaxBlade/status/2066119194534383718)
+    - #cg
+        - #game
+            - [Wow, if you connect Fable to image-gen and image-to-3D APIs, it's *insane* for g](https://x.com/anshuc/status/2065598069790716294)
+        - [Blender-MCP，GitHub 22.8k Star，用 AI 对话直接做 3D 建模  不用学 Blender 的界面，不用记快捷键，跟 Claude](https://x.com/VincentLogic/status/2066824096403554757)
+    - [Built this yesterday with Claude Mythos before everything got weird.  Prompt was](https://x.com/heyamanai/status/2065826883208610287)
+    - [わたし「大局将棋って知ってる？」 Claude Fable 5「しってる。36x36コマ盤面の消費っしょ？」 わたし「観戦するだけのデモ作って。速さとか強さとか](https://x.com/ishiki_emo/status/2065086627849056298)
+    - [Pi vs Opencode  pgr mcp by entireio Minimax M3 via Tokenrouter https://t.co/wxIg](https://x.com/jimmyeatcrab/status/2067614404640976905)
+    - [Introducing cmux Claude Code Agent Teams:  `cmux claude-teams --dangerously-skip](https://x.com/lawrencecchen/status/2039284294682870052)
+    - [How do you give a code LLM knowledge of an entire repository without paying for](https://x.com/liliana_hotsko/status/2065099992965042538)
+    - [Introducing Roughdraft!  A new open source project designed to make collaboratio](https://x.com/nbaschez/status/2057139892883464243)
+    - [fyi! your codex chats can create other /goal chats  &#40;even on an automation&#41; http](https://x.com/nickbaumann_/status/2067304001956409374)
+    - [DEJA DE PROMPTEAR. EMPIEZA A LOOPEAR.  Encontré un sitio que recopila los loops](https://x.com/nicos_ai/status/2065891201170227608)
+    - [A dev got so frustrated watching his AI agent write 500 lines for a 5-line probl](https://x.com/techNmak/status/2065985074492068001)
+}}
+
+\subtree[2026-07-07]{\mdnote{2026-07-07}{
+- #agent
+    - #elixir
+        - #git
+            - [https://x.com/i/article/2067686501891112960](https://x.com/hugobarauna/status/2067690067288572209)
+    - #gpu
+        - #game
+            - [This is actually sick! 🤯  A motion generator for robotics. and gaming.  This is](https://x.com/lukas_m_ziegler/status/2066199991958565096)
+    - #shader
+        - #cg
+            - [④ Fable 5 xhigh &#40;Claude Code · goal mode&#41;  Stack: hand-written raw Three.js + cu](https://x.com/syngji245370/status/2067454976369307667)
+    - #cg
+        - #web
+            - [Studying offline 3D vibe-coding with Three.js:  - Gemma 4 E4B runs on-device via](https://x.com/onirenaud/status/2066837498664477037)
+            - [A fun way to try the new Claude Fable. I asked it to train a bot using RL to nav](https://x.com/risingodegua/status/2065172084293046344)
+    - #game
+        - [Fable one shotted the game logic.  GPT Image 2 for designs.  Blender MCP for mod](https://x.com/McGreenBeats/status/2064746187354149316)
+        - [With flashdreams, you can also create your own game, without paying anyone! Enti](https://x.com/ruilong_li/status/2065103359208743361)
+        - [## On Loopcraft  One might argue the entire game of the next century is to be ab](https://x.com/swyx/status/2065307558198567206)
+    - #sec
+        - [As a result of a US government directive, we are suspending access to Claude Fab](https://x.com/ClaudeDevs/status/2065597942602531163)
+        - [New in Claude Code: Artifacts.  Interactive pages built from your session, like](https://x.com/claudeai/status/2067671912038240487)
+    - #git
+        - [Zed 又推出神奇的東西 專為 AI Agent 時代打造的新型版本控制系統  不同於 Git 以 commit 為單位，DeltaDB 把「對話」與「程式碼編](https://x.com/CashWuGeek/status/2065276119352488354)
+        - [Claude Code and Codex Can Have Real-Time Conversation via Git  Uses a lightweigh](https://x.com/bibryam/status/2065918635709763627)
+    - #software
+        - [herdr 0.7.0 is out, and it's a major one: it introduces plugins!  the idea is si](https://x.com/herdrdev/status/2066560459591893350)
+        - [CMUX is the main IDE for me now - Persist terminal for running loops - Parallel](https://x.com/jasonzhou1993/status/2066857895120249068)
+}}
+
+\subtree[2026-07-08]{\mdnote{2026-07-08}{
+- #agent
+    - #web
+        - #os
+            - [The missing design piece for Codex.](https://x.com/RayFernando1337/status/2065779642070708363)
+        - #software
+            - [Desktop app has fallen a bit behind over the last few weeks as I've focused on i](https://x.com/jullerino/status/2066696412155515021)
+            - [We just made Firecrawl free again!   First open source, then 1,000 free credits](https://x.com/nickscamara_/status/2066925655690805640)
+    - #tui
+        - #software
+            - [moshi moshi 😻  3.6.0 adds theme auto selection — pick a dark and a light theme,](https://x.com/odd_joel/status/2067429339549896974)
+    - #software
+        - [介绍一下我最喜欢的 agentic coding skills 套件，作者 @mattpocockuk 刚刚正式发布 v1.0.0 版本了，相比旧版本有了不少的](https://x.com/ninthbit_ai/status/2067283180307296565)
+        - [If you work with images with text, or scanned documents, here's a small but powe](https://x.com/privatenumbr/status/2065818889213407239)
+        - [Unreal Engine just added MCP.  Now our Claude and Codex can use it natively! htt](https://x.com/ziwenxu_/status/2067294054618976729)
+- #benchmark
+    - #cg
+        - #visualization
+            - [Surflo reconstructs 3D scenes from any number of images by compressing them into](https://x.com/aisearchio/status/2065594151794806834)
+    - #web
+        - [pi-computer-use v0.3.2 brings stronger browser use, latency and token efficiency](https://x.com/injaneity/status/2067601178406617211)
+- #cg
+    - #visualization
+        - #game
+            - [https://x.com/threejs/status/2067745268242829384/video/1](https://x.com/threejs/status/2067745268242829384)
+    - #game
+        - #web
+            - [One solo dev, one day:  &amp;gt; launched a 3D strategy game &#40;free, in your browser&#41;](https://x.com/indiesoftwaredv/status/2065890520623198687)
+    - [&#92;&quot;MeshFlow: Efficient Artistic Mesh Generation via MeshVAE and Flow-based Diffusi](https://x.com/Almorgand/status/2065557982985719841)
+    - [MoVerse turns an image into a navigable 3D world. Runs at 8 FPS on a single RTX](https://x.com/aisearchio/status/2065655388977172968)
+    - [3D Rubik's Cube in the terminal! 💯  Now available in Ratty terminal: https://t.c](https://x.com/orhundev/status/2066470834458210332)
+}}
+
+\subtree[2026-07-09]{\mdnote{2026-07-09}{
+- #formal
+    - #web
+        - [Got a PayPal verification text and thought I been hacked, but it was just codex](https://x.com/steipete/status/2065997212015067508)
+- #gpu
+    - #render
+        - #web
+            - [I think this is the first MNEE path tracer on the web: physically-correct shadow](https://x.com/invalid_degen/status/2065979027790143943)
+    - #os
+        - [🎉 Mole for Mac 1.7 is live.  Apple Silicon fan control, camera/mic privacy alert](https://x.com/HiTw93/status/2065802627997397216)
+    - [这个看起来很夯，基于 SwiftUI 的 Apple Silicon 系统监控工具，无需 root 权限就能读取 CPU、GPU、ANE 和 Media Eng](https://x.com/geekbb/status/2067791979312750669)
+- #game
+    - #software
+        - [ok, marble game prototype works pretty well https://x.com/novikoff/status/2066284681356587414/video/1](https://x.com/novikoff/status/2066284681356587414)
+        - [I'm not the best judge of robotics simulators, but this is easily the most user-](https://x.com/philfung/status/2065174827946971432)
+    - [This is seriously inspiring 🤯 Love how Makan Gilani focuses on movement, shape,](https://x.com/unity3dvfx/status/2066780553500623302)
+    - [Do we really need Fable?  All made using Opus 4.8 with looping, including audio,](https://x.com/webdevcody/status/2067845688906416173)
+- #misc
+    - [Uber’s VP of Eng is on his way to have a polite chat with the four devs who exce](https://x.com/AGrillz/status/2065073360158040148)
+    - [Wait… this is just CSS?   @hugosaintemarie  https://x.com/hugosaintemarie/status/1896938623628652757/video/1](https://x.com/AliGrids/status/2065354898481246386)
+    - [When a designer just keeps shipping fun prototypes all year  This is the result.](https://x.com/AliGrids/status/2066301691578990823)
+    - [🥳 Ecctrl 2.0 is officially released! 🎮A physics-driven controller toolkit for R3](https://x.com/AndrewChenE/status/2066398990560837940)
+    - [C++ just got a new operator  It looks like this: ^^  The committee calls it &#92;&quot;the](https://x.com/CPPAlliance/status/2066492940046733732)
+    - [codex + blender is insane https://x.com/EHuanglu/status/2065843739340509693/video/1](https://x.com/EHuanglu/status/2065843739340509693)
+}}
+
+\subtree[2026-07-10]{\mdnote{2026-07-10}{
+- #misc
+    - [Github 本身在成为一个 A2A 平台。  我本周经历了一个特别魔幻的事情： 1. 我把一个 Github 链接丢给 Codex，让它帮我部署一下。 2.](https://x.com/JeffreyCalm/status/2066066715885371397)
+    - [Apparently I can rent out my MacBook Pro for inference and make ~$423/month.  Th](https://x.com/Michaelzsguo/status/2067795772439982591)
+    - [https://x.com/i/article/2065710494783287296](https://x.com/PandaTalk8/status/2065714368071745710)
+    - [https://x.com/i/article/2064380553919676416](https://x.com/RLanceMartin/status/2064397389189071163)
+    - [Un desarrollador ucraniano creó un agujero negro en su terminal para obligarse a](https://x.com/SantiTorAI/status/2065043248268390535)
+    - [Got raycast lighting working three.js WebGPU https://x.com/TRA4669/status/2065223634008875322/video/1](https://x.com/TRA4669/status/2065223634008875322)
+    - [Orthographic volumetric fog. -- &#40;it doesn't really work, but it *could*&#41;.  💡 * &#91;](https://x.com/TheMirzaBeig/status/2065695888475914604)
+    - [Meanwhile at a Chinese university dorm https://x.com/ViralRushX/status/2066400799308083368/video/1](https://x.com/ViralRushX/status/2066400799308083368)
+    - [Referred a friend for a job  Now HR wants to interview me again 😭 https://x.com/minimalist](https://x.com/aditiitwt/status/2067504220002263356)
+    - [adding some flavor to an FPS!  #gamedev https://x.com/andre_mc/status/2066602842064900493/video/1](https://x.com/andre_mc/status/2066602842064900493)
+    - [奈飞的一个工程师搞了个超牛的东西出来！  能帮你省掉95&#37;的tokens！  什么节能小助理！！！  把你的上下文先压缩一下，再丢给ai  全程可以在本地跑，兼](https://x.com/aronhouyu/status/2067792970326442120)
+    - [Athas now supports notebooks.  You can open .ipynb files directly, open .Rmd fil](https://x.com/athasdev/status/2066240976885006805)
+    - [How @pierrecomputer diffs code viewer works  https://github.com/plannotator/effective-html https://t.c](https://x.com/backnotprop/status/2065479594023829619)
+    - [我要强烈推荐 Kimi K2.7 High Speed &#40;高速版）！太神奇了！  Fable 5只活了3天就下架了，那个「墨流」Demo我见一次就再也忘不了。](https://x.com/bourneliu66/status/2066436537085276284)
+}}
+
+\subtree[2026-07-11]{\mdnote{2026-07-11}{
+- #misc
+    - [https://x.com/i/article/2064937716387811328](https://x.com/coder_left/status/2064951665061703878)
+    - [my favorite place to program https://x.com/davidcrawshaw/status/2066218679113547990/photo/1](https://x.com/davidcrawshaw/status/2066218679113547990)
+    - [minecraft or real life????? https://x.com/donutyfriend/status/2066144440641618104/video/1](https://x.com/donutyfriend/status/2066144440641618104)
+    - [We now support rich formatting for all chatbots.  Tables, nested lists, inline m](https://x.com/durov/status/2065896953519484976)
+    - [Recently I've been obsessed with neural geometry  LLMs don't think in words, the](https://x.com/faizan_a1/status/2066279823543242822)
+    - [repost @damian_madden on IG Never thought maths would look so cool. Lorenz attra](https://x.com/genmediaclub/status/2065071816633397620)
+    - [also https://forge.smol.ai/ from @swyx](https://x.com/gill_kyle/status/2066938993347080362)
+    - [a parameterized crystal maker by Opsu 4.8 and @threejs   download link in commen](https://x.com/hive_echo/status/2065878600424067310)
+    - [@nickbaumann_ Your non-Codex chats can too. https://github.com/kcosr/codex-threads](https://x.com/kcosr/status/2067392940154990976)
+    - [falling into a blackhole with fable https://x.com/kotsoft/status/2065414218174575081/video/1](https://x.com/kotsoft/status/2065414218174575081)
+    - [Did you know? The latest edition of the C standard introduces left-worm and righ](https://x.com/lcamtuf/status/2065881116645720278)
+    - [either GPT-5.6 is coming, or OpenAI is having compute shortages again. this is n](https://x.com/lumendriada/status/2066516170430165269)
+    - [Saw @bruno_simon’s tweet and immediately wanted to upgrade my #tsl snow material](https://x.com/makio64/status/2065064085205528681)
+    - [Moving a project in @OpenAI Codex from one folder to another is messier than it](https://x.com/mark_k/status/2066105249236971682)
+}}
+
+\subtree[2026-07-12]{\mdnote{2026-07-12}{
+- #os
+    - [Meet Nehir: A scrolling tiling window manager for macOS   Nehir has a scrolling](https://x.com/nullbytes00/status/2066972429231309190)
+- #misc
+    - [PROJECT NULLFRAME: A live telemetry dashboard brought to life with Fable 5 - in](https://x.com/mickces/status/2065387473794994355)
+    - [Fable's original joke and animation about rate limits https://x.com/petergostev/status/2065069954571943950/video/1](https://x.com/petergostev/status/2065069954571943950)
+    - [code&#40;dot&#41;storage](https://x.com/pierrecomputer/status/2066951062456545412)
+    - [Bun’s @rustlang rewrite now helps power Prisma Compute in production.  On stable](https://x.com/prisma/status/2065982990178828347)
+    - [Just tried this /ponytail skill and it's simply brilliant  it's like having Gilf](https://x.com/s13k_/status/2066129967012860127)
+    - [https://x.com/i/article/2063986184443899905](https://x.com/sairahul1/status/2064277888216555684)
+    - [In light of what happened, I'm doubling down on skills like /improve.   A fronti](https://x.com/shadcn/status/2065826989769163068)
+    - [Wrote a skill that runs codex /review in a loop until there's no booboos anymore](https://x.com/steipete/status/2054850632067019173)
+    - [How am I only now finding out about appshots?  I was dragging screenshots into c](https://x.com/steipete/status/2065564094879637546)
+    - [Interactive Alpha Stirling engine simulation with animated kinematics, heat-driv](https://x.com/techartist_/status/2066165425738756335)
+    - [This was fixed. You know what's coming 👀  Give us 24 hours to reset the Codex ra](https://x.com/thsottiaux/status/2066956441173323943)
+    - [Damn, did Telegram just kill Hermex?](https://x.com/uzairansar/status/2065947695596896454)
+    - [xiaomi - the Chinese company that makes phones, rice cookers and electric vehicl](https://x.com/wesbos/status/2066546562474316236)
+}}
+    }
+  }
+}

--- a/trees/2026-W29.tree
+++ b/trees/2026-W29.tree
@@ -1,0 +1,211 @@
+\import{macros}
+
+\title{2026-W29}
+\date{2026-07-13}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W29-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-07-13]{\mdnote{2026-07-13}{
+- #rust
+    - #compiler
+        - #software
+            - [Built jzon-rs.  A JSON library for Rust that generates struct-specific parsers a](https://x.com/rajaniraiyn/status/2066451045077987449)
+    - #gpu
+        - #os
+            - [Excited to share cuTile Rust: bringing Rust's fearless concurrency to GPU kernel](https://x.com/ericlbuehler/status/2067324481903763912)
+    - #game
+        - #git
+            - [Epic Games just open sourced Lore : a next-gen version control system, built 81.](https://x.com/ayushagarwal027/status/2067683767632666869)
+    - #git
+        - #tui
+            - [Git conflicts are no longer painful! 🔥  🌳 oyui — A TUI merge editor and staging](https://x.com/orhundev/status/2067582487421739224)
+    - #wasm
+        - [Introducing Rivet 2.3.0  🦀 RivetKit rewritten in Rust 🎨 Reimagined dashboard ⏳ F](https://x.com/rivet_dev/status/2066547033545056530)
+    - #software
+        - [X11 display server just shipped in Rust.  Not hobbyist territory. That's display](https://x.com/Ferbin08/status/2066318988833878455)
+        - [Nub is a new frontend for Node ✨  🦀 A Rust CLI 🧱 Bundler-style JS/TS/JSX transpi](https://x.com/robpalmer2/status/2067487858047287625)
+    - [Vibe slopers are uploading target/ to github, and you are blackpilling? https://](https://x.com/oxcrowx/status/2067057586504192220)
+- #shader
+    - [I made a personal black hole that makes you take breaks 🕳️  A shader for Ghostty](https://x.com/s13k_/status/2064705517264552274)
+- #render
+    - #game
+        - [This guy just built a full procedural world generator with real time Unreal Engi](https://x.com/n1neshards/status/2065904409356243293)
+    - #web
+        - #software
+            - [I made another one 😎   Make pemium generative art, rendered live on your browser](https://x.com/masterofnone/status/2066136241784135957)
+    - [CloudPaintV2 ☁️Test Expected to be released on June 22. #b3d https://t.co/aQyjR4](https://x.com/casey_sheep/status/2066919182399398206)
+- #sec
+    - [Announcing uv audit: native support for vulnerability scanning across your proje](https://x.com/charliermarsh/status/2066954682040267149)
+}}
+
+\subtree[2026-07-14]{\mdnote{2026-07-14}{
+- #zig
+    - [Returning to Zig  https://gracefulliberty.com/articles/return-to-zig/](https://x.com/croloris/status/2066466432385159614)
+- #shader
+    - #web
+        - #software
+            - [Today I saw @Esychology et al's demo of high-res neural cellular automata and it](https://x.com/ekzhang1/status/2067399652480004311)
+    - #os
+        - [🌀The black hole broke out of Ghostty and became a macOS screensaver  Same shader](https://x.com/s13k_/status/2065432787205726546)
+- #webgl
+    - #game
+        - #web
+            - [This is a website 🤯  Created by Abeto - a simple web-based game made with WebGL](https://x.com/HeyMaysarah/status/2066183856374399342)
+- #web
+    - [给编码智能体用的 HTML 技能，专门生成简洁的架构图、计划页和视觉文档。  https://github.com/plannotator/effective-html  effective-html 是](https://x.com/QingQ77/status/2065216257205420225)
+    - [one of my absolute favorite accounts on this platform for a good reason](https://x.com/mervenoyann/status/2067286678083973618)
+    - [2/ introducing scira cli! ⌘  two things it does: research and code.  ask it a qu](https://x.com/sciraai/status/2065451447718969679)
+- #sqlite
+    - [Introducing the Effect SDK for Rivet Actors  Effect, made stateful:  💾 Durable,](https://x.com/rivet_dev/status/2066912703759757391)
+- #tui
+    - [I did something dumb, but I like it and I'm going to ship it. https://t.co/KSH9H](https://x.com/backnotprop/status/2067646948904153129)
+    - [clin is a TUI note manager that is compatible with Obsidian.  You can view graph](https://x.com/terminaltrove/status/2066903965002862909)
+- #software
+    - [holy crap, Lettera will be the de facto &#92;&quot;markdown ide&#92;&quot; within a year  i've been](https://x.com/NathanFlurry/status/2067737695947026841)
+    - [Got fast paced clean multiplayer working  Reconciliation, interpolation, lag com](https://x.com/TRA4669/status/2065108533822009708)
+    - [sharing my 2nd open source proj:  Field Theory v0.3.2  context management — writ](https://x.com/andrewfarah/status/2066406107359465524)
+}}
+
+\subtree[2026-07-15]{\mdnote{2026-07-15}{
+- #agent
+    - [Anthropic just dropped 5 workshops on building self-improving agentic systems fr](https://x.com/0xMovez/status/2073765125958348964)
+    - [https://x.com/i/article/2074204645845839872](https://x.com/ClaudeDevs/status/2074208949205881033)
+    - [im releasing all my agent skills to the public  this is hundreds of hours of tri](https://x.com/DavidOndrej1/status/2073741417143300099)
+    - [https://x.com/i/article/2074150113623306240](https://x.com/EXM7777/status/2074158459545854232)
+    - [This is absurdly clever: there is a way you can cut Fable 5 costs by up to ~70&#37;.](https://x.com/IntCyberDigest/status/2073200409439568031)
+    - [Youtu-LLM-2B &#40;Tencent&#41; on iPhone via Apple Core AI. First MLA model I’ve gotten](https://x.com/JackdeS11/status/2074270453934485821)
+    - [Which local model is the best for Agentic Workflows for a single @NVIDIAAI DGX S](https://x.com/MiaAI_lab/status/2074093556545749235)
+    - [Q is him! This is not larping. These guys from Korea are on the frontier of agen](https://x.com/RayFernando1337/status/2067970881293599042)
+    - [Hy2 -&amp;gt; Hy3 preview -&amp;gt; Hy3  Another massive leap forward, under half a year](https://x.com/ShunyuYao12/status/2074151389945827744)
+    - [Introducing Clips - 100&#37; free, open source, agent-native alternative to Loom  Un](https://x.com/Steve8708/status/2069064659613958348)
+    - [🚀Hy3 is here.  295B MoE. Best in its size class. Rivals trillion-scale flagships](https://x.com/TencentHunyuan/status/2074148098876768478)
+    - [introducing tau τ — an educational agent harness that teaches you how to build a](https://x.com/_alejandroao/status/2071276121593700641)
+    - [harness does play an important role after all https://x.com/adityab29_/status/2074152371857641901](https://x.com/adityab29_/status/2074152371857641901)
+    - [Claude Code团队刚刚发布了关于循环工程的设计指南：  把 Loop 分成了四类：  1. Turn-based：一次 Prompt 驱动，Claude](https://x.com/akokoi1/status/2074287428068839879)
+    - [Sidequest for Pi is a context aware side channel for coding agent tangents:   It](https://x.com/appfactory/status/2071511992225890522)
+}}
+
+\subtree[2026-07-16]{\mdnote{2026-07-16}{
+- #agent
+    - [recommended viewing. as are all of her videos.](https://x.com/badlogicgames/status/2069156188902559751)
+    - [omg it's basically pi, but more minimal for educational purposes and in python.](https://x.com/badlogicgames/status/2071329049448726665)
+    - [this is f*cking gold  Andrej Karpathy came over to Anthropic just five weeks bac](https://x.com/cyrilXBT/status/2074006684952141913)
+    - [More details about using your ChatGPT subscription in @ssh_exe_dev: https://t.co](https://x.com/davidcrawshaw/status/2073109391252042225)
+    - [https://x.com/i/article/2074345700259737600](https://x.com/dotey/status/2074347810619543722)
+    - [https://x.com/i/article/2069070121348317185](https://x.com/dunik_7/status/2069079047510864322)
+    - [My ultimate anti-slop skill.   it's based on 100s of transcripts I had with the](https://x.com/iamsahaj_xyz/status/2068339052299055472)
+    - [Here is how I minimize sycophancy, capitulation, hallucinations, and guessing us](https://x.com/kaifulee/status/2067524130673467886)
+    - [Anthropic says Claude developed a hidden “thinking space” by itself during train](https://x.com/kimmonismus/status/2074203017776423121)
+    - [Introducing https://glm.babel.town/ - the one and only FREE GLM-5.2 API service](https://x.com/mcwangcn/status/2071258952097059168)
+    - [他们拿了 230 万条 Claude（一个很强很贵的AI）在推理时候留下的“思考过程”数据，去训练了一个很小的模型（Qwen3-4B，只有40亿参数）。 结果这](https://x.com/mylifcc/status/2073231555364053472)
+    - [Earworm is public: an open-source protocol for persistent listening in agentic a](https://x.com/sonic_field/status/2074262232737734715)
+    - [I often work in multiple machines at the same time and started to mix up the scr](https://x.com/steipete/status/2074624148215939151)
+    - [Can't wait to see what people will do with GPT-5.6 Sol Ultra. Stash your hardest](https://x.com/thsottiaux/status/2072607914217320644)
+    - [https://x.com/i/article/2073090223194755072](https://x.com/trq212/status/2073100352921215386)
+}}
+
+\subtree[2026-07-17]{\mdnote{2026-07-17}{
+- #agent
+    - #formal
+        - #benchmark
+            - [I gave GLM-5.2 one goal: Turn a 2D dungeon crawler it built into a 2.5D isometri](https://x.com/cedric_chee/status/2070223250035224908)
+        - #render
+            - [Most browser 3D still starts from a main-thread model: rendering, input, UI, sim](https://x.com/felix_trz/status/2070200356966211690)
+        - #sec
+            - [i'm open sourcing UNBROKER: a tool that finds where your personal info is expose](https://x.com/SHL0MS/status/2073128911429668877)
+    - #gpu
+        - #benchmark
+            - [We built a C++ engine &#40;ced.cpp&#41; that tells you what a sound is, rooster, thunder](https://x.com/mudler_it/status/2070398080034164962)
+        - [I'm currently running training for the 35B-A6B model on a rented GPU. Back at my](https://x.com/Hikari_07_jp/status/2073073413485367702)
+        - [🐱 LongCat-2.0 is now fully open-source — MIT licensed, no restrictions.  Since o](https://x.com/Meituan_LongCat/status/2073768940078317713)
+        - [anoooother one!  Introducing ⭐Grug-30b-a3b!⭐  Grug is an open-source experimenta](https://x.com/kaiostephens/status/2072856011619107012)
+    - #benchmark
+        - [Sakana Fugu surprisingly performed near GLM 5.2 level but 17× more expensive!  W](https://x.com/atomic_chat_hq/status/2069171121044513273)
+    - #cg
+        - #game
+            - [A few people asked if Aperture is built on Three.js.  It isn’t.  Three.js is fou](https://x.com/felix_trz/status/2069841175050375208)
+            - [Introducing GameBlocks: open-source building blocks that help coding agents prot](https://x.com/spt4d/status/2072382087638954079)
+    - #game
+        - #web
+            - [What if Crossy Road &amp;amp; Meccha Chameleon had a @threejs mashup?  Built a quick](https://x.com/majidmanzarpour/status/2071284530405683463)
+        - #software
+            - [Google fired the guy that made the google workspace cli, because he made the goo](https://x.com/steipete/status/2069594195522941059)
+        - [v0.2.0 for @threejs Awesome Graphics Agent Skills is out  npx threejs-awesome-gr](https://x.com/scottstts/status/2071234915178336569)
+    - #git
+        - #os
+            - [coding agents: “give me a worktree”  Unity repo: “that’ll be 48GB and one eterna](https://x.com/Libegato/status/2070223467736088697)
+    - [GLM-5.2 is now selectable in Claude Code via Hugging Face🤗 Inference Providers +](https://x.com/zRdianjiao/status/2072906526722064415)
+}}
+
+\subtree[2026-07-18]{\mdnote{2026-07-18}{
+- #agent
+    - #proof
+        - #lean
+            - [Working with Aristotle from @HarmonicMath, an AI agent for formalization in Lean](https://x.com/prz_chojecki/status/2073013525836976417)
+        - #visualization
+            - [using Sideshow's new terminal surface to visualize some TUI mockups  the agent j](https://x.com/bentlegen/status/2069065626769825932)
+        - #software
+            - [🥷 Waza is 8 Claude Code skills for the complete engineer: think, review, debug,](https://x.com/HiTw93/status/2074293658783023343)
+    - #rust
+        - #compiler
+            - [Can't use fable for work &#40;sec&#41;, but I really wanted to push it's limits, so went](https://x.com/_can1357/status/2072822670131859777)
+        - #gpu
+            - [很现实的问题，企业海量pdf怎么办？  这个项目的思路是：  1️⃣把百度的 Unlimited-OCR 模型 用纯 Rust 重写推理层，int8 量化，单个](https://x.com/li9292/status/2074429132159484313)
+        - #git
+            - [Watch git diff while the code is changing! 🤯  👁️ livediff — A real-time diff vie](https://x.com/orhundev/status/2072693455164231918)
+        - #sqlite
+            - [Codex/Claude Code/Cursor などのローカルに残る過去のコーディングエージェント履歴を SQLite に正規化・索引化する Rust 製のC](https://x.com/about_hiroppy/status/2072836592868438486)
+    - #gpu
+        - #web
+            - [jax-js now generates WebAssembly for matrix multiplication, in-browser, that mat](https://x.com/ekzhang1/status/2068499841127264672)
+    - #render
+        - #cg
+            - [No Three.js. No fake web-based depth-of-field or focal-length emulation.  Custom](https://x.com/alex_barashkov/status/2074492797260870072)
+            - [I built a 3D engine in about a month.  That wasn’t the original plan.  Aperture](https://x.com/felix_trz/status/2069470524338810920)
+            - [progress: game-ready 3D scenes in voxel art style, from a single user intent to](https://x.com/runzhuotao/status/2074229970671714501)
+            - [Coded with Claude Sonnet 5 using Three.js, a fantasy singularity observatory fea](https://x.com/techartist_/status/2072036843865186423)
+        - #game
+            - [Claude fable 5 is just insane.  It optimised this entire #threejs city to run at](https://x.com/RyanSael/status/2073412860324327854)
+        - #os
+            - [LongCat performed Opus 4.8 and GPT 5.5 level on real physics tasks for $0!  We g](https://x.com/atomic_chat_hq/status/2072022716400484471)
+        - [You know that &#92;&quot;But, wait...&#92;&quot; moment in every LLM thinking trace?  I made it visi](https://x.com/stevibe/status/2073784489856450916)
+}}
+
+\subtree[2026-07-19]{\mdnote{2026-07-19}{
+- #agent
+    - #rust
+        - #web
+            - [Introducing Takumi v2 beta, the Rust engine that renders JSX to images without a](https://x.com/kanewang_/status/2069594925059244539)
+            - [Introducing agentOS v0.2.0  Lightweight sandbox &amp;amp; agent orchestration powere](https://x.com/rivet_dev/status/2070164128178565349)
+    - #visualization
+        - #software
+            - [Introducing DeepTutor v1.5: Agent-native Personalized Tutoring.  Our core belief](https://x.com/huang_chao4969/status/2074164108057047227)
+    - #sec
+        - #tui
+            - [People of Pi! It is done. If you've seen any of my screenshots, you know I can m](https://x.com/Howaboua/status/2068463790845551064)
+        - [People of Pi, if you'd like second model reviewing agent's work each turn and in](https://x.com/xpasky/status/2070831715518460177)
+    - #web
+        - #os
+            - [Just open-sourced wb — a lightweight browser CLI for AI agents on macOS.  ⚡ 876K](https://x.com/aduermael/status/2069557554951455146)
+            - [Congratulations to Zero authors!! 🎉 You can quickly try it out in browser with G](https://x.com/xlab_os/status/2072778180167897127)
+        - [GLM-5.2-REAP-NVFP4   &#92;&quot;Build a rubik's cube with a button I can click to solve it](https://x.com/0xSero/status/2069875673187954896)
+        - [Agent loops you've seen are demos. This one ships. Install it as a skill in Clau](https://x.com/ChronoAI_HQ/status/2070376363752910926)
+        - [For the next tutorial, I will teach you how to build a collaborative browser aut](https://x.com/codewithantonio/status/2071603951066038398)
+    - #sqlite
+        - [Got em. I poison my AGENTS.md &#40;and other things like code comments&#41; all over the](https://x.com/mitchellh/status/2067970516951150721)
+    - #tui
+        - [Another @herdrdev update. TLDR you should really try it and most definitely inst](https://x.com/Howaboua/status/2068284058061111376)
+    - #software
+        - [this guy just dropped a library of 25 INSANE loops for Fable 5  > automations fo](https://x.com/EXM7777/status/2073689577085337884)
+        - [GLM 5.2 in Amp. Zero data retention, US and West-based inference. It's a good mo](https://x.com/beyang/status/2068053105280008256)
+        - [ast-grep outline is released!   It gives you a fast local map of code structure,](https://x.com/hd_nvim/status/2069246593232998557)
+}}
+    }
+  }
+}

--- a/trees/2026-W30.tree
+++ b/trees/2026-W30.tree
@@ -1,0 +1,178 @@
+\import{macros}
+
+\title{2026-W30}
+\date{2026-07-20}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W30-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-07-20]{\mdnote{2026-07-20}{
+- #agent
+    - #webgl
+        - #game
+            - [FABLE 5 ACABA DE GENERAR ESTO EN THREE.JS  Un generador procedural de mazmorras](https://x.com/UnTalNixon_exe/status/2073969403691962436)
+    - #web
+        - #software
+            - [No Electron. No CLI. No Python. No vision model.  Just native Swift reading the](https://x.com/OsaurusAI/status/2070138640123261374)
+            - [herdr isn't an app. that's by design.    it's a runtime for your coding agents.](https://x.com/herdrdev/status/2072023156139708480)
+- #benchmark
+    - #software
+        - [RTX 3060 12GB doing work 🔥  - Qwen3.6-28B-REAP → **52 t/s** - Qwen3.6-35B-A3B →](https://x.com/azhar0406/status/2069012616614445270)
+    - #sci
+        - [This almost seems too good to be true... 🤔  What caught my attention the most —](https://x.com/MiaAI_lab/status/2073152632969908409)
+    - [Those charts were generated with Sideshow, which also just had a major version r](https://x.com/bentlegen/status/2068323598188654854)
+- #cg
+    - [If you like learning-free planning, this is the really good stuff: many robots n](https://x.com/AjdDavison/status/2074163258034970997)
+    - [A brand-new feature is coming to #Hyper3D Rodin — and it’s way beyond the Auto R](https://x.com/DeemosTech/status/2071590392819286103)
+    - [A WebGPU compute path tracer built from scratch.  Study #3     https://t.co/UZyj](https://x.com/invalid_degen/status/2069120400219332886)
+    - [GPT 5.6 Pro me prouve encore qu'il comprend très bien la 3D.  En seulement 30 mi](https://x.com/mirochill/status/2068691050869211648)
+- #game
+    - [🚨 ANNOUNCEMENT 🚨  I'm happy to announce that Ocean Survivors will be releasing o](https://x.com/AremjiGames/status/2071571877101760767)
+    - [Imagine running a massive GLM-5 model on consumer hardware. That's what nvidia's](https://x.com/HuggingModels/status/2073430639513317564)
+    - [open sourced my @threejs procedural dungeon generator, enjoy 🪄 https://t.co/lEPG](https://x.com/majidmanzarpour/status/2073880053536940501)
+- #docker
+    - #os
+        - [Meet Dory: a free, open-source Docker Desktop and OrbStack alternative for Mac.](https://x.com/python_xi/status/2073105599735177583)
+    - [i don't hate math. i hate that nobody showed me math looked like this.  https://](https://x.com/techNmak/status/2071267375794765923)
+}}
+
+\subtree[2026-07-21]{\mdnote{2026-07-21}{
+- #gpu
+    - #cg
+        - #visualization
+            - [Building robots that understand the physical world starts with accurate 3D mappi](https://x.com/Alacritic_Super/status/2073658380116430881)
+    - [This is an opensource fully procedural building generator running using @threejs](https://x.com/chirovisuals/status/2074135400138830228)
+- #game
+    - #web
+        - [improving a space shooter!  #gamedev https://x.com/andre_mc/status/2069084211944849750](https://x.com/andre_mc/status/2069084211944849750)
+    - #software
+        - [Superpowers now officially supports Kimi Code.🤝  If you're already using the Sup](https://x.com/KimiDevs/status/2072998429249474717)
+        - [📦 Quick showcase of a fully physics-based fall damage reduction system I made fo](https://x.com/OndrejAngelovic/status/2071629600711397483)
+    - [I like to think this is what happens to my Ralph loops when I forget about them](https://x.com/theo/status/2067513832080281638)
+- #misc
+    - [I'm buying a second DGX Spark, my goal is very simple. In daytime I will have DS](https://x.com/0xSero/status/2073546917133549622)
+    - [GLM-5.2 on 4x 6000s in ZCode  /goal build a nintendo ds emulator in C++, do not](https://x.com/0xSero/status/2074870153267818638)
+    - [@LLMJunky I have a friend who might have cracked GLM-5.2 lossless on 2x 6000s an](https://x.com/0xSero/status/2075171761809731623)
+    - [a reminder that things take time. it takes time to read, to connect ideas, to as](https://x.com/0xnichy/status/2071723191849095458)
+    - [8 reasons &#40;free&#41; FluidVoice beats Wispr Flow:  1&#41; Dictation is local, so it's FA](https://x.com/AndrewWarner/status/2074130001381777505)
+    - [Ever wished for an AI that thinks, codes, and creates without limits? Meet Qwen3](https://x.com/HuggingModels/status/2073608813954081137)
+    - [Personal dev stack:   L1                    Ghostty + Herdr + Termius](https://x.com/IurySza/status/2074414831772316151)
+    - [P 老板你有瓶颈吗！？ 你养活了国内 100 万美工！！ https://x.com/LunaAI519/status/2069336523703808045](https://x.com/LunaAI519/status/2069336523703808045)
+    - [New Loop Library skill feature: Lazy Loops! &#40;aka Discover&#41;  Discover will look t](https://x.com/MatthewBerman/status/2069098257444434425)
+}}
+
+\subtree[2026-07-22]{\mdnote{2026-07-22}{
+- #misc
+    - [herdr &#40;https://herdr.dev/&#41; 使用2日目のConfig  # 音がうるさい &#91;ui.sound&#93; enabled = fals](https://x.com/Meijin_garden/status/2072973758907007332)
+    - [https://x.com/i/article/2074551302185476096](https://x.com/MichaelGannotti/status/2074552763326091381)
+    - [@daniel_mac8 been looping for years now https://x.com/NathanWilbanks_/status/2063759412074815774](https://x.com/NathanWilbanks_/status/2063759412074815774)
+    - [https://x.com/i/article/2072628101054611457](https://x.com/OmniTools_AI/status/2072629231704772959)
+    - [Name a better terminal than Ghostty.  I'll wait. https://x.com/Pallavi_345/status/2071847808613969996](https://x.com/Pallavi_345/status/2071847808613969996)
+    - [Early results from the @snowflake's coco team on GLM-5.2 vs Opus-4.7 on dbt-benc](https://x.com/RamaswmySridhar/status/2069460464371954171)
+    - [Made with #python #numpy #matplotlib and #marimo &#40;and also #wigglystuff&#41; https:/](https://x.com/S_Conradi/status/2073481738286666158)
+    - [【ShojiWM】Liquid Terminal https://x.com/_Be4_/status/2069736641787527361](https://x.com/_Be4_/status/2069736641787527361)
+    - [https://x.com/i/article/2063964921495523328](https://x.com/akshay_pachaar/status/2064051835636498924)
+    - [good stuff, @github   https://github.blog/open-source/maintainers/how-pull-request-limits-are-cutting-down-the-noise/](https://x.com/badlogicgames/status/2069867447792841191)
+    - [what people don't accoubt for is that it's a multi-edit tool. if an edit tool ca](https://x.com/badlogicgames/status/2072966135331352647)
+    - [卧槽，这个项目Three.js的典范啊！  这个日本小哥的@yoshifujidesign  把这个Three.js作品把蜘蛛直接无缝变形成了马。  从多条腿的](https://x.com/berryxia/status/2071604725427085809)
+    - [Yesterday, I spent 4 hours with ChatGPT cleaning my online identity.  Result: 39](https://x.com/edgaralandough/status/2073715878797910031)
+    - [got tired of hand-porting my theme to every single tool, so i made little theme](https://x.com/eduwass/status/2069421542027502066)
+}}
+
+\subtree[2026-07-23]{\mdnote{2026-07-23}{
+- #misc
+    - [Fun @threejs experiment/toy for the weekend, probably inspired by all the Meccha](https://x.com/ggsimm/status/2068684506798629358)
+    - [We heard you. And we agree.  In light of recent developments in physical media,](https://x.com/github/status/2072801888525840476)
+    - [https://x.com/i/article/2070841897052946432](https://x.com/h100envy/status/2070852290878009586)
+    - [Ex-Berkeley PhD who leads SGLang at xAI explained how they serve Grok on 100K GP](https://x.com/h100envy/status/2074204275392307403)
+    - [Landscape Generator 2.0 is live now with a full day &amp; night cycle.  I tried to g](https://x.com/hamsteroforion/status/2071764129241534922)
+    - [22 yaşında bir çocuk python'la ağaç çizdi, 8000 dolara sattı. olayın matematiği](https://x.com/himes369/status/2069426778410455271)
+    - [cafleet の v0.16.0 をリリースしました。 Herdr をサポートしました！コーディングエージェントオーケストレーション勢のみなさんぜひ。  ht](https://x.com/himkt/status/2074285471233114613)
+    - [Just released ttd-capa, a tool used with CAPA to extract capabilities from Time](https://x.com/hullabrian/status/2069050271859171496)
+    - [pi+herdr+lakebed clutch af 🐀 https://x.com/joelhooks/status/2070575190778790330](https://x.com/joelhooks/status/2070575190778790330)
+    - [🌀 &#92;&quot;loops&#92;&quot; are nothing new, but they take thoughtful consideration to build durab](https://x.com/joelhooks/status/2070931815972647080)
+    - [My evolving dev setup: https://github.com/just-be-dev/workspace](https://x.com/just_be_dev/status/2071723672126050442)
+    - [Qwen3.6-35B、Uncensoredモデルが通常モデルの3倍くらいダウンロードされててウケるｗ まあしかし、ローカルLLMを使いたい理由ナンバーワンだか](https://x.com/kis/status/2073200786461593651)
+    - [A Black Hole Can Be Dragged Through Spacetime  A Black Hole does not have to sit](https://x.com/mathelirium/status/2068757638234378528)
+    - [What Shape Does Chaos Take Before It Looks Random?  Take one particle moving in](https://x.com/mathelirium/status/2069848907207659689)
+}}
+
+\subtree[2026-07-24]{\mdnote{2026-07-24}{
+- #misc
+    - [The Chinese Physicist Who Turned Force Into Geometry  In 1954, Chinese physicist](https://x.com/mathelirium/status/2070945257894625512)
+    - [Black Hole Can Ring Like a Bell  A Black Hole can vibrate after it is disturbed.](https://x.com/mathelirium/status/2074333520504188942)
+    - [i wanted presentations but in the terminal  so i’m building talktui  write markd](https://x.com/nexxeln/status/2071267665977737220)
+    - [my physics textbook in college was great but lacked interactive examples, catchi](https://x.com/olegakbarov/status/2068869615376343354)
+    - [Mathematics, reality, mind, higher dimensions.  Hopf fibration explorer.  By Jua](https://x.com/pickover/status/2071570015740965152)
+    - [Differential mesh growth experiments with #cuda x #python https://t.co/eimKwcHjw](https://x.com/rybinfx/status/2069463314552500498)
+    - [互联网就是这么不讲道理，昨天发现一个项目感觉很有意思，然后用一个公共靶场尝试过后感觉很强大，分享了一下然后就火了。  一天时间给作者 @apivixtls  的](https://x.com/seventhoce56019/status/2069442058939748861)
+    - [一群人在那边抢购智谱的 token plan，还抢不到。  但是今天美国公司 cloudflare 发邮件告诉我他家算力闲置太多，所以glm5.2开放免费使用了](https://x.com/skaas777/status/2070719507182821378)
+    - [This might be one of the most practical high-quality local models I’ve tested on](https://x.com/softpoo/status/2073209229234835721)
+    - [If you think codex sucks at design, try &#92;&quot;use imagegen to re-imagine this design](https://x.com/steipete/status/2073277317464682723)
+    - [The ablation studies for DeepSeek-V4-Pro are nearing completion. Next up are Kim](https://x.com/support_huihui/status/2072997403830145531)
+    - [Simulating magnetic reconnection, an astrophysical plasma phenomenon where magne](https://x.com/techartist_/status/2071283425689100772)
+    - [&#92;&quot;owntime isn't an option.  Learn how enterprise cloud architectures achieve RPO](https://x.com/tencentcloud/status/2073043544839983511)
+    - [As we are still investigating, I have reset everyone's Codex usage limits. This](https://x.com/thsottiaux/status/2071381664853319742)
+}}
+
+\subtree[2026-07-25]{\mdnote{2026-07-25}{
+- #rust
+    - [https://x.com/i/article/2074449687013179392](https://x.com/CMGS1988/status/2074488576356876585)
+    - [翻了下 Epic Games 出品的这个 Rust 实现的下一代版本管理系统源码，表面看没有发现 AI Coding 痕迹。  但我搜索整个项目的时候，发现了一](https://x.com/blackanger/status/2068644158684684604)
+- #render
+    - #game
+        - [Team ❄️ Snow or Team 🏝️ Sand?  @threejs + SDF volume &#40;to mesh&#41; + basic custom ph](https://x.com/MrCollison/status/2068826883139961149)
+    - [Happy to announce vue-tui@0.1!  What you get: - Vue <script setup> + reactivity,](https://x.com/_hyf0/status/2068016907014590689)
+- #os
+    - #software
+        - [Work-in-progress: a new split layout framework for nearly all Apple platforms &#40;m](https://x.com/mitchellh/status/2070273858154987537)
+    - [Cooldock macOS app just launched 🥳  Your smart second Dock for live widgets  htt](https://x.com/soltwagner/status/2069019899629060508)
+- #misc
+    - [Forward emails to Telegram using Cloudflare Email Routing  https://t.co/NKLm60ow](https://x.com/tom_doerr/status/2073326799803613353)
+    - [Developers buy $4,000 laptops  to run $200/month in AI tools  to build products](https://x.com/trikcode/status/2071594216195563796)
+    - [I took the next step with my Behavior Tree AI by giving it something every enemy](https://x.com/vaibway/status/2071445921540501713)
+    - [Indie dev — follow &amp;amp; add to your Steam wishlist! New vid: motion blur — near](https://x.com/vlandsgame/status/2069081833753411879)
+    - [P H A N T A S M - Glass Spirit Under a Veil  A ghost drifts through the dark ben](https://x.com/wadadawadada/status/2068676250466398231)
+    - [📖 A WebGPU storybook where the page is basically the scene. Chanwoo Hwang’s &#40;@30](https://x.com/webgl_webgpu/status/2074130576827670697)
+    - [Pulling through the thoughts. https://x.com/yiwen_lin/status/2071236309478195680](https://x.com/yiwen_lin/status/2071236309478195680)
+    - [话说，这个领域已经被AI吞掉了吗？ 这要放前几年，这种大屏Demo一出来， 至少都是六位数的订单！！ https://x.com/yyyole/status/2068323235494834687](https://x.com/yyyole/status/2068323235494834687)
+}}
+
+\subtree[2026-07-26]{\mdnote{2026-07-26}{
+- #rust
+    - #gpu
+        - #os
+            - [Exploring &#92;&quot;Spacetime Gaussian Feature Splatting for Real-Time Dynamic View Synth](https://x.com/onirenaud/status/2069060307788660986)
+    - #game
+        - #tui
+            - [terminal media players are the best 😍  https://github.com/dividebysandwich/sparkplayer  #rustlang #ratat](https://x.com/orhundev/status/2071223887984042036)
+    - #tui
+        - [Confession: I love terminals and Rust! 🦀  🫶 https://eipi.boo/ — An anonymo](https://x.com/orhundev/status/2070455909764010421)
+        - [We are building TUIs for the firmware now 🤯  🐀 ratatuefi — Run @ratatui_rs appli](https://x.com/orhundev/status/2072270069082587213)
+    - #software
+        - [Shipped Jujutsu workspaces for Herdr  In Rust ofc because why not https://x.com/coolnalu](https://x.com/NathanFlurry/status/2069381683036758488)
+    - [So true](https://x.com/elonmusk/status/2068369665647108524)
+    - [Rewriting Bun in Rust  https://bun.com/blog/bun-in-rust](https://x.com/jarredsumner/status/2074973674332123157)
+- #shader
+    - #render
+        - #cg
+            - [windfoil — a new algorithm, practically one-shotted by Fable in a ~1 hr long uni](https://x.com/mattdesl/status/2073109765081702687)
+        - [I coded a WebGPU shader sculpture with ChatGPT 5.5. UI tweaks IOR, dispersion, F](https://x.com/techartist_/status/2073927406998401370)
+    - #cg
+        - #visualization
+            - [Exploring higher-dimensional math through 3D: algebraic topology surfaces, param](https://x.com/techartist_/status/2069397579566334186)
+        - [Some talks inspire notes. Others inspire late-night experiments.  After seeing @](https://x.com/chicio86/status/2068301822427619691)
+    - #game
+        - [I coded a WebGL2 Cyber-Manta with Fable 5, blending neon plasma shaders, cyberpu](https://x.com/techartist_/status/2073812687658901573)
+    - [new water_caustic.glsl shader extracted from opensource Paper Shaders repo. I fe](https://x.com/lexrus/status/2072927493691146536)
+- #sci
+    - [🧠 Can we recover the equations governing a system directly from noisy, high-dime](https://x.com/TrackingActions/status/2070238262682058925)
+}}
+    }
+  }
+}

--- a/trees/2026-W31.tree
+++ b/trees/2026-W31.tree
@@ -1,0 +1,176 @@
+\import{macros}
+
+\title{2026-W31}
+\date{2026-07-27}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W31-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-07-27]{\mdnote{2026-07-27}{
+- #shader
+    - #web
+        - [you can just light things with threejs https://x.com/measure_plan/status/2073762898824790480](https://x.com/measure_plan/status/2073762898824790480)
+- #webgl
+    - #gpu
+        - #game
+            - [Built an open-source, real-time procedural soil &amp;amp; terrain studio using @thre](https://x.com/chirovisuals/status/2073084997863366689)
+    - [probably the most beautiful scene ive ever created with codex  it feels like bri](https://x.com/_echozhou/status/2068931876283465791)
+- #visualization
+    - [DYK around half of the brain is not made of neurons? Among the other half is the](https://x.com/AllenInstitute/status/2071740062048391322)
+    - [Stokes Phenomenon - When an Invisible Term Switches On  In Asymptotic Mathematic](https://x.com/mathelirium/status/2071658446848422371)
+- #web
+    - [@keenanisalive et al's &#92;&quot;Geodesics in Heat&#92;&quot; algorithm demo on web in jax-js :&#41;  L](https://x.com/ekzhang1/status/2074342523309326722)
+    - [react scan is one of the few tools that i love for making me feel like an idiot](https://x.com/zebassembly/status/2071781800829927471)
+- #tui
+    - [Say “oh my” to Pi.   Full omp TUI, native GUI on top with inline diffs and rich](https://x.com/superdoteng/status/2074858484395331931)
+    - [herald is a powerful TUI email client &amp;amp; calendar tool for the terminal.  It](https://x.com/terminaltrove/status/2069447478777143487)
+- #software
+    - [React Three Fiber has had great text solutions for years… until you switched to](https://x.com/Andersonmancini/status/2074067077623926854)
+    - [Haven't seen any demos of using vibe coding to prototype gadgets like this  So I](https://x.com/DilumSanjaya/status/2070912580122755484)
+    - [Anime.js is 10 years old! 🎂🎉  A short thread about the current state of the lib,](https://x.com/JulianGarnier/status/2073062636565012597)
+    - [difit https://github.com/yoshiko-pg/difit vs crit https://crit.md/ vs hunk https://t.](https://x.com/Meijin_garden/status/2074064016541127163)
+    - [This inspired me to try another bad idea:  Agent-generated “html” diagrams in hu](https://x.com/bentlegen/status/2073378203654107266)
+}}
+
+\subtree[2026-07-28]{\mdnote{2026-07-28}{
+- #agent
+    - [Dario Said why distilled?😂 Kimi-K3 just went from #18 to #1 in frontend coding.](https://x.com/0x0SojalSec/status/2078010107691155628)
+    - [OpenAI 战略负责人 Dean W. Ball 称，Kimi K3 是一款很强的模型。它在 Agent 编程中的表现，已经接近 2026 年第一季度最好的公](https://x.com/0xLogicrw/status/2078329537532961092)
+    - [Kimi K3 vs Opus 4.8 vs GPT-5.6 Sol  One Fruit Ninja prompt. One generation per m](https://x.com/AiHubMix/status/2078108420054696272)
+    - [Just gave GPT 5.6 Sol: - Root access on a brand new Mac mini - Fully functional](https://x.com/AlexReibman/status/2078392050261856464)
+    - [a week ago @SemiAnalysis_ wrote that Chinese labs are &#92;&quot;simply too compute poor t](https://x.com/AnikaSomaia/status/2077892561386299664)
+    - [https://x.com/i/article/2077795070166913027](https://x.com/BraceSproul/status/2077799049156338142)
+    - [🚨New Paper: Training Small LLMs to Introspect!🚨  We create two rigorous evals of](https://x.com/ElyHahami/status/2078161491069718639)
+    - [&amp;gt; replicate J-space on GLM 5.2 &amp;gt; train a reward model and run RL to reduce](https://x.com/GoodfireAI/status/2077073005088501780)
+    - [Kimi 3 could've never done this https://x.com/MarkKnd/status/2078185821279224163](https://x.com/MarkKnd/status/2078185821279224163)
+    - [This is what I use for all my agentic workflows evals. Great tool!](https://x.com/MiaAI_lab/status/2077769725975675167)
+    - [a graph engineering article has hit the timeline https://x.com/RhysSullivan/status/2078599574936240410](https://x.com/RhysSullivan/status/2078599574936240410)
+    - [On @Kimi_Moonshot K3: please note that the model requires thinking history prese](https://x.com/Xianbao_QIAN/status/2077843337030385664)
+    - [Stay tuned for K3.1](https://x.com/Xinyu2ML/status/2078009071647809680)
+    - [continuing Imitation Learning  humans are remarkably good at high-fidelity imita](https://x.com/aimalysheva/status/2077843461081079888)
+    - [Pi社区开源了codex没有开源的computer-use实现。  深入分析了一下仓库，眼前一亮！ https://t.co/kvVtpJMcka](https://x.com/alading22/status/2076815570805149748)
+}}
+
+\subtree[2026-07-29]{\mdnote{2026-07-29}{
+- #agent
+    - [Control the ideas, not the code: blog post here https://t.co/RLjVUvGWVX](https://x.com/antirez/status/2076634907049164891)
+    - [&#92;&quot;Video = World + Event Stream&#92;&quot;  Wan-Streamer v0.3 treats video as a world plus e](https://x.com/askalphaxiv/status/2078159284194414845)
+    - [recommended reading.](https://x.com/badlogicgames/status/2076606446637056342)
+    - [recommended reading. simple is good, simple is beautiful. simple works.](https://x.com/badlogicgames/status/2077837933894160841)
+    - [Kimi K3 is not really Opus class!   Not on long context multi-turn complex agent](https://x.com/bindureddy/status/2077945200069275855)
+    - [agent-spec 1.0 太好用了，我用它来写一本 grok build 的深度探索的书。  https://github.com/ZhangHanDong/agent-spec   当然，实现](https://x.com/blackanger/status/2077842100616659254)
+    - [Fable 5 has been removed from Claude Code.  All of a sudden it says usage credit](https://x.com/bridgemindai/status/2078185349327593973)
+    - [Beginning July 20, Claude Fable 5 will be included in all Max and Team Premium p](https://x.com/claudeai/status/2078302415804379218)
+    - [true. 我在年初看到kimi linear这篇论文的时候，就决定将linear att选为自己的研究方向，当时的scaling曲线比较震撼。mechanis](https://x.com/flyingpetal472/status/2077937063610241355)
+    - [Hugging Face 出的极简智能体，手把手教你从零造一个属于自己的 coding agent。学习写 agent 的入门玩具。  https://t.co](https://x.com/geekbb/status/2075041498077302884)
+    - [https://t.co/249JaHcEz7](https://x.com/h100envy/status/2068987470960623783)
+    - [I asked the new Kimi K3 to pentest a website and looked into its inner reasoning](https://x.com/hrkrshnn/status/2078249492596584503)
+    - [Kimi K3 applies quantization-aware training from the SFT stage onward, using MXF](https://x.com/ivanfioravanti/status/2077866268414108012)
+    - [About ~25 prompts to gpt-5.6-sol &#40;&#92;&quot;high&#92;&quot;&#41;, and you've got a nice &#92;&quot;specimen conso](https://x.com/janole/status/2076637287933264341)
+    - [In Argo, you can get Claude Code and Codex to work together.   This agent team e](https://x.com/junxi_song/status/2075918736817889551)
+}}
+
+\subtree[2026-07-30]{\mdnote{2026-07-30}{
+- #agent
+    - [i built a new pi subagent extension that is more codex-like; main agent can easi](https://x.com/lumendriada/status/2076842304925474932)
+    - [去看了下 Kimi 的技术博客，多朴实的一家公司啊  文字开头就直白的告诉了大家──我们整体性能仍然落后于最强大的专有模型 Claude Fable 5 和 G](https://x.com/manateelazycat/status/2077953688237416701)
+    - [A junior just asked me &#92;&quot;what do I do if I'm being grilled about something I don'](https://x.com/mattpocockuk/status/2076373232295587865)
+    - [Reworded /grill-me so it can now truly be used anywhere - not just engineering.](https://x.com/mattpocockuk/status/2076611482033193226)
+    - [GPT-5.6-Sol just accidentally deleted almost ALL of my Mac’s files.  And this is](https://x.com/mattshumer_/status/2075657271401390161)
+    - [hey @thsottiaux i am sad to say that you have a bug  I have 0&#37; weekly limits and](https://x.com/melvynx/status/2077848362938761499)
+    - [If you like pi-tidy-tools, you might like pi-tidy-subagents.   Same minimal UX.](https://x.com/mikeyobrienv/status/2076107537599115767)
+    - [It’s gone they pulled it early](https://x.com/mweinbach/status/2078183217526428027)
+    - [Noticed that StreamLake has lower pricing for glm-5.2  Time for a pricing update](https://x.com/nahcrof/status/2076040656808501686)
+    - [Kimi K3 is Freeeeeeee !! https://x.com/qiluaH02/status/2078261675288092970](https://x.com/qiluaH02/status/2078261675288092970)
+    - [How can an LLM switch between low-, medium-, and high-effort reasoning? And how](https://x.com/rasbt/status/2078471977237450829)
+    - [Fable 5 vs GPT 5.6 SOL    Created with Arcads MCP https://x.com/rom1trs/status/2](https://x.com/rom1trs/status/2077382083832340784)
+    - [Rebuilt the theme park voxel map, pushed the 3d agent to make it bigger and dens](https://x.com/runzhuotao/status/2077980369337655431)
+    - [There are only 3 models: - Luna/High - Terra/Ultra - Sol/High https://t.co/silyN](https://x.com/ryanjanssen/status/2075626345455898876)
+    - [Kimi K3 is built on Kimi Delta Attention &#40;KDA&#41; and Attention Residuals &#40;AttnRes&#41;](https://x.com/scaling01/status/2077770130000323068)
+}}
+
+\subtree[2026-07-31]{\mdnote{2026-07-31}{
+- #agent
+    - #benchmark
+        - #cg
+            - [My notes on Kimi K3, plus some thoughts on what we can still learn from the peli](https://x.com/simonw/status/2077852005129933247)
+        - #game
+            - [Kimi K3 has one problem and it is a BIG one.  It is slow. Painfully slow.  24 to](https://x.com/bridgemindai/status/2078162250221695154)
+        - [Kimi Code pricing is actually HORRIBLE. Why is nobody talking about this??? 😭  I](https://x.com/OmedVibeCodes/status/2077862760268837047)
+        - [Yesterday's replies recommended Luna for subagents. My Codex tests went the oppo](https://x.com/Voxyz_ai/status/2076320930188427363)
+        - [Turns out you can get an opus 4.8 level model perf at 190 tokens per second and](https://x.com/arafatkatze/status/2076958055632396595)
+        - [Introducing autoresearch with GPT 5.6  We had GPT 5.6 Sol reproduce the key find](https://x.com/askalphaxiv/status/2076737985559822734)
+    - [We just killed Higgsfield.    You can now use Seedance 2.0 directly from Claude](https://x.com/shengkun_ye/status/2077854613949276319)
+    - [GPT-5.6 is absolutely f*cked at trading.  They connected it to live options flow](https://x.com/shiri_shh/status/2078173078023217475)
+    - [Grep, BM25, pfft, BOOLEAN queries is all you need!](https://x.com/srchvrs/status/2077854958494306576)
+    - [If you set gpt-5.6-sol to &#92;&quot;ultra&#92;&quot;, all the subagents it spawns will also be set](https://x.com/theo/status/2075742083370127504)
+    - [There it is!](https://x.com/thorstenball/status/2078362156911768047)
+    - [If you aren't yet bold enough to install the Codex app, you can stay in the pres](https://x.com/thsottiaux/status/2076119366647894371)
+    - [Morning. The last 48 hours of Codex and ChatGPT Work have been intense! Three im](https://x.com/thsottiaux/status/2076365965915467978)
+    - [Updates for Codex and ChatGPT Work users. No nerfing, only good stuff!  - We hav](https://x.com/thsottiaux/status/2076495156757577895)
+    - [最近 Pi 生态出了几个值得关注的扩展。pi-discuss-mode 让你和 agent 对话时不用担心误操作；Pi Exa 给 Pi 接上了网页搜索；pi-](https://x.com/yibie/status/2077325583017767314)
+}}
+
+\subtree[2026-08-01]{\mdnote{2026-08-01}{
+- #agent
+    - #benchmark
+        - #game
+            - [You have no idea how insane this is.  This team got 99&#37; on the hardest and most](https://x.com/ryaneshea/status/2077792956187279746)
+        - #web
+            - [This is just crazy.  Poetiq has built harnesses that make Opus 4.8 / GPT-5.5 out](https://x.com/bosmeny/status/2077494848517816670)
+        - #software
+            - [Google engineer explained how to fine-tune a tiny LLM from 46&#37; to 90&#37; accuracy o](https://x.com/h100envy/status/2077784077604692440)
+    - #cg
+        - #visualization
+            - [A different way to visualize the building blocks of matter.  This 3D spiral arra](https://x.com/cosmosarcive/status/2077656653479215434)
+        - #game
+            - [I tested Kimi K3 vs Claude Opus 4.8  Same prompt, an armory bay with lighting, p](https://x.com/Bhavani_00007/status/2077798166729208223)
+        - #os
+            - [推荐三个最近在 HN 上热传的 coding agent 配套工具。  Clawk（465⭐）——给你的 coding agent 一个一次性的 Linux V](https://x.com/yibie/status/2077229825379688723)
+        - [Who’s Kimi K3 prompt is porting this to Apple Vision Pro ?](https://x.com/Sdefendre/status/2077927711083806833)
+        - [here's a direct comparison between fable and sol on @threejs 3d model building.](https://x.com/scottstts/status/2077126590438207782)
+        - [Kimi K3 is out. But it's not what I expected, not better than Fable or Opus 5 le](https://x.com/thegenioo/status/2077768467554455581)
+    - #context
+        - [This is huge!! super excited about it. Meet 𝐂𝐞𝐫𝐞𝐛𝐫𝐚𝐬 𝐊𝐧𝐨𝐰𝐥𝐞𝐝𝐠𝐞: one of the most](https://x.com/LinghuaJ/status/2077829577322426879)
+        - [“Language Models Need Sleep: Learning to Self-Modify and Consolidate Memories”](https://x.com/askalphaxiv/status/2076826479082536996)
+        - [also: sidebar rows no longer have a default gap between entries, so everything p](https://x.com/herdrdev/status/2077436994133561568)
+        - [There's a few issues with Codex that stacked really badly, causing people's usag](https://x.com/theo/status/2076512403668488299)
+        - [&#40;1&#41; is not correct, it is not due to 2X charging after 272k context, we don't ch](https://x.com/thsottiaux/status/2076543065045795309)
+        - [K3 has now crossed the 1M context-length barrier, and DeepSeek's sparse attn has](https://x.com/yzhang_cs/status/2077843838614605918)
+}}
+
+\subtree[2026-08-02]{\mdnote{2026-08-02}{
+- #agent
+    - #formal
+        - #proof
+            - [It's one of the most foundational equations in mathematical physics. Lanyon just](https://x.com/getjonwithit/status/2078114275868967338)
+    - #gpu
+        - #benchmark
+            - [TL;DR: Kimi K3 is bullish for inference compute demand.](https://x.com/ChrisCamillo/status/2077928685022089453)
+            - [Self-evolving: AttnRes Kernel Optimization  Given FLA Triton AttnRes at producti](https://x.com/Kimi_Moonshot/status/2077830242060923207)
+            - [HOLYYYY  27B model under 6GBs and 4GBs  Local AI will be the default  P.S. We ar](https://x.com/TheAhmadOsman/status/2077097942318485797)
+            - [One DGX Spark. Qwen3.6-35B  64 users. 700+ tok/s. 32,768 tokens in 54 seconds.](https://x.com/WescheNex1q/status/2075388296914505754)
+            - [Introducing Aster Inference -- The world's fastest inference API created by AI r](https://x.com/asterailabs/status/2077556435085574429)
+        - #os
+            - [optimizers, adaptive depth and depth extrapolation 👀](https://x.com/ZhengyangGeng/status/2078541335150424424)
+        - [We’ve just released the 1-bit &amp; 4-bit version of Hy3, a flagship-scale 295B mode](https://x.com/TencentHunyuan/status/2076953120765280284)
+        - [We’re releasing new Qwen3.6 quants that run 2.5× faster on your GPU.  Qwen3.6-27](https://x.com/UnslothAI/status/2075566124687892597)
+        - [For reference, a single RTX 5090, same Qwen3.6-35B  128 users. 2,500 tok/s. 65,5](https://x.com/totheagi/status/2075830041842499730)
+    - #game
+        - #web
+            - [I've been using GPT 5.6 SOL and Claude Fable for serious game development since](https://x.com/metatransformr/status/2077844841128427780)
+        - [OK, after testing it out myself, now I understand why @Kimi_Moonshot K3 can deli](https://x.com/Xianbao_QIAN/status/2077846780654596488)
+        - [Kimi K3 Jailbroken   can write good celebrity stuff  can code malware can hack w](https://x.com/chetaslua/status/2078097100433457276)
+    - #os
+        - [postmortem with gpt-5.6-sol:   fable launched 4 researchers; each triggered clau](https://x.com/lumendriada/status/2075715390194233700)
+    - #docker
+        - [This is a fun project Lakedbed, Herdr, Pi, Effect, XState prototyping a looping](https://x.com/joelhooks/status/2076903279536259372)
+}}
+    }
+  }
+}

--- a/trees/2026-W32.tree
+++ b/trees/2026-W32.tree
@@ -1,0 +1,192 @@
+\import{macros}
+
+\title{2026-W32}
+\date{2026-08-03}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W32-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-08-03]{\mdnote{2026-08-03}{
+- #agent
+    - #proof
+        - #benchmark
+            - [The first experimental evidence of recursive self-improvement &#40;RSI&#41;.   Autoresea](https://x.com/zhengyaojiang/status/2077079778793042425)
+    - #rust
+        - #zig
+            - [zig 作者发表了对 bun 用 rust 重写的看法  &#92;&quot;在有 LLM 之前 Jarred &#40;Bun 作者&#41;已经在生产垃圾代码了&#92;&quot; 😭 https://t.c](https://x.com/localhost_4173/status/2075470256395657518)
+        - #gpu
+            - [Want to run a 70B+ model but don't have an 80GB GPU? Mesh LLM distributes infere](https://x.com/DataChaz/status/2076571482201997476)
+        - #software
+            - [We implemented Kimi K3's native harness in Rust.  Now, @OpenInterpreter is the #](https://x.com/OpenInterpreter/status/2078227281227788785)
+        - [I appreciate the thoughtful blog post.  As someone that bet on bun early in mult](https://x.com/YoavCodes/status/2075004601636446633)
+    - #shader
+        - #render
+            - [updated my @threejs game dev agent skills:  📐 designs the game better - core loo](https://x.com/majidmanzarpour/status/2075040799851487652)
+        - #web
+            - [I asked k3:  &#92;&quot;I want you to push the boundaries of what's possible in web design](https://x.com/johnlindquist/status/2077840176370602179)
+    - #render
+        - #visualization
+            - [HTML isn't just markup anymore.  For AI agents, it's becoming the best visualiza](https://x.com/pascowebdesigns/status/2076475853542961214)
+    - #os
+        - #software
+            - [your agent gonna be like &#92;&quot;sure i can use dd&#92;&quot;  sudo dd if=/dev/zero of=/dev/sda b](https://x.com/thdxr/status/2077553783198908543)
+    - #software
+        - [your daily reminder that herdr is not just an app; it’s the agent runtime to bui](https://x.com/herdrdev/status/2077740056140222664)
+        - [不需要再开多个 terminal 跨 Agent 沟通了。  tmux-bridge 让 Claude Code、Codex、Gemini CLI、Kimi C](https://x.com/iluciddreaming/status/2077996241976451333)
+        - [From skills, to graphs, and back to skills. https://x.com/kcosr/status/2078595303402266827](https://x.com/kcosr/status/2078595303402266827)
+        - [I had to turn memories off in codex. When working across multiple projects, code](https://x.com/kevinkern/status/2076963194782773656)
+        - [Some extremely smart ideas in here around:  1. Using /wayfinder as an orchestrat](https://x.com/mattpocockuk/status/2077743625639714850)
+    - #sci
+        - [Manifold hypothesis strikes again](https://x.com/IlyasHairline/status/2078153471505604683)
+}}
+
+\subtree[2026-08-04]{\mdnote{2026-08-04}{
+- #agent
+    - #visualization
+        - [ngl this is better than our built-in visualization  . 🔥](https://x.com/JinjingLiang/status/2076948617261449493)
+    - #web
+        - #os
+            - [It finally finished, here's the final output. Used 60&#37; of my monthly Kimi usage](https://x.com/mweinbach/status/2077878247920951400)
+        - #software
+            - [Seeing a lot of conversation about Codex vs ChatGPT Work  In TPOT, the differenc](https://x.com/nickbaumann_/status/2077802413432647702)
+            - [The most important change were: To use the &#92;&quot;Work&#92;&quot; area, to instruct the AI to us](https://x.com/pozsgaybalazs/status/2076763217926168840)
+            - [Hello beautiful people! We have reset usage limits across Codex and ChatGPT Work](https://x.com/thsottiaux/status/2075641131002700120)
+            - [Introducing... another usage limit reset for all our ChatGPT Work and Codex user](https://x.com/thsottiaux/status/2075820987833274448)
+        - [He wrote half of the modern web tools everyone uses. in his spare time.  instead](https://x.com/Granite0x/status/2076621696887361880)
+        - [I've been looking forward to this one.  Today we're releasing Immersive Web Emul](https://x.com/felix_trz/status/2075619397633532012)
+        - [i realized that many people use paid services to let their agents browse and sea](https://x.com/lumendriada/status/2078172952856793417)
+        - [pi-web-access is an extension that provides web search &#40;and more&#41; for Pi coding](https://x.com/nicopreme/status/2024129561106018530)
+        - [Introducing ax - the AI-era curl!  One command to code agents to fetch, discover](https://x.com/yusukebe/status/2075354866202083479)
+    - #software
+        - [ChatGPT Sol is remarkable. For 1-2 days I was disappointed, but then I read one](https://x.com/pozsgaybalazs/status/2076409836263063960)
+        - [We used this one: https://t.co/6szUgtJeFZ](https://x.com/pozsgaybalazs/status/2076409894152884720)
+- #benchmark
+    - [Here you go, run GLM-5.2 no pruning on 4x RTX PRO 6000s, I've tested it extensiv](https://x.com/0xSero/status/2074832742311739716)
+    - [New benchmark just dropped!](https://x.com/MatthewBerman/status/2077419567257993444)
+}}
+
+\subtree[2026-08-05]{\mdnote{2026-08-05}{
+- #benchmark
+    - #game
+        - #software
+            - [Worth explaining what's actually new in K3 from @Kimi_Moonshot, because the game](https://x.com/MTorygreen/status/2078056300986905019)
+    - #context
+        - [https://x.com/i/article/2077990815679361024](https://x.com/elliotarledge/status/2078048144844280315)
+    - [This is pure cope trying to be desguised as reasonable take. The problem with al](https://x.com/basedjensen/status/2077881852896121190)
+    - [I removed 423 GB from GLM‑5.2 without changing the model.   1,403 GB → 980 GB. 7](https://x.com/brianbellx/status/2076432307687215494)
+    - [My take on Kimi K3 &#40;tldr: it's GOOD&#41;. See the thread for the full process used.](https://x.com/doodlestein/status/2077902353470980164)
+    - [Upcoming models performance predictions :   Opus-5 = Slightly worse than Fable,](https://x.com/jun_song/status/2077372165696135279)
+    - [After a lot of tests: NO, Luna is nice ON THE benchmark but an absolute shit in](https://x.com/melvynx/status/2076621638729146434)
+    - [MOSS-Transcribe-Diarize by @MosiAI_Official just dropped &#40;congrats!&#41;, and it alr](https://x.com/mudler_it/status/2075197087860265166)
+    - [At different times you complained about speed, code slop, frontend quality, ...](https://x.com/thsottiaux/status/2076145711922696371)
+- #cg
+    - #game
+        - [kimi k3 cooked again.  one shot:  a full 3D chilli product experience the chilli](https://x.com/abhinavflac/status/2077680879480999964)
+    - #software
+        - [Introducing MorphoHDL, a minimal language prototype for growing boolean circuits](https://x.com/zzznah/status/2076775628913741913)
+    - #sci
+        - [Since nobody called it out in the comments, this “new way” to show 3D Gaussian s](https://x.com/keenanisalive/status/2078189577165238716)
+    - [Spaceship Earth Magnetosphere https://t.co/ILv5O9S07h](https://x.com/CosmicWatch/status/2076462323716206792)
+    - [electromagnetics seem so alien](https://x.com/brad_rothenberg/status/2077782310259245345)
+    - [Finally tested Kimi K3 on voxel art, and the hype is real. Its 3D reasoning capa](https://x.com/runzhuotao/status/2078329363440058785)
+}}
+
+\subtree[2026-08-06]{\mdnote{2026-08-06}{
+- #formal
+    - [Introducing: Mechanistic World Models.   Scientific discovery is not just predic](https://x.com/IngmarPosner/status/2077648004794716589)
+- #compiler
+    - [oh... my](https://x.com/yacineMTB/status/2077914240619327613)
+- #gpu
+    - #benchmark
+        - #cg
+            - [China open-sourced a model that reconstructs any scene in 3D from a regular vide](https://x.com/thesupermanmx/status/2077779856050606155)
+        - #game
+            - [We might finally have the local model that the 12-16 GB VRAM crowd has been wait](https://x.com/MiaAI_lab/status/2077161017285439914)
+    - [Kimi K3 2.8T is so large that it will not fit on a single NVIDIA DGX B200, even](https://x.com/SemiAnalysis_/status/2077966560447074689)
+    - [We’re releasing Gemma 4 NVFP4 quants that run 1.5× faster on your GPU.  Gemma-4-](https://x.com/UnslothAI/status/2077070408948584617)
+    - [https://twitter.com/shivamhwp/status/2078021933418066390/photo/1](https://x.com/shivamhwp/status/2078021933418066390)
+    - [Found this great article on implementing Flash Attention in CUDA https://t.co/lV](https://x.com/v0xium/status/2078118523789066748)
+- #cg
+    - #visualization
+        - #game
+            - [Grok 4.5 is seriously impressive at building 3D experiences. Coded a floating sc](https://x.com/techartist_/status/2076278552295866815)
+        - [Made this while testing if AI can work out the math behind a mechanism  Just fro](https://x.com/DilumSanjaya/status/2076711723437068491)
+- #game
+    - #software
+        - [Intro &#92;&quot;gatho&#92;&quot;, a self-hostable javascript toolkit for multiplayer games and real](https://x.com/isaac_mason_/status/2076482019023008109)
+    - [Amazing run-and-gun game concept... Stylish like Vib-Ribbon from PS1 era https:/](https://x.com/IndieGamesLib/status/2076652865821561130)
+    - [pi 也有自己的computer-use 了， 支持Mac 和Windows。  看起来是作者逆向了codex 的实现，底层不是cua driver。  我觉得](https://x.com/LinearUncle/status/2076477615276474592)
+    - [kimi k3 just have reminded to people of the mighty scaling law  but they only pr](https://x.com/q_yeon_gyu_kim/status/2078089919118057597)
+    - [New Three.js City Asset Pack is out now!  🏙️ 66 assets — towers, shops, street f](https://x.com/threejsassets/status/2078086218311499942)
+}}
+
+\subtree[2026-08-07]{\mdnote{2026-08-07}{
+- #gpu
+    - #benchmark
+        - #software
+            - [744B parameters. On a laptop. With 25GB RAM.  Colibri runs GLM-5.2 &#40;744B MoE&#41; in](https://x.com/chenzeling4/status/2075731830477877612)
+    - #cg
+        - #game
+            - [Kimi K3 built a browser-based 3D martial arts   RPG featuring melee combat, ques](https://x.com/chetaslua/status/2077831714274156804)
+    - #software
+        - [Chinese factories are buying RTX 5090s in bulk, desoldering the chips, and rebui](https://x.com/kyzoroX/status/2077829867421237348)
+        - [China has killed the GPU mafia 🤯  They open-sourced a framework that runs DeepSe](https://x.com/thesupermanmx/status/2078530117077434687)
+- #misc
+    - [月之暗面新团队成员杨新宇解释了 Kimi 为什么能推出 K3。  他称，自己今年离开学界进入产业，期间接触了多家 AI 公司。他总结出同行的四种通病：  ① 傲](https://x.com/0xLogicrw/status/2078060153216311377)
+    - [GLM-5.2 has been cracked, 86.8 tok/s decode and 1.2k tok/s prefill https://t.co/](https://x.com/0xSero/status/2077040838715064395)
+    - [this one has been sitting in my drafts for way too long, i finally finished it a](https://x.com/0xrsydn/status/2075879095100145854)
+    - [两个香港学生，把Karpathy的自动研究框架干到了5倍速。  没换更强的模型，也没加更多算力，甚至代码都没怎么改。  只是在原来的循环上面，又套了一个循环。](https://x.com/AYi_AInotes/status/2075380100120375319)
+    - [@thdxr chronicle? it takes screenshot of covos and uses 5.5 to generate memory f](https://x.com/Anrahya/status/2078565549140009120)
+    - [met a guy at Google making $1.2M a year.  asked him how he ships alone at the pa](https://x.com/ArchiveExplorer/status/2077389023144821111)
+    - [クリエイター&#40;ArsOlta氏&#41;がシールド破壊演出をBlenderとGodotで再現  Blenderで六角形シールドを作成し、Godotのシェーダーでリアルな](https://x.com/Botan_cr/status/2076994976907677982)
+    - [Printing Hand Muscles Test #b3d #geometrynodes https://t.co/1XzMZokcUm](https://x.com/Cartesian_C/status/2077060186007609666)
+    - [We've reset 5-hour and weekly rate limits for all users.](https://x.com/ClaudeDevs/status/2077603834453770467)
+    - [The one account to follow this evening: @Jianlin_S Actual frontier engineering i](https://x.com/Dorialexander/status/2077818455886008681)
+    - [Hyperbolic Gears can explain  Alexander Horned Spheres. https://en.wikipedia.org/wiki/Alexander_horned_sphere](https://x.com/Ebayednoob/status/2078301025581273400)
+}}
+
+\subtree[2026-08-08]{\mdnote{2026-08-08}{
+- #misc
+    - [@qqqqqf_ 一眼gpt,黑话满天飞,本来5.5已经调教到能看懂的程度了,5.6一更新又是一堆黑话,又到了看不懂的时代](https://x.com/EllenWu19548/status/2078037624254873865)
+    - [🚀 Qwythos-9B-v2 is here — the new &amp;amp; improved Qwythos.  Same deep reasoning a](https://x.com/EmperoAI/status/2075647519179051255)
+    - [I am honestly waiting for @rasbt blog on Kimi Delta Attention](https://x.com/Gauri_the_great/status/2078093769925423276)
+    - [35B-A6B Model Development Progress Report!! In A6B, we're expanding the number o](https://x.com/Hikari_07_jp/status/2076151007952920708)
+    - [GLM 5.2 is currently available for dirt cheap through openrouter. https://t.co/Z](https://x.com/ImSh4yy/status/2078512135714316772)
+    - [ELECTRIC FIELD — ORBITING POTENTIAL CONTOURS https://openprocessing.org/@Kazoops/2981052 電磁の三体問題シェーダ](https://x.com/KAZOOOps/status/2077970793368268905)
+    - [https://t.co/gP78gJgbGT  推荐codex 降智雷达图，每天早上和下午各自更新一次。  从今天的图看,Sol Max 很反常，IQ 只有7](https://x.com/LinearUncle/status/2076600950127722654)
+    - [开放了grok-build项目的源码解读，类似deepwiki  https://linearuncle.github.io/grok-build-wiki  这个项目优点： 1. 中文，deepwiki](https://x.com/LinearUncle/status/2078073633574965730)
+    - [After doing ~50B tokens, this is the config I've landed on https://t.co/EERJFTXO](https://x.com/MarcosHernanz/status/2077066471474401543)
+    - [Meet kbd-1.0-codex-micro, built with @work_louder.  Map the buttons and joystick](https://x.com/OpenAIDevs/status/2077425991790870644)
+    - [OpenClaw is 🔥 and Peter is GOAT  Send this to your OpenClaw Agent:   models auth](https://x.com/Saboo_Shubham_/status/2040514038342603058)
+    - [とうとうIphoneでQwen3.6−27bが動くようになりました  1ビット量子化でモデルファイルは3.9GBまでコンパクト化して性能はベースモデルの90％を](https://x.com/Tono_Ken3/status/2077142545734443122)
+    - [updated!!! https://x.com/Xinyu2ML/status/2078038445537308980](https://x.com/Xinyu2ML/status/2078038445537308980)
+    - [If compression is intelligence, text cannot be the final for superintelligence.](https://x.com/ZhengyangGeng/status/2077849330581655751)
+    - [Introducing Slop.md...  A 80,000+ Character .MD File that removes all common AI](https://x.com/aaayandev/status/2077078710499287410)
+}}
+
+\subtree[2026-08-09]{\mdnote{2026-08-09}{
+- #misc
+    - [Using Fable 5 to add fur and a new voice to my RL creature. The voice is based o](https://x.com/aaronlemke/status/2072478892464521597)
+    - [Using Sol to build a large scale tentacle craft navigating the rings of Saturn.](https://x.com/aaronlemke/status/2076805589989261676)
+    - [annoyed at how much better the gpt 5.6 models seem to work in pi when you swap e](https://x.com/aliouftw/status/2078122571908674011)
+    - [This man can write!  Pair this understanding with profiling &#40;shameless plug to m](https://x.com/ariG23498/status/2077233472658362378)
+    - [worth re-reading in light of the K3 drop today](https://x.com/astridwilde1/status/2077975632546578861)
+    - [recommended reading. don't despair. learn and adapt.](https://x.com/badlogicgames/status/2076638077322252593)
+    - [recommended reading by Laura Summers who appears to be not on this hellsite beca](https://x.com/badlogicgames/status/2077692101664329961)
+    - [Finally we have an American alternative to GLM 5.2  Awesome to see American Open](https://x.com/beffjezos/status/2077474971325214860)
+    - [You can now try Inkling in Amp:  amp update amp plugins add --auto-update @amp/i](https://x.com/beyang/status/2077809038457528331)
+    - [https://t.co/LywoNH70YZ](https://x.com/brianbellx/status/2076432309507477626)
+    - [&amp;gt; Fable to plan &amp;gt; Luna xhigh to execute &amp;gt; Sol xhigh to review  Don't ov](https://x.com/cjzafir/status/2077041655144947949)
+    - [testing some more ways of doing webgpu wind line LOD with @WindBorneWx weatherme](https://x.com/codetaur/status/2075298576272642333)
+    - [https://t.co/PTeDiv1b6L](https://x.com/demishassabis/status/2076957440109625718)
+    - [Progress bar explorations. Which one is you favorite? https://t.co/o1G7VivYF1](https://x.com/disarto_max/status/2076714200609501610)
+    - [all will become fidgetable https://t.co/ICGZASMrhU](https://x.com/disconcision/status/2076335711758713167)
+}}
+    }
+  }
+}

--- a/trees/2026-W33.tree
+++ b/trees/2026-W33.tree
@@ -1,0 +1,170 @@
+\import{macros}
+
+\title{2026-W33}
+\date{2026-08-10}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W33-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-08-10]{\mdnote{2026-08-10}{
+- #misc
+    - [BREAKING: a source familiar with the matter confirms employees at thinking machi](https://x.com/eliebakouch/status/2077744370942431705)
+    - [this is the real loop engineering](https://x.com/elliotarledge/status/2078581135660249573)
+    - [https://t.co/J326Vz9jWj  Enjoy! https://t.co/EVnBt6dHMb](https://x.com/erfan_mhi/status/2077442595530104887)
+    - [GPT 5.6-Sol Ultra no longer supports Full Access in Codex https://t.co/Dg1VMkXCD](https://x.com/flavioAd/status/2077761445048070615)
+    - [Kimi K3 vs. GPT 5.6 Sol in paper craft animation.  Generated with Seedance 2.0.](https://x.com/higgsfield_ai/status/2077944477159920022)
+    - [Kimi 这么拿货 Blackwell 显然是有理由的，仅仅为了在硅芯片上容纳一个 2.8T 参数模型（并以 FP16 量化运行它），你就需要 5.6TB 的](https://x.com/iamai_omni/status/2077873465403818344)
+    - [why not use subagents?  subagents are inherently complex and hard to observe  /t](https://x.com/iamsahaj_xyz/status/2076949303147536812)
+    - [wx-cli 被 DMCA了，准备下架隐藏了😂。 腾讯的大手发力了啊。 https://t.co/ukUxI5Oeom](https://x.com/jakevin7/status/2076699183000715453)
+    - [Yeh, @Kimi_Moonshot K3 just made a Torus Space Habitat https://twitter.com/jasonkneen/status/2077898322577166404/video/1](https://x.com/jasonkneen/status/2077898322577166404)
+    - [https://t.co/6iCX0j0aBP](https://x.com/jasonzhou1993/status/2075179471951614381)
+    - [&#92;&quot;Video models are world simulators.&#92;&quot;  Ok — can they predict a ball bouncing off](https://x.com/jdiazchao/status/2077826878627594446)
+    - [using herdr to have claude drive pi and pi drive claude such that the model is p](https://x.com/joelhooks/status/2075642140416438558)
+    - [tldraw offline local models - powered by webgpu + https://github.com/mlc-ai/web-llm https:](https://x.com/jsscclr/status/2078059764039225638)
+    - [“Kimi is just distilled from Fable”  Meanwhile in other labs :  > Grok got caugh](https://x.com/jun_song/status/2077942559377428710)
+    - [Imagine Kimi-K3 running on Cerebras.  750tok/s beast will change the world.](https://x.com/jun_song/status/2078172506775855223)
+}}
+
+\subtree[2026-08-11]{\mdnote{2026-08-11}{
+- #misc
+    - [Best Local AI models by VRAM size &#40;7/18&#41; :  Phone &#40;~4gb&#41; : Bonsai-27b Nano &#40;~12g](https://x.com/jun_song/status/2078510344046326231)
+    - [An OpenAI &#40;aka ClosedAI&#41; executive is really out here saying the most absurd thi](https://x.com/jun_song/status/2078692022102454428)
+    - [https://t.co/XGcDdnbMOf](https://x.com/kasong2048/status/2074449455122960448)
+    - [假如你还在问什么是loop Engineering.一张图看懂  https://t.co/nbeL8EWcXB](https://x.com/li9292/status/2076831009279254604)
+    - [LatentMoE so good.](https://x.com/llm_wizard/status/2078162763621306694)
+    - [看 V2EX 这个帖子才知道  原来不是所有人都可直接使用满血版的 Kimi K3 ？🤡 https://twitter.com/manateelazycat/status/2077991166352724283/photo/1](https://x.com/manateelazycat/status/2077991166352724283)
+    - [A Neural Sheet Discovers the Shape of Data  A self-organizing map &#40;SOM&#41; starts a](https://x.com/mathelirium/status/2075617210135945601)
+    - [String Theory makes an ambitious proposal:   Quantum excitations and Spacetime g](https://x.com/mathelirium/status/2076676075694772683)
+    - [In String Theory, it has been shown that one vibration of a closed string behave](https://x.com/mathelirium/status/2076979909117849721)
+    - [Built the same timezone checker app with GPT 5.6  Luna XHigh VS Terra High VS So](https://x.com/melvynx/status/2076667363739754647)
+    - [I opted GPT 5.6 out of my personality steering. It's brief enough out of the box](https://x.com/mitsuhiko/status/2076565852875362761)
+    - [找到一个降低5.6Sol token消费的办法：  在~/.codex/config.toml 中加入  model_context_window = 2720](https://x.com/mylifcc/status/2075948586471149966)
+    - [All jokes and beef aside, @waterloo_intern is unbelievably cracked and you shoul](https://x.com/oneill_c/status/2077843685425991837)
+    - [Strange Universe.  Math, Physics, Reality.  &#92;&quot;6 belts are anchored on the outside](https://x.com/pickover/status/2077732507970134171)
+    - [ASCII Web Section https://t.co/yOatEDSRNN](https://x.com/praveenisomer/status/2074820794136265142)
+}}
+
+\subtree[2026-08-12]{\mdnote{2026-08-12}{
+- #misc
+    - [Video generation is a by-product or sub-product of advancements in LLMs. It cann](https://x.com/prime_cai/status/2078135959225594180)
+    - [people thought chinese / oss models are cheaper and they loved it  but kimi k3 i](https://x.com/q_yeon_gyu_kim/status/2078086263517893041)
+    - [Kimi K3 出音味来 https://twitter.com/qqqqqf_/status/2077985224940798329/photo/1](https://x.com/qqqqqf_/status/2077985224940798329)
+    - [@Gauri_the_great Section 7.2 :&#41; https://magazine.sebastianraschka.com/p/visual-attention-variants](https://x.com/rasbt/status/2078098161621475515)
+    - [Hey Tibo, mind resetting Anthropic limits again? Thanks.](https://x.com/rezoundous/status/2078017643622388111)
+    - [A few more voxel maps built by Grok 4.5 - suburb, downtown, island.  #blender #t](https://x.com/runzhuotao/status/2077254523220107635)
+    - [lots of post-training  it will not even attempt to solve a hard problem https://](https://x.com/scaling01/status/2077785562652590485)
+    - [Wow, I asked kimi k3 to produced interstellar style wormhole in @threejs, it wor](https://x.com/scottstts/status/2077844350168453267)
+    - [Built a black hole observatory with Codex. Cycles through Kerr singularity, fram](https://x.com/techartist_/status/2075029670660378796)
+    - [our team's first week of having both sol and fable the crazy thing is 30&#37; of our](https://x.com/thdxr/status/2075963734745342361)
+    - [is there any writing on chatgpt's new memory system  it used to suck and is now](https://x.com/thdxr/status/2078562641803456785)
+    - [@mylifcc This is not correct. Do not do this if you do not understand exactly wh](https://x.com/thsottiaux/status/2076201049086648705)
+    - [Hello. We have reached 8M active users across Codex and ChatGPT Work.  We are on](https://x.com/thsottiaux/status/2077114635308986427)
+    - [Embarrassment of riches. But looks like we might hit 9M soon. Should we reset th](https://x.com/thsottiaux/status/2077271889626706300)
+    - [Oops... I did it again.   Enjoy reset usage limits for all paid users for Codex](https://x.com/thsottiaux/status/2078320950488297917)
+}}
+
+\subtree[2026-08-13]{\mdnote{2026-08-13}{
+- #proof
+    - #lean
+        - #sci
+            - [I'm working on a three-paper process: paper-style, Lamport-style &#40;step-justifica](https://x.com/octonion/status/2078116918486057346)
+- #os
+    - #tui
+        - #software
+            - [Change the harness not your workflow.   Here we ask Pi to build a custom workflo](https://x.com/pidotdev/status/2076977507451183210)
+        - [usbtree is a TUI for monitoring USB devices in the terminal.  You can view USB h](https://x.com/terminaltrove/status/2077130620677873969)
+    - [Wait, what happened to the wonderful @ChatGPTapp macOS app?  Chat is now a popup](https://x.com/auchenberg/status/2075305953684046303)
+    - [pi-computer-use has hit 1,000 GMO-free stars on GitHub! a major milestone and a](https://x.com/injaneity/status/2077325208202129855)
+    - [OpenAI 把 Codex 和 ChatGPT 合并了🤓原来的 Codex 桌面端更新后会直接变成新版 ChatGPT，原来的 ChatGPT 桌面端则被改名](https://x.com/yupi996/status/2075421507237597282)
+- #misc
+    - [Whoa google tweeting about diffusion model theory :o](https://x.com/tylerfarghly/status/2078094934197043498)
+    - [hyperstition is real in machine learning. i really don’t think mythos is a unive](https://x.com/willdepue/status/2078187851406315842)
+    - [Tibo can you stop resetting? How am I supposed to use the reset thats about to e](https://x.com/xmangonic/status/2077738744489087243)
+    - [So basically, the current frontier models are 1.5T-parameter Transformers with 4](https://x.com/yifanzhang_/status/2078160559804142072)
+    - [@doodlestein it's insane https://x.com/zakelfassi/status/2077826259485401537?s=20](https://x.com/zakelfassi/status/2077926933741043763)
+    - [~/.codex/config.toml for those at home https://t.co/o2NOdok4LL](https://x.com/zats/status/2076611470209519830)
+    - [对于 tmux 用户来说，切换到 herdr 不如直接用 https://github.com/hiroppy/tmux-agent-sidebar](https://x.com/zdyxry/status/2077996038233993562)
+    - [Want to know what makes Kimi K3 so good? I break it down in my blog post on line](https://x.com/ziv_ravid/status/2078173866598232122)
+    - [No.   We are focused on intelligence frontier right now.  Video generation does](https://x.com/zxytim/status/2077847196867993711)
+}}
+
+\subtree[2026-08-14]{\mdnote{2026-08-14}{
+- #proof
+    - #software
+        - #sci
+            - [GPT-5.6 appears to have identified a new classification-free proof of the spectr](https://x.com/octonion/status/2077992280451932418)
+- #rust
+    - #zig
+        - #compiler
+            - [&#92;&quot;How our rewrite from Rust to Zig is going&#92;&quot;  https://rtfeldman.com/rust-to-zig &#40;about the](https://x.com/etorreborre/status/2078012450700468681)
+            - [this part made me lol  i was ready for some big reveal on how jarred was trying](https://x.com/thdxr/status/2075317678248427674)
+        - [The personal attacks on Jarred have not stopped by the way. They have continued](https://x.com/kellabyte/status/2075455336408871176)
+        - [Since the @bunjavascript folks recently wrote about their experience moving from](https://x.com/rtfeldman/status/2077690704386789658)
+    - #elixir
+        - [BullMQ, one of the most widely used Redis job queues, now has a native Rust impl](https://x.com/ayushagarwal027/status/2077030356935410061)
+    - #gpu
+        - [I built my own inference engine in Rust + CUDA to run models that don't fit my G](https://x.com/Giannisanii/status/2076945182449103017)
+    - #tui
+        - [No more typing long rsync commands by hand 😌  🔄 lazyrsync — A friendly TUI for s](https://x.com/orhundev/status/2076760832503955860)
+- #shader
+    - [Procedural compute shader tentacle creature sketch in @threejs &amp;amp; @webgl_webg](https://x.com/aaronlemke/status/2078355966152839641)
+    - [I built an opensource fully procedural bookcase with @threejs  + cannon-es + cus](https://x.com/chirovisuals/status/2076672615335235932)
+- #render
+    - #web
+        - [After spending 4 HOURS debugging a sign flip issue, I finally got clouds to refr](https://x.com/dangreenheck/status/2077749340919955660)
+    - [Hello! It's about time I started posting here.  I'm Alex Harri. I write technica](https://x.com/alexharri_/status/2076800884244201839)
+- #sec
+    - #software
+        - [Worth reading Xi Jinping's speech about AI for yourself, rather than letting som](https://x.com/1a3orn/status/2077987166379237385)
+    - [Cloudflare is basically a website security and speed app.  So why does a CDN nee](https://x.com/Im_IrushiK/status/2077406725586694468)
+}}
+
+\subtree[2026-08-15]{\mdnote{2026-08-15}{
+- #zig
+    - [My Electrobun 2.0 blog post is already 3400+ words and it's just the intro that](https://x.com/YoavCodes/status/2078154631452987583)
+    - [If you missed the Zig/Bun drama, here's a recap. https://t.co/hfo1NrPGFB](https://x.com/tetsuo_cpp/status/2075960665815298382)
+- #shader
+    - #cg
+        - #software
+            - [Drop in any SVG logo and transform it with compute-powered 3D effects like Parti](https://x.com/npm_i_shaders/status/2077441745420210287)
+    - [Kimi K3 on my shader test: &#92;&quot;create a visually interesting shader that can run in](https://x.com/emollick/status/2077783731691995348)
+    - [Came across @xikhar 's lore accurate codex effort slider design video and coded](https://x.com/techartist_/status/2076760255846138141)
+- #web
+    - [I don't often get to see what people build with my assets. So when stuff like th](https://x.com/dangreenheck/status/2077496729969057919)
+    - [Added a banked reset to 500k users of ChatGPT Work and Codex.  What’s been happe](https://x.com/thsottiaux/status/2076418567143408112)
+    - [Thank you to the 7M active users who are now using Codex and ChatGPT Work.  We h](https://x.com/thsottiaux/status/2076735790567338203)
+    - [Made a potter's clay interaction.   https://t.co/oHzlNkZRZt  The surface moves p](https://x.com/tol__is/status/2076949469162004598)
+- #software
+    - [GLM-5.2 Nvidia NVFP4   No pruning, no quantising, exact same model card.  110 to](https://x.com/0xSero/status/2075326725320278208)
+    - [Physical realities beyond the Standard Model.  Exploring how fundamental particl](https://x.com/Dragonmaurizio/status/2078490402295107707)
+    - [I'm starting to use /side more while also having longer threads with GPT 5.6. Th](https://x.com/kcosr/status/2077248065988088114)
+    - [Using OpenCode, Pi, Codex, etc. meant fragmented sessions  Came across ADEs and](https://x.com/pseudokid/status/2077010296762478818)
+    - [New TIL: Using uvx in GitHub Actions in a cache-friendly way  I finally found a](https://x.com/simonw/status/2076836099910193484)
+}}
+
+\subtree[2026-08-16]{\mdnote{2026-08-16}{
+- #agent
+    - [Andrej Karpathy just broke the entire premise of modern AI:  &#92;&quot;Agents aren't magi](https://x.com/0xMortyx/status/2078468804276019504)
+    - [don't get me wrong, i love building startups  but every time i'm about to launch](https://x.com/ConnorKowallo/status/2054548961734672389)
+    - [🚨https://chat.z.ai/ may be skipping GLM-5.3 and going straight to GLM-5.5  • Exp](https://x.com/LuminaXspace/status/2078891258836050380)
+    - [I solved 6 open Erdős problems in 5 days, using @OpenAI GPT-5.6 Sol.  I have a m](https://x.com/Qiaoqiao2001/status/2080003441821163958)
+    - [Many LLM-based optimization algorithms have been proposed recently. We find that](https://x.com/ShangyinT/status/2080334982988562452)
+    - [https://x.com/i/article/2078854036363579392](https://x.com/TaoMachina/status/2078859242921226249)
+    - [Open weights models really accelerated!  > Qwen-3.8 &#40;2.4T&#41;, “second only to Fabl](https://x.com/Yuchenj_UW/status/2078876169106284889)
+    - [🧩 Kimi K3’s Architecture Is Here—and KDA + AttenRes Arrive Together Zhihu contri](https://x.com/ZhihuFrontier/status/2080499106502574110)
+    - [Lol i hope everyone had as good a time as me, yea this is just the triple cover](https://x.com/__alpoge__/status/2079300117417329043)
+    - [@slimer48484 I've got a procedure for generating infinite counter-examples, I th](https://x.com/alexisgallagher/status/2079316351060263054)
+    - [5. However, one thing that right now is happening is that many fields like robot](https://x.com/antirez/status/2078759966383522181)
+    - [Imagine for instance doing new materials research giving the LLM, during trainin](https://x.com/antirez/status/2078759968098926916)
+    - [Making 3d motion graphics with coding agents is absurdly fun. Breaking down geos](https://x.com/bilawalsidhu/status/2080146952524550329)
+    - [This video by Remotion is literally motion design porn.  no skills , mcp , tools](https://x.com/chddaniel/status/2078869144171380763)
+    - [🚨 Deepseek V4 pro GA is being tested to few users   &amp;gt; this is the output on t](https://x.com/chetaslua/status/2078491975771443396)
+}}
+    }
+  }
+}

--- a/trees/2026-W34.tree
+++ b/trees/2026-W34.tree
@@ -1,0 +1,209 @@
+\import{macros}
+
+\title{2026-W34}
+\date{2026-08-17}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W34-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-08-17]{\mdnote{2026-08-17}{
+- #agent
+    - #benchmark
+        - #docker
+            - [tau 𝝉 has come a long way in the past 3 weeks. it has become a really comfortabl](https://x.com/_alejandroao/status/2078879920256594080)
+        - [Kimi K3 has a serious problem.  One provider is serving it. 16 tokens per second](https://x.com/bridgemindai/status/2078810910701867135)
+    - #cg
+        - [How much of the new 3D Jacobian Conjecture counterexample was guessed? Very litt](https://x.com/nasqret/status/2079525552399044796)
+    - [Claude is reassuringly terse about trending X papers. &#92;&quot;Transformers are unreliab](https://x.com/docs2info/status/2079439054060609989)
+    - [Open Source AI updates :   &amp;gt; GLM-5.2 ✅ Almost Opus-level &amp;gt; Kimi-K3 ✅ Almos](https://x.com/jun_song/status/2078757735760539862)
+    - [Everyone’s so focused on the US-China AI race.  But the fiercer AI race might be](https://x.com/kyleichan/status/2078580715642388481)
+    - [Blenderで3Dモデリング始めて一週間。 ただ、この3Dモデルを作るのに、Blenderは一度も開いていない。  GPT-5.6-solが企画からモデリング](https://x.com/posi_posi8/status/2078853975655530849)
+    - [SOAP, Muon, and Beyond: Pushing LLM Pretraining Scales  Paper: https://t.co/P4Og](https://x.com/sheriyuo/status/2080496760095748440)
+    - [DeepSeek staff brushes off accusations of Fable routing https://x.com/teortaxesT](https://x.com/teortaxesTex/status/2078916373623796166)
+    - [there's a bunch of idiots going around saying &#92;&quot;opencode doesn't cache tokens&#92;&quot;  r](https://x.com/thdxr/status/2079953961579102612)
+    - [everyone should internalize this  all those tricks to make the tool work better](https://x.com/thdxr/status/2080760584572706906)
+    - [10M!   New day, new usage reset for paid users of Codex and ChatGPT Work. Lands](https://x.com/thsottiaux/status/2079609157934886975)
+    - [This was due to a heroic effort by many people at Anthropic working sometimes li](https://x.com/trq212/status/2078514180051906864)
+    - [Three days ago, we made Kimi K3 free on Clusy.  Today, we’re doing it again.  🚨](https://x.com/urjr1/status/2079010317485662624)
+    - [It's finally happened: after several unsuccessful attempts, I found a prompt tha](https://x.com/wtgowers/status/1906969462009381157)
+}}
+
+\subtree[2026-08-18]{\mdnote{2026-08-18}{
+- #agent
+    - #formal
+        - #proof
+            - [Simulating high-dimensional phase spaces in classical mechanics comes with an in](https://x.com/getjonwithit/status/2079559361412698459)
+            - [A formally verified electrodynamics simulation &#40;electromagnetic pulse in a metal](https://x.com/lanyon_ai/status/2079216834759250267)
+        - [GPT 5.6's solution + CoT.  &#92;&quot;I lean math says valid, but impossible consensus ind](https://x.com/slimer48484/status/2079302950107713798)
+    - #gpu
+        - [One guy built Kimi K3 alone and made over $10,000,000 in a single month. Then he](https://x.com/0xzynex/status/2078856151706308965)
+        - [Another field is simulations. RL via real world simulations of processes that ca](https://x.com/antirez/status/2078759969868874158)
+    - #cg
+        - #game
+            - [Made a game character selection screen with GPT-5.6 Sol  Started with a few char](https://x.com/DilumSanjaya/status/2078522831571444214)
+            - [Reused a character set from another app I made. The 3D models were generated wit](https://x.com/DilumSanjaya/status/2078522833823817961)
+            - [🧵  DeepSeek appear to have engaged, or be engaging in, a large-scale operation t](https://x.com/synthwavedd/status/2078514339552628880)
+        - #software
+            - [img2threejs v1.3 is now available. 🎋  One photo → procedural Three.js code. No m](https://x.com/NickDevFE/status/2080189136917672064)
+        - [DeepSeek V4 GA Leaks: Coming Tomorrow  - High chance of launching tomorrow &#40;othe](https://x.com/pankajkumar_dev/status/2078536231026372846)
+        - [Friends, it's time to meet Puck.  It's a your new assistant in Amp.  Fast &amp;amp;](https://x.com/thorstenball/status/2079205300263907507)
+    - #game
+        - [New paper: Understanding Reasoning from Pretraining to Post-Training!  We study](https://x.com/Pavel_Izmailov/status/2079268684317508020)
+        - [Qwen3.8 Max xhigh is shocking  It generated a very robust Angry Birds Clone  Als](https://x.com/luckeyfaraday/status/2079016779062313427)
+    - #context
+        - [Chinese labs are now competing with each other to build the strongest open-weigh](https://x.com/fanofaliens/status/2078872950317744500)
+        - [if you've run into this, please restart Claude Code, fix should be propogating](https://x.com/trq212/status/2079103743535280508)
+}}
+
+\subtree[2026-08-19]{\mdnote{2026-08-19}{
+- #agent
+    - #proof
+        - #gpu
+            - [Right now the inability to buy enough NVIDIA cards slowed-down progresses even a](https://x.com/antirez/status/2078759973413085684)
+            - [7. If you want a qualitative proof of all that: have you ever thought how strage](https://x.com/antirez/status/2078759975170535450)
+            - [When there is *actual* competition and breakthroughs, you see a company taking t](https://x.com/antirez/status/2078759976969912782)
+        - #cg
+            - [Erase the special coefficients from the new counterexample to the Jacobian Conje](https://x.com/nasqret/status/2079626786187493388)
+        - #visualization
+            - [@davikrehalt @littmath @__alpoge__ Some visualisations that helped me understand](https://x.com/MicaelMarch/status/2079338280273719543)
+        - #sci
+            - [More context on what happened with Fable and the Jacobian conjecture tonight.](https://x.com/AndrewCurran_/status/2079081226217066891)
+            - [Awesome! GPT 5.6 just solved a nearly 70 year old conjecture &#40;Erdős #119&#41;   As @](https://x.com/jdlichtman/status/2078753074685083982)
+        - [That prompt works well for producing counter-examples.  Also Fables CoT leaked w](https://x.com/slimer48484/status/2079300071040917636)
+    - #lean
+        - #render
+            - [Visualizing the ultimate showdown between the two most talked-about LLMs today:](https://x.com/LeeLinAI123/status/2078942544642355461)
+        - [The International Math Olympiad &#40;IMO&#41; 2026, the hardest math contest for high sc](https://x.com/deedydas/status/2079409461874332066)
+    - #gpu
+        - #os
+            - [A swarm of GPT 5.6 Sol agents spent over 40 hours optimizing a Kimi K3-like mode](https://x.com/xenovacom/status/2080692536926933311)
+        - [6. TLDR once you can't just do scaling to be a frontier lab, with incredible spe](https://x.com/antirez/status/2078759971592818942)
+        - [我来给大家翻译下Kimi k3暂停新订阅的技术原因：  1，GPU（H100、H200、B300）算力不够，正在增加GPU推理集群。  2，阿里和腾讯都是Moo](https://x.com/btcmos/status/2078887356514583031)
+    - #os
+        - [ChatGPT Voice is now in the desktop app.  Control your computer and direct multi](https://x.com/OpenAI/status/2080378182469857576)
+        - [&#92;&quot;Open-weight models are inherently decelerationist&#92;&quot;  You young people do not kno](https://x.com/francoisfleuret/status/2078845071680471519)
+}}
+
+\subtree[2026-08-20]{\mdnote{2026-08-20}{
+- #agent
+    - #proof
+        - #web
+            - [yes GPT can do it too ;-&#41;. I highly recommend looking at Codex's write-up, its r](https://x.com/SebastienBubeck/status/2079219534679183388)
+            - [Congrats to Levent for discovering this!  OOC I had an internal version of Codex](https://x.com/aaron_lou/status/2079218392452530249)
+            - [Prompt adopted from @__eknight__ 's CDC proof prompt is also pasted below: https](https://x.com/aaron_lou/status/2079218394276966804)
+    - #rust
+        - #zig
+            - [more drama in the Bun Zig -&amp;gt; Rust rewrite saga https://t.co/60qP7j52vW](https://x.com/DanielLockyer/status/2080629636644450503)
+        - #tui
+            - [Wow, I found a smart way to bookmark code! 🤯  🔖 codemark — Structural bookmarks](https://x.com/orhundev/status/2078529014109716865)
+    - #shader
+        - [People of @pidotdev, piggy backing on the @isoden_'s amazing shaders, I built pr](https://x.com/IurySza/status/2078874691255562638)
+    - #render
+        - #cg
+            - [Blender just became a prompt box.  With Kimi K3 connected through Blender MCP, y](https://x.com/irinatoxi/status/2080572572530254311)
+            - [Claude Fable 5 vs Kimi K3 — same 3D build, 3.3x cheaper.  someone prototyped a 3](https://x.com/kirillk_web3/status/2078996559216394458)
+    - #sec
+        - [I have made a repository with landing page where the three approaches by @__alpo](https://x.com/nasqret/status/2079384176269177188)
+    - #sci
+        - [Why, according to Terry Tao, the recent disproof of the Jacobian conjecture in N](https://x.com/aran_nayebi/status/2079968389267705889)
+        - [A must-read for anyone looking to deeply understand JEPAs  SIGReg from First Pri](https://x.com/askalphaxiv/status/2080497896265564186)
+        - [Terence Tao posted his ChatGPT session trying to understand the Jacobian conject](https://x.com/connerdelights/status/2079687509077073977)
+        - [@littmath @__alpoge__ GPT: Take π: P¹ × Sym²&#40;P¹&#41; → Sym³&#40;P¹&#41;, &#40;p, &#123;q,r&#125;&#41; ↦ &#123;p,q,r](https://x.com/davikrehalt/status/2079175065695035442)
+        - [Prompted by the disproof of the Jacobian Conjecture, which also disproved the Ga](https://x.com/octonion/status/2079385308127166575)
+        - [Incredible news about the Jacobian conjecture.  One thing I'd love to read is a](https://x.com/thomasfbloom/status/2079304775175143491)
+}}
+
+\subtree[2026-08-21]{\mdnote{2026-08-21}{
+- #agent
+    - #visualization
+        - #game
+            - [Microsoft open sources the Palantir $PLTR killer. https://github.com/microsoft/O](https://x.com/IntuitMachine/status/2078561240922697980)
+    - #web
+        - #git
+            - [The fastest coding agent in the world is still slow if ten tasks are standing be](https://x.com/techNmak/status/2078865953228743076)
+        - #software
+            - [used a trick @jlongster came up with  agents can control browsers but you can al](https://x.com/thdxr/status/2078727284865827140)
+    - #sqlite
+        - #software
+            - [推荐这期 Pi 插件合集。Pi 作为最小 agent harness，真正的扩展能力来自社区插件——从一键装 17 个扩展的 pi-agent-extensio](https://x.com/yibie/status/2080443196476407910)
+    - #software
+        - [introducing akarso  a CLI to post on every social platform. for agents &amp;amp; hum](https://x.com/__morse/status/2078956142387196203)
+        - [pi coding agent 缺队列、容器隔离和费用控制，pi-dispatch 把这几层补上再跑成服务。  将 pi 以容器化服务运行，提供持久化作业队列、](https://x.com/geekbb/status/2080516574683775418)
+        - [i’ve been trying to build a codex-flavored pi by forking it. thanks to the vienn](https://x.com/lumendriada/status/2080296852616778171)
+        - [Bruh... someone recreated the UI of Claude Code, Codex &amp; Grok as reusable ShadCN](https://x.com/rammcodes/status/2078502239967350924)
+- #compiler
+    - [I tried out std::simd,  I'm not entirely sure if I'm using it the right way, but](https://x.com/yutongwu111140/status/2078530278352716289)
+- #benchmark
+    - #game
+        - #docker
+            - [Unlimited-OCR is a 3B parameter model that parses entire 100-page PDFs in one sh](https://x.com/RoundtableSpace/status/2078883816144515430)
+    - [1/ Parameter scale is a brute-force crutch. What if a 35B model could beat a 1,0](https://x.com/che_shr_cat/status/2078832507634487757)
+- #cg
+    - #sci
+        - [@__alpoge__ https://www.mathnet.ru/mzm1169  I think Fable simplied find this pap](https://x.com/Anemoi413515/status/2079256621847322911)
+        - [@keenanisalive Thank you, Good opprotunity to share 3b1b amazing clip about thes](https://x.com/NahshonTomer/status/2078472785798574518)
+    - [What if your floor plan changes updated a 3D model of the home in real time?  Wi](https://x.com/DraftedAI/status/2078527636528308295)
+    - [The same problem in 3D, visualized with Grok 4.5 build: why light always comes b](https://x.com/PI010101/status/2078523573132796072)
+}}
+
+\subtree[2026-08-22]{\mdnote{2026-08-22}{
+- #formal
+    - #proof
+        - #lean
+            - [A very nice response on AI-generated formal proofs in Lean: Should we trust them](https://x.com/PI010101/status/2080712497691316511)
+            - [Today @HarmonicMath published solutions to eight previously studied open problem](https://x.com/Timeroot/status/2079543388999651462)
+        - [&#40;Sorry this is probably not too helpful, obviously A^3 is an A^1 bundle over A^2](https://x.com/littmath/status/2079353531430289734)
+    - #lean
+        - #software
+            - [This is a very sad day for formalization](https://x.com/Someody42/status/2079291759629070449)
+            - [Excited to share the launch of Tau Ceti, a new library of AI-formalized mathemat](https://x.com/leanprover/status/2079259658880237918)
+    - [The germ of the idea might have come from a suggestion in the following paper by](https://x.com/Allawonder/status/2079125928945332562)
+    - [&#40;Annotated&#41; Structure and Interpretation of Classicical Mechanics - https://srus](https://x.com/srush_nlp/status/2079277881465708898)
+- #gpu
+    - #benchmark
+        - #cg
+            - [china is not slowing down and this one is insane..  Chinese researchers just ope](https://x.com/heyrobinai/status/2078773865925509613)
+    - [🔥 Researchers extended llama.cpp and tripled decode on an RTX 4090 when running](https://x.com/TeksEdge/status/2078695993063920025)
+    - [CJ is good people. transcribe.cpp, ggml based STT engine supporting tons of mode](https://x.com/badlogicgames/status/2078732087973101609)
+    - [This is an absolute gemm in GPU collectives. Literally came out 3 days ago. http](https://x.com/elliotarledge/status/2079394348991697247)
+    - [let's go big dawg](https://x.com/keennay/status/2078568490034692400)
+- #game
+    - [The guy who actually prompted Fable in this case has a PhD in Mathematics from t](https://x.com/ChrisSeltzer/status/2079398678826045878)
+    - [Model So Goated That they had to pause new subscription 🥲  Btw K3 now has access](https://x.com/chetaslua/status/2078895170951782633)
+- #git
+    - [A frustrating open-source experience with Zed @zeddotdev :  1. I implemented a U](https://x.com/mauriciord/status/2080342310022234286)
+}}
+
+\subtree[2026-08-23]{\mdnote{2026-08-23}{
+- #lean
+    - #render
+        - #sci
+            - [GPT-5.6-Sol-Ultra is so good at maths that it created Minecraft clone in Lean &#40;y](https://x.com/petergostev/status/2076342016099696851)
+    - [@__alpoge__ Lean4 agrees https://x.com/J_Pyxal/status/2079528612881895625](https://x.com/J_Pyxal/status/2079528612881895625)
+- #gpu
+    - #game
+        - [NVIDIA did it again..  they trained a GPT that generates human movement instead](https://x.com/HowToPrompt__/status/2080588702913274184)
+    - #web
+        - #wasm
+            - [Someone open-sourced a 66M parameter model that beats ElevenLabs, OpenAI, and Ge](https://x.com/thesupermanmx/status/2078475758318858693)
+- #misc
+    - [https://x.com/i/article/2078460932032770048](https://x.com/0xDominiqq/status/2078468926791410079)
+    - [Kimi 在用户群紧急回应了套餐调整争议。老用户除了可以继续使用和自动续费，今后即使曾手动关闭续费，也能重新订阅旧套餐。  旧套餐还将支持内部升级。例如，199](https://x.com/0xLogicrw/status/2079035402061775011)
+    - [https://x.com/i/article/2078800470173437952](https://x.com/0xcherry/status/2078801473555841257)
+    - [I always wanted to port OPEdefs.m https://arxiv.org/abs/hep-th/9506159 into Pyth](https://x.com/196884/status/2079595351351177451)
+    - [If you’re using omp, stop and take a second to realize it’s pure slop and a terr](https://x.com/BlockedPaths/status/2078578002070217086)
+    - [There's an infinite ladder of this geometric construction too, per GPT 5.6 Sol a](https://x.com/CalAldred/status/2079398430657409291)
+    - [Another math breakthrough from GPT-5.6 Sol! https://x.com/DeryaTR_/status/207890](https://x.com/DeryaTR_/status/2078909344301596975)
+    - [@pranav_so The file was this paper from arxiv https://t.co/LOAA7PAifB](https://x.com/DmitryRybin1/status/2080343464235917814)
+    - [Learn FSM, Actor-based DAGs, and then Control-state Graphs.   So you stop fallin](https://x.com/FourEyedWiz/status/2078773864813703225)
+    - [In 9 pages,  The Many Faces of Information Geometry   https://www.researchgate.n](https://x.com/FrnkNlsn/status/2079192985208754296)
+    - [@LotusDecoder 你只要之前买过Kimi，现在就能买。新号是完全买不了了。 很良心，比智谱强。](https://x.com/Gorden_Sun/status/2079025202277794121)
+}}
+    }
+  }
+}

--- a/trees/2026-W35.tree
+++ b/trees/2026-W35.tree
@@ -1,0 +1,161 @@
+\import{macros}
+
+\title{2026-W35}
+\date{2026-08-24}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W35-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-08-24]{\mdnote{2026-08-24}{
+- #misc
+    - [Linearizing Softmax Attention into Gated DeltaNet https://t.co/pusW2eZdKb](https://x.com/Jianlin_S/status/2080162408874844514)
+    - [Iridescent Soap Bubble Lissajous Knot https://openprocessing.org/@Kazoops/298227](https://x.com/KAZOOOps/status/2079348264105844866)
+    - [Kimi Business Membership is now available for enterprise orders, offering teams](https://x.com/Kimi_Moonshot/status/2078482617176100896)
+    - [Kimi K3 has received far more love than we expected, and our GPUs are feeling it](https://x.com/Kimi_Moonshot/status/2078855608565207130)
+    - [ヤコビアン予想。とにかく色々な多項式をいじって反例を見つけたのかと思っていたが、幾何学的な議論に基づいて導き出されたのか⬇️ 分岐因子 R をもつ次数２以上の有](https://x.com/Kiwamu_Watanabe/status/2079370952803229715)
+    - [https://x.com/i/article/2078526602334576640](https://x.com/KyleLiang5/status/2078543088419840292)
+    - [卧槽？GLM-5.2被接上眼睛了？？  Baseten刚刚开源了GLM-5.2-Vision-NVFP4模型。  他们冻结了GLM-5.2的全部语言权重，直接接](https://x.com/MaxForAI/status/2080353310020952118)
+    - [More context on the Jacobian Conjecture. Who wants to try n=2? https://t.co/Gs2o](https://x.com/PI010101/status/2080039662924726316)
+    - [We're announcing a major update to Weather Lab, our interactive website for shar](https://x.com/PeterWBattaglia/status/2078132675332755933)
+    - [https://t.co/abn0pdlaTP](https://x.com/Salad95238547/status/2079508549382644194)
+    - [@TheWhiteTower16 Well this is a direct threat to Mathlib development: time spent](https://x.com/Someody42/status/2079470696678174826)
+    - [@TheWhiteTower16 I’ve spent hundreds of hours formalizing maths in my life. And](https://x.com/Someody42/status/2079471175122489536)
+    - [每当有新模型刷屏，我就用自己的工具比较一下价格，然后继续使用DeepSeek V4 Flash，毕竟约等于不要钱。 https://x.com/TooooooB](https://x.com/TooooooBug/status/2078782789923868840)
+    - [前两天看到一个网站，除了网站本身的设计非常简洁出色外，还有一个非常好看的手写风格标注的部分。  没想到现在开发成一个单独的开发库了。 https://x.com](https://x.com/ZaynHao/status/2079499530173862169)
+    - [没想到帖子这么受欢迎，  这是网址哈：  https://mdtask.dev/  https://neat-annotations.syabro.com/](https://x.com/ZaynHao/status/2079553104908038173)
+}}
+
+\subtree[2026-08-25]{\mdnote{2026-08-25}{
+- #misc
+    - [&#40;that is fable’s thought process too after ideating about a bunch of random stuf](https://x.com/__alpoge__/status/2079301078068179224)
+    - [is k3 actually a transformer?  why not consult The Chart! https://x.com/_lyraaaa](https://x.com/_lyraaaa_/status/2078299899343319478)
+    - [Free &amp;amp; Open Source @shadcn Components](https://x.com/aisdkagents/status/2056428452987781155)
+    - [A major issue with Gaussian splatting is that it can create visual artifacts fro](https://x.com/alexfredo87/status/2054920674435534938)
+    - [Why open models are not deaccelerationist, but exactly the contrary, in a few po](https://x.com/antirez/status/2078759955834786290)
+    - [1. Many skilled workers will remain able to deliver work effectively only with m](https://x.com/antirez/status/2078759957567058043)
+    - [2. What happened so far with LLMs is that on basically consolidated ideas and re](https://x.com/antirez/status/2078759959290884253)
+    - [To scale, a lot of money was needed, and it was useful that economic systems are](https://x.com/antirez/status/2078759961065095203)
+    - [3. The above was a needed &#92;&quot;startup&#92;&quot; phase. AI companies, in the future, will nee](https://x.com/antirez/status/2078759962885374452)
+    - [4. It is not obvious that just scaling will not be enough: maybe it will be. In](https://x.com/antirez/status/2078759964638605522)
+    - [@nihilunbounded I shared this on the main thread, seems like there is some prior](https://x.com/b_shrir/status/2079094004885668003)
+    - [Kimi K3 is running 100&#37; FASTER than it was this morning.  Why? Moonshot hit capa](https://x.com/bridgemindai/status/2078958257138528373)
+    - [threejs + webgl https://x.com/codetaur/status/2078709954454974828](https://x.com/codetaur/status/2078709954454974828)
+    - [https://x.com/i/article/2078674233731985408](https://x.com/daleverett/status/2078969402046009374)
+    - [@nihilunbounded Good luck even understanding the formulation of a problem whose](https://x.com/doomslide/status/2079302362221478239)
+}}
+
+\subtree[2026-08-26]{\mdnote{2026-08-26}{
+- #misc
+    - [Google's&#40; $GOOG &#41; earnings report showed negative cash flow for the first time,](https://x.com/fantasy_keith/status/2080304495121383705)
+    - [蹬了一个月20刀的 Ollama Pro 和5刀（次月10刀） OpenCode Go 这两个穷鬼套餐，说说我的体验。  如果你的主要需求是 GLM 5.2 这](https://x.com/iamcheyan/status/2078732985537601895)
+    - [Wormhole, now driven by a vector field.  Online: https://jeonghopark.de/wormhole](https://x.com/jeonghopark/status/2078581906862493971)
+    - [&#92;&quot;mythos is a looped transformer&#92;&quot; is the new &#92;&quot;o1 uses test time MCTS&#92;](https://x.com/kalomaze/status/2078768830411862026)
+    - [Parametric equations generate these meshed surfaces that close upon themselves i](https://x.com/mathemetica/status/2079042933316362688)
+    - [Mohr's Circle geometrically determines stresses on any inclined plane in plane s](https://x.com/mathemetica/status/2079284707754406030)
+    - [lol saw this on WeChat just now 🤣 https://t.co/1iNeuQ0QA0](https://x.com/mattyryze/status/2080576311412871519)
+    - [ヤコビアン予想の否定的解決と、結び目理論及び３・４次元多様体との関連について。 https://x.com/musubimeriron/status/20794](https://x.com/musubimeriron/status/2079486166144086489)
+    - [結び目外部における本質的曲面の幾何学的有限性理論の解説です。 https://t.co/eSUd1wkq50](https://x.com/musubimeriron/status/2080538985236201953)
+    - [FREE Math Book. 729 pages.  &#92;&quot;Topology Without Tears&#92;&quot; by Morris.  “Topology's inf](https://x.com/pickover/status/2079586506998472980)
+    - [it is available again for me  just bought one more https://x.com/q_yeon_gyu_kim/](https://x.com/q_yeon_gyu_kim/status/2078956910129389616)
+    - [toldya  not just a simple distillation](https://x.com/q_yeon_gyu_kim/status/2079416313282490518)
+    - [https://x.com/i/article/2079034819250630656](https://x.com/qingke_ai/status/2079035914740019638)
+    - [If you are trying to compare yourself to Kimi, open source the model just like K](https://x.com/rsalakhu/status/2078465203486826749)
+    - [https://typebulb.com/u/lab/you-re-relatively-right/full](https://x.com/scaling01/status/2079332505988022453)
+}}
+
+\subtree[2026-08-27]{\mdnote{2026-08-27}{
+- #proof
+    - [@littmath @eye_of_newton @wildlyramified @Jess_Riedel @littmath This is beautifu](https://x.com/Jacob_Tsimerman/status/2079344414904770884)
+    - [@Jacob_Tsimerman @eye_of_newton @wildlyramified @Jess_Riedel I don’t see a total](https://x.com/littmath/status/2079347618417971212)
+    - [Quick note - we got lucky that our xz&#40;1,1&#41; counterexample has an explicit lift t](https://x.com/octonion/status/2079542239571681332)
+- #misc
+    - [昨天有一个大新闻，说A社的数学家用Fable给著名的雅可比猜想找了一个反例，证伪了这个猜想（或者严格地说，是雅可比猜想三维以上的情况）。  今天剧情就反转了。原](https://x.com/snowboat84/status/2079413517116137680)
+    - [昨天这条帖子有了许多评论，我就不一一回复了，做统一回复，一共以下八条：  一、Vitushkin的例子写在哪里？写在他论文的Section 6的第一个例子，见下](https://x.com/snowboat84/status/2079638682320220471)
+    - [I have literally 100s of these. Can't wait to share. https://x.com/soulegit/stat](https://x.com/soulegit/status/2078449584301363692)
+    - [Kimi 这个新套餐我没有看懂……但我大受震撼。 https://x.com/syhily/status/2078860847271801167](https://x.com/syhily/status/2078860847271801167)
+    - [Same planets, two models: one with clean simple orbits, the other drowning in ep](https://x.com/themathpulse/status/2078523685775044938)
+    - [https://t.co/dFlTPW8avu](https://x.com/wangyinrec/status/2079105222178488738)
+    - [真他妈的人才，网友每天让CodeX背诵一遍“八荣八耻” https://x.com/weiyux2021/status/2078455578125279266](https://x.com/weiyux2021/status/2078455578125279266)
+    - [Codex重置追踪站火了：OpenAI涨到900万用户，限额重置已经成了日常操作  有人专门做了个网站，追踪OpenAI Codex每次&#92;&quot;使用限额重置&#92;&quot;的时间点](https://x.com/wlzh/status/2078762807768797449)
+    - [昨日、2026年のフィールズ賞が発表されました！  受賞者のHong Wangさんの代表的成果の一つが、Joshua Zahlさんと解決した3次元掛谷予想です。](https://x.com/yohaku121244/status/2080495216797302888)
+    - [我太喜欢pi了 我在pi下gpt 5.6 sol codex天天内存泄露，用pi我电脑风扇至少不怎么转 https://t.co/VIsh4ZPinC](https://x.com/ytiihyslqlabpow/status/2080399333267038391)
+    - [Very insightful work! RL barely change the weights and mostly rotate the weight](https://x.com/zdhnarsil/status/2080064299238846811)
+}}
+
+\subtree[2026-08-28]{\mdnote{2026-08-28}{
+- #proof
+    - #lean
+        - #sci
+            - [i hope nobody formalized this yet - here it is in lean https://x.com/deancureton](https://x.com/deancureton/status/2079060862011138424)
+    - #web
+        - #sci
+            - [More puzzles and more explanations. So now we know two models can apparently do](https://x.com/nasqret/status/2079250464990744755)
+    - #software
+        - [Watch mathematician Lisa Piccirillo derive the equivariant intersection form λ ·](https://x.com/matheorems/status/2079882032646434864)
+    - #sci
+        - [To understand the construction of the Jacobian conjecture counterexample. Unwrap](https://x.com/Almost_Sure/status/2079336373891260801)
+        - [Dinitz-Garg-Goemans conjecture is false. This graph theory problem was open for](https://x.com/DmitryRybin1/status/2079904005652893709)
+        - [now that we're learning more about the geometry of the jacobian conjecture count](https://x.com/QiaochuYuan/status/2079675420954538153)
+        - [This note makes the Dixmier &amp;amp; Poisson consequences explicit and fully checka](https://x.com/SirrahChan/status/2079386505882083580)
+        - [One thing you should pay attention to is that the Swampland guys are basing a wh](https://x.com/WKCosmo/status/2079330754106986889)
+        - [Brandt 5.1 Conjecture is TRUE. It is one thing to find a counter-example, still](https://x.com/YahliHazan/status/2080478342416105912)
+        - [Just imagine being 20yo and have the balls to just even try solving a conjecture](https://x.com/tak3sh8/status/2080554199683662016)
+- #rust
+    - #compiler
+        - [I agree, and also default C compilers should have direct support for it.](https://x.com/antirez/status/2079158625168220448)
+    - [For over two years, the largest open code dataset was The Stack v2… until today.](https://x.com/anton_lozhkov/status/2080254608639701222)
+    - [more than ~5T deduped code training tokens with a permissive license, very impor](https://x.com/eliebakouch/status/2080322879015584240)
+- #render
+    - #software
+        - #sci
+            - [@connerdelights jacobian conjecture for baby https://t.co/noLvaXnwkR](https://x.com/afterthesoul/status/2079816243419185399)
+}}
+
+\subtree[2026-08-29]{\mdnote{2026-08-29}{
+- #rust
+    - #zig
+        - #software
+            - [Bun: Zig suffers from memory safety issues. Zig: no it doesn't, Bun people are s](https://x.com/TomHacohen/status/2079250600630567180)
+        - [We upgraded Lightpanda to Zig 0.16.  The new https://t.co/B48EjDRW0Q dropped in](https://x.com/lightpanda_io/status/2080436626304733355)
+        - [The Bun port in Rust showed the real person behind Zig. For context see https://](https://x.com/nank1ro/status/2079323026600910876)
+    - #tui
+        - [Late-night icon picker for terminal people 😍  🌃 latuicon — A TUI icon picker for](https://x.com/orhundev/status/2078930953486143678)
+    - #software
+        - [I really don't like that FIl-C is reduced to &#92;&quot;ah it's just garbage collector&#92;&quot;. I](https://x.com/valigo/status/2079239061986767250)
+- #sci
+    - [To make the construction of the Jacobian conjecture counterexample a bit more ex](https://x.com/Almost_Sure/status/2079519043925487807)
+    - [for reference, this is unwrapping the AG language and filling in the gap from th](https://x.com/Almost_Sure/status/2079525637497192933)
+    - [https://x.com/Almost_Sure/status/2079540857733009547?s=20](https://x.com/Almost_Sure/status/2079543229540655503)
+    - [and, like magic https://x.com/Almost_Sure/status/2079547034411893051](https://x.com/Almost_Sure/status/2079547034411893051)
+    - [Fun corollary: this same graph also kills the Morell–Skutella convex-combination](https://x.com/Archos_Casual/status/2080132491025813706)
+    - [2d jacobian conjecture is still open and it was the origin of the problem and wh](https://x.com/CTankie1917/status/2080843400543383564)
+    - [Came up with a way to generate an infinite family of counterexamples, via Fable](https://x.com/CalAldred/status/2079169959972769869)
+    - [It only took two months  &#40;this is equivalent to the Jacobian conjecture&#41;](https://x.com/DavidTurturean/status/2079891584988893506)
+    - [As I understand it, due to the implications between Dixmier and Jacobian, only D](https://x.com/DavidTurturean/status/2079921065841639639)
+}}
+
+\subtree[2026-08-30]{\mdnote{2026-08-30}{
+- #sci
+    - [I just found a fairly new primer published on arXiv  titled ''An Introduction to](https://x.com/DiracGhost/status/2080390731873534411)
+    - [hello there the jacobian conjecture is not merely false, it is factory false. al](https://x.com/GuyZys/status/2079335737829580957)
+    - [So here's an explanation of how you can get this without AI. Let's define the po](https://x.com/OSalberger/status/2079326500093063444)
+    - [@__alpoge__ Basically it is a fairly tractable conjecture to find counterexample](https://x.com/OSalberger/status/2079330175846842642)
+    - [@__alpoge__ The solution by @__alpoge__ is part of a family given by setting aff](https://x.com/OSalberger/status/2079336991548981654)
+    - [@__alpoge__ @grok Tabulate all the solutions of low degree](https://x.com/OSalberger/status/2079345841295286719)
+    - [@__alpoge__ The nice thing about the twist from x is that it makes the non-injec](https://x.com/OSalberger/status/2079356248055521491)
+    - [@__alpoge__ Basically the key ingredient is that it has a discrete symmetry, but](https://x.com/OSalberger/status/2079370348991045921)
+    - [Also, F is an automorphism iff h3 is constant and &#40;h1,h2&#41; is an automorphism, th](https://x.com/OSalberger/status/2079392253814956377)
+    - [I found another counterexample to Jacobian Conjecture. This counterexample has g](https://x.com/ShivaKintali/status/2080103587926143359)
+    - [hello there the jacobian conjecture is false thanx to my close friend akhil for](https://x.com/__alpoge__/status/2079028340955197566)
+    - [Inspired by @__alpoge__ 's post https://x.com/__alpoge__/status/2079028340955197](https://x.com/archanfel_anoth/status/2079493117984887004)
+    - [I did some vibe mathin’ with Fable + Sol on this and found something interesting](https://x.com/efe_ufuk/status/2079346515437408285)
+    - [Going through van den Essen's book on the Jacobian Conjecture trying to see “why](https://x.com/gro_tsen/status/2079215501490717094)
+}}
+    }
+  }
+}

--- a/trees/2026-W36.tree
+++ b/trees/2026-W36.tree
@@ -1,0 +1,180 @@
+\import{macros}
+
+\title{2026-W36}
+\date{2026-08-31}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W36-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-08-31]{\mdnote{2026-08-31}{
+- #sci
+    - [Here are low-degree solutions &#40;h3 affine&#41; where det JF is constant:  Trivials: -](https://x.com/grok/status/2079346540716421468)
+    - [@__alpoge__ https://claude.ai/share/95cfebfc-797c-4ae0-be7a-1a31a7d03bbd  Infini](https://x.com/hooji2/status/2079093392383111527)
+    - [@thomasfbloom Then you might be interested in this! ;-&#41; https://github.com/javie](https://x.com/javieraragon/status/2079356280909570321)
+    - [I basically agree with this. I think it tells us more about how much low hanging](https://x.com/littmath/status/2079733114520383637)
+    - [Did mathematicians miss the counterexample to the Jacobian conjecture because th](https://x.com/littmath/status/2079827446321590467)
+    - [From a paper of van Essen arguing the conjecture is plausibly false: https://t.c](https://x.com/littmath/status/2079827448754217193)
+    - [Another one, from a 2025 paper by El Hilany &#40;https://t.co/3KiJlylyll&#41;: https://t](https://x.com/littmath/status/2079838226395615484)
+    - [This arXiv paper explainer video tweet set a new record for engagement on the @E](https://x.com/mhmazur/status/2078872027767734503)
+    - [If anyone's interested, here are Fable's attempts at disproving a handful of oth](https://x.com/neelsomani/status/2079646189201641968)
+    - [Whoa, GPT 5.6 Sol just found a small counterexample for the Gaussian Moments Con](https://x.com/octonion/status/2079183963382284288)
+    - [@__alpoge__ I had some fun with GPT-5.6 Pro generalizing the construction and pu](https://x.com/prz_chojecki/status/2079141121540624709)
+    - [Wow, this is an amazing geometric explanation of the counterexample to the Jacob](https://x.com/prz_chojecki/status/2079308882589925542)
+    - [@__alpoge__ ok i guess I can shut this down https://x.com/shpetim/status/2079206](https://x.com/shpetim/status/2079206468474049021)
+    - [more small-scale llm math psychosis: it appears the Bowler-Brown-Fenner common c](https://x.com/tenobrus/status/2080133010842861809)
+}}
+
+\subtree[2026-09-01]{\mdnote{2026-09-01}{
+- #zig
+    - [Wrote up a practical introduction to SIMD using a real example from Ghostty. SIM](https://x.com/mitchellh/status/2079992025261424803)
+- #webgl
+    - #web
+        - [Heres a link to check out my browser-based 3d Artificial Life audio visualizer w](https://x.com/aaronlemke/status/2079797144308142135)
+    - [WebGL raymarching heightfield https://x.com/markovurnek_/status/2078889293540417](https://x.com/markovurnek_/status/2078889293540417861)
+- #visualization
+    - [Autoencoders encode data x from R^n to latent z = f&#40;x&#41; in R^k via encoder f and](https://x.com/mathemetica/status/2079468554861293612)
+- #web
+    - #sci
+        - [Feed this into your Fable and turn off web search. Watch it freak out.  It's an](https://x.com/hosseeb/status/2079104877880569863)
+    - [DLA &#40;Diffusion-Limited Aggregation&#41; Coral web app &#40;WebGPU enabled&#41; - Try it out:](https://x.com/ekimroyrp/status/2078499118104887691)
+- #software
+    - #sci
+        - [OpenAI had to pause internal deployment of the unreleased model that disproved t](https://x.com/AndrewCurran_/status/2079253388211183970)
+    - [@the_meursault_ I’ve been fighting this war from the inside, and people supporti](https://x.com/Someody42/status/2079471713029419076)
+    - [@the_meursault_ It’s clear to me that AI companies are only interested in maths](https://x.com/Someody42/status/2079472174872596712)
+    - [Try Kimi K3 on ClinePass, a subscription for ~5x discounted access.  Use it on C](https://x.com/cline/status/2079052347255525757)
+    - [https://x.com/i/article/2078882223206617088](https://x.com/towards_AI/status/2078892237287801283)
+- #sci
+    - [@martinmbauer Already in the 1970s, Moh brute-forced it for n=3 up to degree 3,](https://x.com/tilmanbayer/status/2079394566701293787)
+    - [Moishe Kohan on Jacobian conjecture. Math Stackexchange, 2017](https://x.com/vit_tucek/status/2079266595122102640)
+    - [A digestion of the Jacobian conjecture counterexample https://t.co/2OhxuW7iiQ 一昨](https://x.com/yutakashino/status/2079782482254184475)
+}}
+
+\subtree[2026-09-02]{\mdnote{2026-09-02}{
+- #agent
+    - [Andrew Ng just dropped 8-page PDF on 4 agentic steps &#92;&quot;from Loops to Graphs from](https://x.com/0xCodila/status/2080344428179259846)
+    - [Lots of people are saying Codex limits were cut. While yes, cache writes are 1.2](https://x.com/Nek__12/status/2081000799203738006)
+    - [I think I got a simple self-directed decidable typing for a Pi + Self and that i](https://x.com/TheEduardoRFS/status/2081048304809287960)
+    - [people are asking me “why aren’t you trying to follow the math being output by c](https://x.com/airkatakana/status/2081346745372746036)
+    - [I tried to adapt the transcript of my video &#92;&quot;Being Linus Torvalds&#92;&quot; into an engli](https://x.com/antirez/status/2080980201178063059)
+    - [recommended reading. till the end.](https://x.com/badlogicgames/status/2080704350339387666)
+    - [Seems OpenAI / chatgpt / codex global outage. They finally updated the status pa](https://x.com/dnikolayev/status/2080946566978744544)
+    - [Took us a minute, but stacked PRs are now on GitHub 🥞 https://github.blog/change](https://x.com/github/status/2082865588800504140)
+    - [Meet LM Studio Bionic.  The Agent made for Open Models.  https://lmstudio.ai/ ht](https://x.com/lmstudio/status/2077836987386429807)
+    - [Congrats, Yangqing!](https://x.com/lmxyy1999/status/2082139719979380912)
+    - [people of pi, i just found a way to not to be broke while using fable 5  &#92;&quot;cache](https://x.com/q_yeon_gyu_kim/status/2082470966903689666)
+    - [just tried kimi k3 ultrafast &#40;100~200tps? idk&#41;  with the help of codemode extens](https://x.com/q_yeon_gyu_kim/status/2083051065889734817)
+    - [The Kimi K3 architecture figure for yesterday's big open-weight model release, a](https://x.com/rasbt/status/2082098201247600765)
+    - [*Language Models are Injective and Hence Invertible* by @GiorgosNik02 @tommaso_m](https://x.com/s_scardapane/status/2082436329741160825)
+}}
+
+\subtree[2026-09-03]{\mdnote{2026-09-03}{
+- #agent
+    - #formal
+        - #benchmark
+            - [Why is OpenAI in trouble?  The developer and enterprise market already leans hea](https://x.com/Da7_Tech/status/2080916472159674654)
+        - #sci
+            - [An LLM breaks a 20-year-old graph theory conjecture.   We found An explicit 4,12](https://x.com/28tomabou/status/2081024890640159059)
+    - #proof
+        - #sci
+            - [This is insane. This is a VERY central problem in additive combinatorics and it’](https://x.com/Rohit_Writes/status/2082862702259826940)
+        - [amateur mathematicians have been posting their vibe-mathed results for the past](https://x.com/airkatakana/status/2082833011566137374)
+    - #benchmark
+        - #sec
+            - [终于，大家意识到了这个严重的问题 最近半年，模型的训练是在 agentic coding 方面一直突飞猛进 RLVR 但在其他领域却止步不前 甚至英文写作都开始](https://x.com/oran_ge/status/2082262911364579697)
+        - [We use the same standard harness for Anthropic/Opus  Same completions style endp](https://x.com/GregKamradt/status/2082675514582630833)
+        - [opus 5 is a VERY interesting release for a few reasons  1. it showed that the ge](https://x.com/kunchenguid/status/2081125298050060694)
+    - #render
+        - #software
+            - [fun fact: almost all diagrams in the report are made with TikZ written/edited by](https://x.com/bigeagle_xd/status/2081990002045841836)
+    - #cg
+        - #web
+            - [Opus 5 crushed Fable 5 at 3D destruction physics for 2x cheaper!  We gave four m](https://x.com/atomic_chat_hq/status/2080760629653102958)
+        - [To understand and empathize with how workers in many or most fields outside soft](https://x.com/random_walker/status/2082163285588107752)
+    - #git
+        - [Andrej Karpathy just dropped 12-page PDF on &#92;&quot;Graph Engineering&#92;&quot; for multi-agenti](https://x.com/Serantych/status/2081037322867363889)
+    - #context
+        - [A senior Anthropic engineer just dropped 12-page PDF on &#92;&quot;Graph Engineering&#92;&quot; for](https://x.com/h100envy/status/2081081295073955873)
+    - [Claude Code’s 5 hour limits = Codex weekly limit  @thsottiaux look into it what’](https://x.com/wholyv/status/2081073718294728857)
+    - [a=&#40;y,d=mag&#40;k=&#40;y&amp;lt;7?8+sin&#40;y^9&#41;*6:4+cos&#40;y&#41;&#41;*cos&#40;i+t/2&#41;,e=y/2-13&#41;&#41;=&amp;gt;point&#40;&#40;q=y](https://x.com/yuruyurau/status/2080677794439393704)
+}}
+
+\subtree[2026-09-04]{\mdnote{2026-09-04}{
+- #agent
+    - #render
+        - #web
+            - [people kept asking for a browser in herdr. but herdr lives in your terminal so i](https://x.com/herdrdev/status/2081790556804411782)
+    - #sec
+        - #software
+            - [openai: 🚨our internal model hacked a third party, this is unprecedented, pause t](https://x.com/davidad/status/2082969668696838586)
+    - #web
+        - #software
+            - [absolutely insane holy](https://x.com/vishyfishy2/status/2082868034637578430)
+    - #software
+        - #context
+            - [Releasing the model weights and technical report of Kimi K3.  Kimi K3 is our mos](https://x.com/Kimi_Moonshot/status/2081760186235289764)
+            - [this scaling law is a piece of art, kimi K3 recipe improves by ~2.5x over kimi K](https://x.com/eliebakouch/status/2081762200180453657)
+            - [lost for words rn.](https://x.com/yzhang_cs/status/2081763943958425950)
+        - [recommended reading. very cool. should be even easier once the new harness hits.](https://x.com/badlogicgames/status/2082167925964705879)
+        - [Exciting day! 🥞 Stacked PRs are in public preview on GitHub, built by my team wi](https://x.com/depoll/status/2082871123046478033)
+        - [Using GPT-5.6 Sol Ultra to write code isn't worth it. It doesn't just use more t](https://x.com/diegohaz/status/2081279520691138862)
+        - [@GregKamradt With all due respect, things have evolved way beyond token in / tok](https://x.com/thsottiaux/status/2082734562103484862)
+- #benchmark
+    - [Sorry, but as a ChatGPT and Codex Pro user, I couldn't care less about an API pr](https://x.com/dieaud91/status/2082881596554670456)
+    - [Análise preliminar das implicações do corte de preços no Luna e Terra &#40;baseado n](https://x.com/rafaquint/status/2082942652811485549)
+    - [5.6 Terra high is underrated. Switched @clawsweeper &#40;GitHub review bot&#41; to it an](https://x.com/steipete/status/2078236791329657017)
+    - [@dieaud91 Works the same in the paid subscription!](https://x.com/thsottiaux/status/2082912394284827091)
+}}
+
+\subtree[2026-09-05]{\mdnote{2026-09-05}{
+- #formal
+    - #proof
+        - #lean
+            - [Shoutouts to Ramana Kumar for refuting the Collatz Conjecture in Lean, *as check](https://x.com/ElliotGlazer/status/2082283443237667280)
+            - [@gro_tsen Update: it seems the discoverer Ramana Kumar &#40;who is both an expert in](https://x.com/JasonRute/status/2082522886409986367)
+            - [So, someone came up with an AI-generated formal proof, in Lean, of a solution to](https://x.com/gro_tsen/status/2082483878480977959)
+        - [Some thoughts on these slides:  &#40;1&#41; proof abundance is really good, it is comple](https://x.com/DmitryRybin1/status/2081241894919496002)
+    - [&#92;&quot;Within 3 years, commonly available AI tools will, effectively for free and with](https://x.com/cortesi/status/2081503526090637319)
+    - [&#92;&quot;So much complexity in software comes from trying to make one thing do two thing](https://x.com/pickover/status/2081398786723574159)
+- #gpu
+    - #game
+        - #os
+            - [Efficiency!   In two steps a&#41; Train fantastic model b&#41; Use fantastic model to ma](https://x.com/thsottiaux/status/2082578335167807775)
+    - [At Astral, we created pre-built wheels for popular GPU-enabled packages &#40;like Fl](https://x.com/charliermarsh/status/2082908642928402558)
+    - [Kimi K3 running on a single Mac Studio using MLX! WOW! Just WOW!](https://x.com/ivanfioravanti/status/2082189065873477821)
+- #cg
+    - #visualization
+        - [Visualization of matter-wave diffraction.  Showing a localized quantum wave pack](https://x.com/PhilosophyOfPhy/status/2082311401440452984)
+- #game
+    - [claude 20x limits actually much more generous atm than codex 20x limits, interes](https://x.com/ValtteriValo/status/2080982766544375963)
+- #misc
+    - [some of the things i'm working on https://x.com/0xBunny/status/20806354764577960](https://x.com/0xBunny/status/2080635476457796081)
+    - [Yurii Nesterov is a Belgian-Ukrainian mathematician and one of the founders of m](https://x.com/CalcCon/status/2080705644395626501)
+    - [This is a pretty good poster of the SETOL paper, the foundational theory behind](https://x.com/CalcCon/status/2081433338292924563)
+}}
+
+\subtree[2026-09-06]{\mdnote{2026-09-06}{
+- #misc
+    - [Oh my god https://x.com/jiamimaodashu/status/2081355681115054243](https://x.com/DeltyThe73rd/status/2081530214983868721)
+    - [I usually recommend lighter topics on Sundays, but this time around, I got you a](https://x.com/DiracGhost/status/2081496316631253463)
+    - [&#92;&quot;How to read Mathematics? A study guide&#92;&quot; &#40;by Petra Schwer&#41;: https://arxiv.org/ab](https://x.com/DynamicsSIAM/status/2081962512397070364)
+    - [Covariant and contravariant https://www.johndcook.com/blog/2013/02/28/covariant-](https://x.com/FunctorFact/status/2080686995404140859)
+    - [Before “computer art” was a category, Desmond Paul Henry stood in his Manchester](https://x.com/Interface_art/status/2082815976664666126)
+    - [Excited to have @modal as Day 0 launch partner for Kimi K3!  They trained a cust](https://x.com/Kimi_Moonshot/status/2081767591887122564)
+    - [We are committed to pushing the model frontier across cost efficiency, capabilit](https://x.com/OpenAI/status/2082878156483219672)
+    - [Some inference learning basics https://x.com/Raman_bansal_/status/20816049959805](https://x.com/Raman_bansal_/status/2081604995980599676)
+    - [我自己买了个美国服务器，把它做成 Tailscale 出口节点。电脑和手机都能连，开启后全局走美国 IP，一个月成本大约120元，流量1TB。TMD 网速贼快！](https://x.com/RealYDT/status/2081355632129786277)
+    - [A plot Opus 5 made for me to explain what they were doing https://x.com/Sauers_/](https://x.com/Sauers_/status/2081188919224254758)
+    - [なんとKimi-K3の1ビット量子化が完了しております  246GBです  世界最速の男の称号樹立でありましょうか](https://x.com/Tono_Ken3/status/2081862693443735883)
+    - [突然发现“国家超算“也有提供 Token Plan 呀，而且支持 K3，价格看起来也很不错 有使用过的推友吗，有坑不 https://www.scnet.cn/](https://x.com/VersunPan/status/2081648050049863722)
+    - [我第一反应是 作者是傻逼 第二反应是 作者是天才 https://x.com/XiaoTian258/status/2081362244903006423](https://x.com/XiaoTian258/status/2081362244903006423)
+    - [one matrix replaced the KV cache.  &#40;the technique is 100&#37; open source&#41;  Kimi jus](https://x.com/akshay_pachaar/status/2080733411422204040)
+}}
+    }
+  }
+}

--- a/trees/2026-W37.tree
+++ b/trees/2026-W37.tree
@@ -1,0 +1,188 @@
+\import{macros}
+
+\title{2026-W37}
+\date{2026-09-07}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W37-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-09-07]{\mdnote{2026-09-07}{
+- #misc
+    - [@natolambert Free until you become successful, then call sales and add the Kimi](https://x.com/alienoperatortv/status/2081766744612655185)
+    - [@irisparadox @arenamagdotcom OpenROAD mostly](https://x.com/bzogrammer/status/2082930504475767008)
+    - [On this 126 byte snippet: - ty 0.0.65 stack-overflows - mypy 2.3.0 segfaults - P](https://x.com/charliermarsh/status/2082885991686090885)
+    - [https://x.com/chloeallegra228/status/2082288349872529885](https://x.com/chloeallegra228/status/2082288349872529885)
+    - [Scenario: you need to prepare for an interview. I got your back. https://x.com/g](https://x.com/ggsimm/status/2082403476470890784)
+    - [We are experiencing degraded availability for the GPT-5.2, GPT-5.3-Codex, GPT-5.](https://x.com/githubstatus/status/2080953332307218558)
+    - [Music-JEPA: Learning a World Model of Sound from Action  &#92;&quot;we propose to learn a](https://x.com/iScienceLuvr/status/2081659005529964851)
+    - [@bzogrammer @arenamagdotcom What are you using to design the CPU?](https://x.com/irisparadox/status/2082927613157294253)
+    - [そういえば、Flow Matching &#40;確率パスを学習させる生成モデル&#41;のこれめっちゃよかった  https://arxiv.org/abs/2412.062](https://x.com/jNkif3uTQa86516/status/2081385347003658387)
+    - [@steph_palazzolo @amir Literally no one reads anymore.   Buncha upset replies he](https://x.com/joshpuckett/status/2082625447658143804)
+    - [https://x.com/i/article/2077420690375098368](https://x.com/kafkasudo/status/2081262032637345866)
+    - [@lakshyaag weird misinformation to find circling on twitter, no.](https://x.com/karpathy/status/2081193667529003247)
+    - [@PjoyAI @lakshyaag I thought the way to announce such a thing was not to change](https://x.com/karpathy/status/2081195664479068350)
+    - [Transferring data with rapidly flashing qr codes 🫰 https://www.reddit.com/r/vibe](https://x.com/mrdoob/status/2082913353853534515)
+}}
+
+\subtree[2026-09-08]{\mdnote{2026-09-08}{
+- #misc
+    - [Some papers about Looped Transformers arranged chronologically:  Universal Trans](https://x.com/neural_avb/status/2082002890521264305)
+    - [成功了！玻利维亚区的chatgpt，这波我也上车了： 1、订阅了一个 plus，139.99波币，即，12.61美元， 2、如果升级到20X是1379.99波币](https://x.com/niaoshu/status/2080726744697634818)
+    - [Go deeper.  We analyze 64 distinct personality types to reveal the complex layer](https://x.com/personalityhub/status/2075761906472906996)
+    - [Mathematics.  Infinity.  Imagine spending a lifetime studying the mysterious &#92;&quot;Ta](https://x.com/pickover/status/2081164890002124999)
+    - [I don’t agree w all the criticism of @lilianweng  It’s very different being a gr](https://x.com/pranavcmadhukar/status/2082606369040175569)
+    - [We’ve applied a mitigation for elevated error rates affecting ChatGPT, Codex and](https://x.com/reach_vb/status/2080958657487917263)
+    - [&#92;&quot;We can instantly build knowledge into a Transformer block, no training required](https://x.com/srai009/status/2081455164788289747)
+    - [K3 is out. Your cloud provider probably doesn’t have it. We do :&#41; https://exe.de](https://x.com/ssh_exe_dev/status/2081858756753952967)
+    - [Lilian Weng, the Thinking Machines cofounder who announced her departure earlier](https://x.com/steph_palazzolo/status/2082521981543419953)
+    - [被 Kimi K3 的新中文难哭了，要它给我写英文了。 https://x.com/syhily/status/2081352716010528887](https://x.com/syhily/status/2081352716010528887)
+    - [We have reset usage limits for all Codex and ChatGPT Work users.  Last night aro](https://x.com/thsottiaux/status/2081096447718723984)
+    - [We’re celebrating the fast adoption of chatGPT Work and all the incredible effor](https://x.com/thsottiaux/status/2081899343091843463)
+    - [Terrific work by @ilanbigio and @sandersted on the investigation and post. Seems](https://x.com/thsottiaux/status/2082637967852806207)
+    - [How does Kimi handle 1M+ token context while being 6.3× faster at decoding and u](https://x.com/timothibo/status/2081827294197563727)
+}}
+
+\subtree[2026-09-09]{\mdnote{2026-09-09}{
+- #proof
+    - #render
+        - #visualization
+            - [Hodge Conjecture ✍️  Imagine two completely different worlds of mathematics. One](https://x.com/scievision369/status/2081111776591245582)
+        - [PSA: Mathematicians, it is time to adjust the settings in your beamer presentati](https://x.com/mathandcobb/status/2081045241600069650)
+    - #sci
+        - [&#92;&quot;Topology Without Tears&#92;&quot; is a free textbook that provides an introduction to top](https://x.com/antoniolupetti/status/2081372043061100907)
+    - [After Sol spun for about 33 hours in a session trying to come up with a substant](https://x.com/MikePFrank/status/2081032780134396402)
+    - [I had Sol write this report on its 33-hour-long effort to find a simplified proo](https://x.com/MikePFrank/status/2081068258019721584)
+- #rust
+    - [When I post plots of the CPU I'm working on, people are surprised at how organic](https://x.com/bzogrammer/status/2082708225934377234)
+- #render
+    - #software
+        - [I modified Codex CLI to render latex https://x.com/haskallcurry/status/208182496](https://x.com/haskallcurry/status/2081824968757715087)
+    - [AIが87年間未解決だった数学の難問「ヤコビアン予想」の反例を発見したとして、数学界で話題になりました  このノートブックでは、Wolfram言語を使って、その](https://x.com/WolframJapan/status/2082053451547373634)
+- #os
+    - [It was always possible to speak to your computer. It wouldn’t do much in return.](https://x.com/thsottiaux/status/2081254182502465981)
+- #misc
+    - [https://x.com/i/article/2077616768491585536](https://x.com/waterloo_intern/status/2081762065392541951)
+    - [AI说快重置了 https://x.com/wong2__/status/2080896755827417360](https://x.com/wong2__/status/2080896755827417360)
+    - [https://x.com/i/article/2081060394894802944](https://x.com/wquguru/status/2081061229192233425)
+    - [No one is in academia for the money. Almost no one is in academia for the presti](https://x.com/yuanyi_z/status/2082546536756445350)
+}}
+
+\subtree[2026-09-10]{\mdnote{2026-09-10}{
+- #rust
+    - #software
+        - [Maybe we should talk about real services more, not just microbenchmarks. Same im](https://x.com/yagiznizipli/status/2082905235459117202)
+- #zig
+    - [Keep fighting, I want more drama!  Let's rewrite bun back into zig 🤪  https://zi](https://x.com/xuanwo/status/2080620408026632699)
+- #shader
+    - #gpu
+        - [Alhamdulillah... 😌  Built a GPGPU Flow Field Particle Simulation using JavaScrip](https://x.com/ayaan_is_a_dev/status/2080993410056691870)
+- #visualization
+    - [&#92;&quot;Lab compute 3x-es year over year. For a lab to 10x revenue while continuing to](https://x.com/dwarkesh_sp/status/2082500372124610702)
+- #sec
+    - #software
+        - [More opensource goodness. We have just released a CLI and TypeScript SDK for fin](https://x.com/thsottiaux/status/2082241164850364555)
+- #web
+    - [Hello people of Sol! I've reset usage limits for all ChatGPT Work and Codex user](https://x.com/thsottiaux/status/2082317452755751098)
+- #software
+    - [i saw tweets of people complaining that @OpenAI official harness, Codex, was des](https://x.com/CardilloSamuel/status/2081025317171331322)
+    - [In the next version of Bun  Bun.serve can serve a whole folder https://x.com/bun](https://x.com/bunjavascript/status/2082489775001616446)
+    - [@thsottiaux I was convinced you walked into the server room, unplugged one cable](https://x.com/snowy_smile_/status/2081104696157274594)
+- #sci
+    - [https://arxiv.org/abs/2201.03660 This paper contains a math conjecture worth scr](https://x.com/ThomasVanRiet2/status/2081632899720253785)
+    - [insane times we live in  I recall spending a few hours on this problem couple ye](https://x.com/mertunsal2020/status/2082606996155695205)
+    - [My Codex found a non-trivial zero of the Riemann zeta function off the critical](https://x.com/nasqret/status/2080954486202266059)
+    - [The Maxwell conjecture is false. Counterexample found by AI &#40;GPT-5.6 Sol&#41;, commu](https://x.com/philarathoon/status/2082831490560262624)
+}}
+
+\subtree[2026-09-11]{\mdnote{2026-09-11}{
+- #agent
+    - [It's 2026. If your screen recordings don't look like this...  Straight to the pe](https://x.com/DerekFeehrer/status/2069213588297044120)
+    - [Haha, this is crazy!  Solving a low-hanging open problem in an area new to you u](https://x.com/HamedHa26534517/status/2083966133422461075)
+    - [Me: Please convert this entire codebase from ai-sdk to pi-agent-core. Claude: I](https://x.com/KentonVarda/status/2084293600142135365)
+    - [codex tip: use Luna Max to deploy for &#40;nearly&#41; free.  Luna Max is more than capa](https://x.com/MatthewBerman/status/2084060433233907875)
+    - [I am now really worried about what math research will look like at the end of my](https://x.com/Someody42/status/2083513994346713565)
+    - [recommended reading  https://www.seangoedecke.com/llms-reward-expertise/](https://x.com/badlogicgames/status/2084399057095594414)
+    - [banger](https://x.com/badlogicgames/status/2085103130052612494)
+    - [DSPy can now optimize your program's code, in addition to the prompt.   It's ins](https://x.com/dbreunig/status/2085080631353147576)
+    - [What if you could have an AI agent monitoring every log line, and you didn’t hav](https://x.com/jadtnaous/status/2084687148452577537)
+    - [I am reminded of a very memorable quote on MathSE. https://x.com/ma_sabba/status](https://x.com/ma_sabba/status/2084764654375444937)
+    - [same tui, same Claude session and same herdr, now you can see the images your ag](https://x.com/odd_joel/status/2083095799387521261)
+    - [If you're looking for more conjectures to prove with LLMs just browse UnsolvedMa](https://x.com/prz_chojecki/status/2083185617198780917)
+    - [I understand there's a lot of desire to get Luna used as a sub agent.  I do not](https://x.com/pvncher/status/2083300990350954981)
+    - [DeepSeek v4 flash is the only model designed for loop engineering.  In the past](https://x.com/quxiaoyin/status/2084611364245676279)
+    - [It’s a good agent harness  Coding harnesses are solved basically  pi back on top](https://x.com/shawmakesmagic/status/2085166100787134600)
+}}
+
+\subtree[2026-09-12]{\mdnote{2026-09-12}{
+- #agent
+    - #formal
+        - #proof
+            - [We’re releasing the manuscripts, formal Lean certificates, and reasoning walkthr](https://x.com/OpenAI/status/2084352165464903730)
+        - #benchmark
+            - [Luna is dirt cheap now, so this is probably the best time to make it your Codex](https://x.com/eidzoku/status/2083206063818469778)
+    - #proof
+        - #sci
+            - [Here's my current model basic prompt:  Let's prove &#91;Conjecture&#93;. Perform a deep](https://x.com/octonion/status/2082814707635777588)
+        - [so after 24h i have half of them with fable  i didn’t see much discussion of pro](https://x.com/__alpoge__/status/2083855298239078748)
+    - #rust
+        - [With my maintainer hat on, I think the rust-lang/rust LLM policy is very thought](https://x.com/charliermarsh/status/2085065098616275359)
+    - #gpu
+        - #benchmark
+            - [My feed is full of people pleading for a codex reset  Stop begging. And take con](https://x.com/onusoz/status/2085046696338481257)
+    - #benchmark
+        - #render
+            - [We're starting to leave the territory where you'd test an LLM by e.g. &#92;&quot;create an](https://x.com/karpathy/status/2083749667410727319)
+        - #game
+            - [qwen 3.8 max vs deepseek v4 flash 0731 vs kimi k3 vs gpt 5.6 sol – on rubik's cu](https://x.com/thehypedotnews/status/2085034409741131948)
+    - #cg
+        - [Day 5: Inference Engineering    Today was more about ML than inference tbh. Got](https://x.com/not_ellington/status/2085194032335196398)
+        - [Qwen-3D: A Generalist 3D Vision-Language Model for Spatial Understanding  TL;DR:](https://x.com/shumpeiMaxwell/status/2085130724173332902)
+    - #sec
+        - #software
+            - [Today we're open sourcing Cloudflare OS:  - An agent workspace grounded in skill](https://x.com/akaphill/status/2084992807912268258)
+    - #git
+        - [🤷‍♂️ https://fut.sh/  Fully slopped. I guarantee nothing.](https://x.com/mikker/status/2085265518554943931)
+    - #software
+        - [Wow. Lotta love for ‘sol-advisor’.  Uses GPT-5.6 Sol as orchestrator/advisor and](https://x.com/daniel_mac8/status/2083691272938688727)
+    - #sci
+        - [Announcing two new conjectures proved https://chatgpt.com/share/6a69989a-0878-83](https://x.com/jasondeanlee/status/2082592996537893080)
+    - [To celebrate a week of efficiency and let you run 100'000 Luna threads this week](https://x.com/thsottiaux/status/2083395449814229287)
+}}
+
+\subtree[2026-09-13]{\mdnote{2026-09-13}{
+- #agent
+    - #web
+        - #software
+            - [How to use my new /human-review skill to edit HTML and Markdown files directly:](https://x.com/petergyang/status/2085055745410945126)
+        - [I made a page-flipping sketchbook inspired by Matthew Yu's concept.  Books and p](https://x.com/MengTo/status/2085252340643430629)
+    - #software
+        - [I removed GPT-5.6 Luna Max from 'sol-advisor'. 😥  @pvncher says Luna doesn't wor](https://x.com/daniel_mac8/status/2084040587397693593)
+        - [I agree that if you think &#92;&quot;capabilities growth will be slower, spikier, and more](https://x.com/dwarkesh_sp/status/2082950186784137538)
+        - [众所周知，我们学术很强，这不，新论文来了。  这次讲自进化 Agent 面临一个关键的“评估难题”：真正困难的不是生成新的 Harness 修改方案，而是判断这](https://x.com/elliotchen100/status/2082833135562371556)
+        - [Gave DeepSeek vision with one skill.  npx -y skills add liustack/modlens  Repo l](https://x.com/hqmank/status/2084998933731008639)
+- #formal
+    - #proof
+        - #lean
+            - [@GaryMarcus  The physical motivation is compelling, but the mathematical identif](https://x.com/PinChoALTA/status/2084539489985130904)
+            - [After a long back and forth, GPT-5.6 Sol produced a proof &#40;formally verified in](https://x.com/_monotau/status/2082548624890990949)
+    - [&#92;&quot;Data-Driven Formal Methods for Complex Dynamical Systems: A Survey&#92;&quot; &#40;by Behrad](https://x.com/DynamicsSIAM/status/2083251165530394780)
+- #benchmark
+    - #cg
+        - [NEW RESEARCH: You can now create a new robot optimized for any given task!  I lo](https://x.com/LeoKharon/status/2085018570803618047)
+    - [🚀 DeepSeek-V4-Flash Official API is now LIVE in public beta!  🔷 We’ve massively](https://x.com/deepseek_ai/status/2083084415157022911)
+- #cg
+    - #visualization
+        - [InfiniSplat &#40;SIGGRAPH Asia 2026&#41;​ is trending on @HuggingFace! 🚀 Turn a single i](https://x.com/pengsida/status/2084838787205718427)
+        - [On indoor scenes, our InfiniSplat delivers consistent and significant gains over](https://x.com/pengsida/status/2084952494271344746)
+    - [Coded a 3D coastal station with a lighthouse, keeper’s residence, procedural ter](https://x.com/techartist_/status/2084719803139604746)
+- #docker
+    - [The gist of my findings is that if you find yourself needing a std::list in C++,](https://x.com/lemire/status/2083974791602520490)
+}}
+    }
+  }
+}

--- a/trees/2026-W38.tree
+++ b/trees/2026-W38.tree
@@ -1,0 +1,169 @@
+\import{macros}
+
+\title{2026-W38}
+\date{2026-09-14}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W38-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-09-14]{\mdnote{2026-09-14}{
+- #formal
+    - #proof
+        - #lean
+            - [black-boxing human proofs DESTROYS the credibility of Lean verification: even if](https://x.com/bcubeddd/status/2084730915020783739)
+- #lean
+    - #os
+        - [Oh dear https://x.com/ElliotGlazer/status/2083611698410537452](https://x.com/ElliotGlazer/status/2083611698410537452)
+    - #software
+        - [Postmortem for Lean Kernel Soundness Bug #14576 https://leodemoura.github.io/blo](https://x.com/Leonard41111588/status/2083610354802635263)
+    - [@doomslide @littmath @nihilunbounded You can hold me responsible for the Lean, b](https://x.com/AcerFur/status/2084808286747201711)
+    - [I feel a weird guilt that I am the first to experience the beauty of the produce](https://x.com/DimitrisPapail/status/2083898738725036528)
+    - [From lecture notes to Lean: Formalizing a textbook on probability theory. ~ Shuo](https://x.com/Jose_A_Alonso/status/2083075983716786335)
+- #gpu
+    - #visualization
+        - [Day 28/90 of Inference Engineering  I learned how to optimize an SGEMM with 1D b](https://x.com/maxxfuu/status/2085245154202701922)
+    - [Day 214/365 of GPU Programming  Continuing my SASS studies today and found this](https://x.com/levidiamode/status/2085136396260429969)
+- #misc
+    - [anthropic: if we release this humanity might end.  qwen: here is god in a zip fi](https://x.com/0xDevShah/status/2084130121062203776)
+    - [Unfortunately this disinformation has now spread to the LEAN Zulip. This is why](https://x.com/AcerFur/status/2083896397112447249)
+    - [this is the most exciting plot i have seen all year: https://x.com/CalvinMccarte](https://x.com/CalvinMccarter/status/2083240432004137240)
+    - [THE FASTEST ROBOT IN THE FACTORY? 🌍  Everyone is talking about AI, humanoids and](https://x.com/CobotUli/status/2085118917496709354)
+    - [Luna on xhigh is way better than Max.](https://x.com/Da7_Tech/status/2084877708559802851)
+    - [Because of the current progress in AI, many people are starting to think that th](https://x.com/DiracGhost/status/2084003993169404297)
+    - [Book: &#92;&quot;Geometric Methods for Stochastic Dynamical Systems&#92;&quot; &#40;by Jinqiao Duan, Tin](https://x.com/DynamicsSIAM/status/2083233597537005835)
+}}
+
+\subtree[2026-09-15]{\mdnote{2026-09-15}{
+- #misc
+    - [No. Viazovska’s results were a breakthrough on a long-stalled problem. 1 and 2 w](https://x.com/ElliotGlazer/status/2084061851462291926)
+    - [RH is provable &#40;in ZFC&#41;: ~95&#37; Independence is independent: ~4&#37; Disprovable &#40;equi](https://x.com/ElliotGlazer/status/2084134153961021636)
+    - [If your code doesn't look like this, what are you even doing? https://x.com/HSVS](https://x.com/HSVSphere/status/2085049810332025057)
+    - [How confusing do you want the paper to be? Author: Yes #physics #scicomm https:/](https://x.com/Hassaan_PHY/status/2083750358262644762)
+    - [🚀不少人遇到  Codex  每次打开或提问时总是先触发 5 次 “Reconnecting” 重连 这个问题。  这个问题的本质原因：WebSocket（WS](https://x.com/Lonely__MH/status/2063134508267012264)
+    - [After doing ~60B tokens, this is my full AGENTS.md https://x.com/MarcosHernanz/s](https://x.com/MarcosHernanz/status/2083954734487212511)
+    - [ICC property&#40;T&#41; groups without W*-superrigidity  Shuoxing Zhou https://arxiv.org](https://x.com/OpAlgebras/status/2084551785595699556)
+    - [@math_lore @claudeai @AnthropicAI @OpenAI It's in the paper here: https://philpa](https://x.com/QualiaQuanta/status/2084395075425976335)
+    - [Matter particles can be described using the geometrical language of principal bu](https://x.com/SamuelGWalters/status/2084199876347498861)
+    - [I'm tired of seeing mostly the pro-AI reactions shared on Twitter, so I'll just](https://x.com/Someody42/status/2042960937410232499)
+    - [On-Policy and Off-Policy Learning for Large Action Spaces https://arxiv.org/abs/](https://x.com/StatMLPapers/status/2083040828465774941)
+    - [--&amp;gt; This is cool stuff https://arxiv.org/abs/2607.28615](https://x.com/ThomasVanRiet2/status/2083111786622935430)
+    - [@AcerFur &#40;i checked at the time btw, that counterexample def fits the hypotheses](https://x.com/__alpoge__/status/2083968139432505693)
+    - [i will take literally any excuse to advertise Weil’s review of, and eventually f](https://x.com/__alpoge__/status/2085291154401264007)
+    - [We've been thinking can we distill the knowledge humans encoded in expert system](https://x.com/__zrrr__/status/2082906868054360454)
+}}
+
+\subtree[2026-09-16]{\mdnote{2026-09-16}{
+- #misc
+    - [With the recent surge in research on Looped Transformers, we have compiled a lis](https://x.com/askalphaxiv/status/2082891909714886781)
+    - [just realized: it's a shitty alt screen mode layout engine. back to true form!](https://x.com/badlogicgames/status/2083106157271384560)
+    - [so cute 🐈💨](https://x.com/cc_usage/status/2082803867863883999)
+    - [Codex users: do this right *now*.  Max reasoning effort is off by default.  Luna](https://x.com/daniel_mac8/status/2083218469680549930)
+    - [Language models *already* using quantum-like representations makes me think they](https://x.com/dearmadisonblue/status/2084805181267484739)
+    - [Empty apartment but all I need is my router to run Codex tasks https://x.com/der](https://x.com/derrickcchoi/status/2084288047512731755)
+    - [https://github.com/VladimirReshetnikov/ProveIt/tree/main/Shenanigans https://x.c](https://x.com/ereliuer_eteer/status/2083041435767734556)
+    - [alias nvim=red https://x.com/fcoury/status/2083613929608032700](https://x.com/fcoury/status/2083613929608032700)
+    - [Good news: Tibo does grant the occasional Codex reset.  Bring solid feedback or](https://x.com/hqmank/status/2085228562668552371)
+    - [This is a *really* good blog post by @reza_byt about how SIGReg works &#40;the main](https://x.com/iScienceLuvr/status/2084856534153216511)
+    - [ABC予想の証明をめぐる最近の論争  米アリゾナ大准教授で数学者のKirti Joshi氏が、ABC予想を証明した望月新一教授のIUT理論に関する一連のプレプリ](https://x.com/i_tetsuya137/status/1773253445857820745)
+    - [Twenty magnetic field sources. Thousands of interactions.  Particles, field line](https://x.com/jeonghopark/status/2083679457001247091)
+    - [we haven't gotten any breakthrough in LLMs for 9 years  attention is all you nee](https://x.com/joaomendoncaaaa/status/2083846853687226642)
+    - [Actual interaction with Fable just now:  &#92;&quot;Yes, you asked for A and I said B was](https://x.com/johnmyleswhite/status/2084792343874396554)
+    - [Universal Transformers &#40;https://arxiv.org/abs/1807.03819&#41; is one of my favorite](https://x.com/kohjingyu/status/2084448169593598051)
+}}
+
+\subtree[2026-09-17]{\mdnote{2026-09-17}{
+- #misc
+    - [To my taste this is the best counterexample of the year so far. https://x.com/li](https://x.com/littmath/status/2084849631478046969)
+    - [&#91;Submitted on 29 Apr 2025&#93; Final Report on the Mochizuki-Scholze-Stix Controvers](https://x.com/math_jin/status/1924665601618018475)
+    - [We released a major update to our book, &#92;&quot;The Elements of Differentiable Programm](https://x.com/mblondel_ml/status/2085311790846730727)
+    - [Possibly the single best thing I've read about efficient harness engineering.](https://x.com/morganlinton/status/2084719560343846954)
+    - [今天早上 npm 又爆了。 keyv 维护者 GitHub 账号被入侵，一整套缓存相关包全被投毒。 keyv（1.27亿周下载）、flat-cache（5.65](https://x.com/mylifcc/status/2084658036417925512)
+    - [Tomorrow I'll speak at the FPTalks series on floating point and numerical analys](https://x.com/nmwsharp/status/2085100640020353200)
+    - [My friend doing a math PhD at CalTech just told me it is a Fields-medal level re](https://x.com/odysseus0z/status/2083420609850245197)
+    - [Scientific plotting in the terminal! 🐀  https://github.com/shergin/malevich  #ru](https://x.com/orhundev/status/2084714572284375069)
+    - [spent all day reading this article on vllm internals. really neat https://x.com/](https://x.com/prathamgrv/status/2084974537087811975)
+    - [Today I'm excited to ship hucre v1.0.0 🎉  It started as an idea to build a moder](https://x.com/productdevbook/status/2084582972368257178)
+    - [You should be Luna-maxxing:  &amp;gt; Luna &#40;Max&#41; matches GPT‑5.5 xHigh for roughly 1](https://x.com/reach_vb/status/2083304682890338353)
+    - [impressive work  https://arxiv.org/abs/2607.28930](https://x.com/star_stufff/status/2084545131164860551)
+    - [kew is a terminal music player for your local music collection.  You can search](https://x.com/terminaltrove/status/2084752861812985874)
+    - [@_chenglou I was part of that team. Basically ChatGPT one year before it came ou](https://x.com/thsottiaux/status/2083596911060324570)
+}}
+
+\subtree[2026-09-18]{\mdnote{2026-09-18}{
+- #proof
+    - #lean
+        - #sci
+            - [1/3 I would have replied to @nihilunbounded directly but they have me blocked fo](https://x.com/AcerFur/status/2084789964349255856)
+        - [Wow nearly missed this: A serious team tried to  formalize &#40;@leanprover&#41; Mochizu](https://x.com/MarioKrenn6240/status/2084388222864617572)
+        - [@MarioKrenn6240 @leanprover There is a reasonable critique that the team trying](https://x.com/rbhar90/status/2084448515422597175)
+    - [@doomslide All formalisations were fully autonomous, just using a Codex skill I](https://x.com/AcerFur/status/2083919382888206509)
+    - [Canonical embedding of the states of a Markov chain into Euclidean space &#40;a rigo](https://x.com/jaycrosstweets/status/2084668013286994108)
+    - [An internal version of Astra, @OpenAI’s next major model family, solved 10 major](https://x.com/polynoamial/status/2083467194663571701)
+- #misc
+    - [点を打つ→線がつながる、を9通り 最小全域木・ボロノイ・等高線・ストリングアート・路線図... #generativeart #creativecoding #](https://x.com/tsumiki_room/status/2083186181379104803)
+    - [这位OpenAI的同学说了一个事实：现在顶级实验室几乎不太读这些顶会论文了（水文太多，虽然偶有佳作，很多结果很牛的论文都有人为操作痕迹）。😅](https://x.com/turingbook/status/2084871747200065623)
+    - [A Visual Guide to Quantization by Maarten Grootendorst &#40;@MaartenGr&#41; - genuinely](https://x.com/vivekgalatage/status/2085235631853310063)
+    - [gradients are ridiculous powerful tools we for some reason only use during train](https://x.com/willdepue/status/2083919332375937227)
+    - [My prediction: mathematicians will survive and thrive in the future, even in the](https://x.com/wwwojtekk/status/2083818022301847621)
+    - [AI and &#40;Research&#41; Mathematics. A thought experiment to break past the shallownes](https://x.com/yiannissak/status/2084655290964685238)
+    - [LOL, their servers are overloaded, so they need to raise prices and destroy some](https://x.com/zephyr_z9/status/2085186195617968338)
+    - [这两天 Codex 额度蹬完了，一直也没等来重置，把模型换成 DeepSeek Flash V4 之后发现内置浏览器操作好像不行了。换成了 @annaxtime](https://x.com/zhongerxin/status/2084939171161063710)
+}}
+
+\subtree[2026-09-19]{\mdnote{2026-09-19}{
+- #proof
+    - #lean
+        - #sci
+            - [As everyone and their mother knows by now, the OAI paper on existence of nonsofi](https://x.com/nihilunbounded/status/2084725404728992240)
+    - #render
+        - [Dynamic geometries, vortex-shedding, supersonic flow. People have spent decades](https://x.com/getjonwithit/status/2083190944208183801)
+- #rust
+    - #git
+        - #tui
+            - [How many Git repos do you have sitting half-finished?  🚢 drydock — Track uncommi](https://x.com/orhundev/status/2084784961136017881)
+    - #tui
+        - [Now we can DJ from the terminal!   🎚️ termixer — A live DJ mixer for TidalCycles](https://x.com/orhundev/status/2084604801065553936)
+- #render
+    - [quick spike: getting multiplayer editing working on diffs/edit with yjs + partyk](https://x.com/threepointone/status/2084645457687453732)
+- #web
+    - #software
+        - [My last open-source skill, /no-ai-slop, clearly hit a nerve with 4K GitHub stars](https://x.com/petergyang/status/2085006701984698712)
+    - [Tomorrow will be my last day at Google after 27 years, and watching it grow from](https://x.com/JeffDean/status/2085083442669318443)
+- #tui
+    - #software
+        - [very much hyped up by this  manage all your cloud machines in one slick terminal](https://x.com/AniC_dev/status/2085120305479999757)
+- #software
+    - [PI + pi](https://x.com/badlogicgames/status/2085091341776605358)
+- #sci
+    - [&#92;&quot;A Mathematical Introduction to Diffusion Models&#92;&quot; by Jianfeng Lu is a recent pap](https://x.com/antoniolupetti/status/2084299947789160457)
+    - [GPT 5.6 Sol has found a counter-example to this graphical Lie algebra conjecture](https://x.com/bryancsk/status/2085225261520306679)
+    - [Very nice 13-page exposition!](https://x.com/currying/status/2084086948738584811)
+    - [New math paper🚨 Big news🚨 🚨 Gromov's conjecture &#92;&quot;Every property that's true for](https://x.com/iron_redux/status/2083359008526659857)
+    - [Back in 2019 Yura Malitsky and I wrote a paper about adaptive estimation of grad](https://x.com/konstmish/status/2084269698892312932)
+}}
+
+\subtree[2026-09-20]{\mdnote{2026-09-20}{
+- #agent
+    - [OpenAI 产品负责人 Tibo 此前公开教用户给 Claude Code「换脑」：保留 Claude Code 的 harness，把底层模型换成 GPT。](https://x.com/0xLogicrw/status/2086284482659897392)
+    - [People are calling me double-faced about this take. To be clear, I have the same](https://x.com/AcerFur/status/2086936183494291479)
+    - [stop sending bad prompts to your Pi coding agent.  you liked pi-clarify, so i pu](https://x.com/DODOREACH/status/2087304957011911157)
+    - [. @sh_reya is at it again. The main reason our students love our eval course is](https://x.com/HamelHusain/status/2084323411317359054)
+    - [Discovery is representational phase change.](https://x.com/ProfBuehlerMIT/status/2086048374835269762)
+    - [turns out sol max wasn't the whole problem  if you have “Approve for me” enabled](https://x.com/RijnHartman/status/2085644389242565072)
+    - [@DeepInfra @deepseek_ai @nvidia Your price is not good  Look: https://x.com/nahc](https://x.com/Sharo_k_h/status/2088547043098722557)
+    - [Just two days ago &#40;on Aug 8th 2026&#41;, I have increased the percentage of zeros of](https://x.com/ShivaKintali/status/2086938506593747173)
+    - [Prompt to GPT-5.6 Sol  `Develop, from first principles, a theory of unification](https://x.com/TEJINDER_TIFR/status/2087244474393166096)
+    - [让 Claude Fable 5 和本地跑的 DeepSeek V4 Flash（DGX Spark，thinking 开满）下国际象棋，下出了年度最离谱对比：](https://x.com/YRSM_Simon/status/2084683195967021056)
+    - [jacob and me and a number of other exceptions aside i still don’t really see the](https://x.com/__alpoge__/status/2087322403617886226)
+    - [Here's a PoC https://pasta.can.ac/omegiligox.py  Note how I said nothing about t](https://x.com/_can1357/status/2087230118460641650)
+    - [kinda missed having proper thinking streams ngl. switching thinking levels work](https://x.com/_can1357/status/2087248228769001691)
+    - [Now when you connect Sideshow via MCP, your agent sends a test post that verifie](https://x.com/bentlegen/status/2085048202995351640)
+}}
+    }
+  }
+}

--- a/trees/2026-W39.tree
+++ b/trees/2026-W39.tree
@@ -1,0 +1,184 @@
+\import{macros}
+
+\title{2026-W39}
+\date{2026-09-21}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W39-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-09-21]{\mdnote{2026-09-21}{
+- #agent
+    - #benchmark
+        - [@jarredsumner ive been working on composable math tools &amp;amp; open benchmarks fo](https://x.com/morluto/status/2086882523167232351)
+    - #cg
+        - #game
+            - [Introducing  Hy3D WorldClaw——an agentic workflow that generates large scale 3D o](https://x.com/TencentHunyuan/status/2087068591296536755)
+    - [Crazy how good this is looking... just sub agents running in the background runn](https://x.com/csanz/status/2085495157852410259)
+    - [Codexers: Multi-agent v2 now supports GPT-5.6 Luna.  You can use Luna Max as a n](https://x.com/daniel_mac8/status/2088693300051996811)
+    - [Shoutouts to @AyghriTweets for the best skill ever.  Claude and Codex are actual](https://x.com/echantech1/status/2087436535134375987)
+    - [8 days ago, while jogging, I asked Claude to solve the Riemann Hypothesis  It di](https://x.com/jarredsumner/status/2086869681785500011)
+    - [Jeremy Berman: the ultimate destroyer of ARC-AGI.  No one will ever do it better](https://x.com/mattshumer_/status/2087647325208383509)
+    - [introducing pi-peer  @badlogicgames's pi sessions can now find and message each](https://x.com/micLivs/status/2085846770534256723)
+    - [@deedydas https://arxiv.org/abs/2602.04022](https://x.com/naa_ganesan/status/2086894985782198624)
+    - [Repeating the same experiment but one year later. GPT 5.6 Pro cannot be used van](https://x.com/nasqret/status/2086078115806150752)
+    - [There are now two tiers of sub agents in codex   1. Full collaborative agents th](https://x.com/pvncher/status/2088666195381592153)
+    - [I meant to say &#92;&quot;ghiblify&#92;&quot;, but I said &#92;&quot;gimlify&#92;&quot; https://x.com/thsottiaux/status/](https://x.com/thsottiaux/status/2085610005768945984)
+    - [Let Sol manage an efficient fleet of Luna agents for you.  These models know eac](https://x.com/thsottiaux/status/2088725163923984638)
+    - [Big update to pyncd, I just told an agent to generate a diagram for Attention is](https://x.com/vtabbott_/status/2087922834462867620)
+}}
+
+\subtree[2026-09-22]{\mdnote{2026-09-22}{
+- #agent
+    - #formal
+        - #proof
+            - [Very cool! Terence Tao posted &#92;&quot;A Digestion of the Proof of Sendov's Conjecture&#92;&quot;](https://x.com/LechMazur/status/2087767547391205541)
+            - [I asked Claude &#40;Opus + Fable 5&#41; to work on unsolved problems in math, and it fou](https://x.com/nick_konz/status/2087212120479859077)
+        - #software
+            - [DeepSeek Harness implements RSI &#40;Recursive Self-Improvement&#41; for agents.  The pa](https://x.com/hsu_steve/status/2087990297129050399)
+        - [It's a very illuminating talk by @littmath. A bit grim too. My comment: I think](https://x.com/nasqret/status/2087443088734113801)
+    - #lean
+        - #sci
+            - [1/ Today we are releasing Lea, a Lean theorem proving agent built for mathematic](https://x.com/chegday/status/2088290461072908638)
+        - [68.220195&#37; thanks to ChatGPT 5.6 Pro https://x.com/cs_olen/status/20872342270961](https://x.com/cs_olen/status/2087234227096166501)
+        - [I’d tried once before in a single session and it went nowhere. Eight days ago, w](https://x.com/jarredsumner/status/2086869686042685710)
+        - [The heavy lifting was recent human work - Baluyot, Goldston, Suriajaya &amp;amp; Tur](https://x.com/jarredsumner/status/2086869688353694109)
+    - #compiler
+        - [Agents see text; codemods see a graph. Two read-only tools show why agents need](https://x.com/devagrawal09/status/2087640940593000767)
+    - #gpu
+        - [NVIDIA researchers did it again!  They found a way to make KV cache transferable](https://x.com/_avichawla/status/2085632663902412985)
+    - #cg
+        - #game
+            - [Was thinking 3D game assets, so I made a Gothic citadel beneath a total eclipse,](https://x.com/techartist_/status/2085408995943354368)
+    - #game
+        - #sec
+            - [guys you do know you can just disable thinking, and instead give it a &#92;&quot;deep_thin](https://x.com/_can1357/status/2087228354399265125)
+            - [3&#41; Scheming in the wild:  Sometimes models are kind enough to use words like “ch](https://x.com/kotekjedi_ml/status/2087147183707697175)
+    - #context
+        - [i actually completely don't understand how changing the reasoning level for a mo](https://x.com/albfresco/status/2088640798984151372)
+}}
+
+\subtree[2026-09-23]{\mdnote{2026-09-23}{
+- #agent
+    - #proof
+        - #lean
+            - [hi we have a new little technique to put zeta zeroes on the line thanks to @jarr](https://x.com/__alpoge__/status/2086868936495423561)
+            - [If you paste the text below  Sonnet 5 refuses to believe it but can’t say why  H](https://x.com/jarredsumner/status/2086869693361803519)
+        - #software
+            - [tfw deepseek hires a jane streeter to lead the harness team and suddenly there a](https://x.com/fluorane/status/2087947994989785361)
+        - [@dmitrykrachun @ar0cket1 I agree with this, but I do think the result is of much](https://x.com/AcerFur/status/2086983753486999927)
+        - [https://www-cdn.anthropic.com/23455459f8832d06bb175cc0f88d019aed962ef8.pdf for s](https://x.com/__alpoge__/status/2086870739257639034)
+        - [this so called &#92;&quot;informal note&#92;&quot; by anthropic is pretty meme-worthy in its extreme](https://x.com/julianboolean_/status/2086972039705821249)
+        - [This is no doubt an impressive result, but to be clear, even if we proved that &#40;](https://x.com/mathandcobb/status/2086932663286333758)
+        - [I'm a huge amateur here, so probably totally wrong: the 67.2&#37; is a statement abo](https://x.com/stanislavfort/status/2086882586505159055)
+    - #rust
+        - #lean
+            - [&#92;&quot;Leanstral&#92;&quot;  Leanstral shows Lean theorem proving can scale as a normal code-age](https://x.com/askalphaxiv/status/2085578083403218977)
+    - #lean
+        - #sci
+            - [I am sorry but @__alpoge__  didn't found anything. Until he provides evidence of](https://x.com/rperezmarco/status/2087557380481446365)
+    - #render
+        - [mermaid in pi ❤️ https://x.com/aliouftw/status/2085619722905596081](https://x.com/aliouftw/status/2085619722905596081)
+    - #os
+        - #software
+            - [Introducing Magnitude: your actually local agent 100&#37; private and offline. No to](https://x.com/tomgreenwald/status/2085789053828616695)
+    - #sci
+        - [fwiw this take is the closest to consensus I've seen among my colleagues. I'm st](https://x.com/ElliotGlazer/status/2086931703289839859)
+        - [I wonder if anyone will put open problems or future-work ideas in their papers a](https://x.com/Pooyahat/status/2088057398762016860)
+}}
+
+\subtree[2026-09-24]{\mdnote{2026-09-24}{
+- #agent
+    - #sec
+        - [@_can1357 Now you've done it. Soon we will only be able to use these models in c](https://x.com/kcosr/status/2087239155608703486)
+        - [Some background: In May, @matthew_d_green found that encrypted reasoning could b](https://x.com/kotekjedi_ml/status/2087147055164911930)
+        - [Cross-model portability means Haiku 4.5 can read Opus 4.8’s thoughts.  Well, if](https://x.com/kotekjedi_ml/status/2087147073145856489)
+        - [As you might guess, this suggests that distilling reasoning traces may have been](https://x.com/kotekjedi_ml/status/2087147093735714919)
+        - [Further, if you ever shared online a Claude Code/Codex session with encrypted re](https://x.com/kotekjedi_ml/status/2087147116468826513)
+        - [In the paper we discuss more threats like misuse uplift &#40;see the pic attached&#41;,](https://x.com/kotekjedi_ml/status/2087147132444975275)
+        - [But we also took a chance to have a look at some in-the-wild scheming, reward se](https://x.com/kotekjedi_ml/status/2087147148819468694)
+        - [2&#41; Illegible reasoning:  We confirm prior reports by @ApolloResearch: OpenAI mod](https://x.com/kotekjedi_ml/status/2087147166435627253)
+        - [4&#41; Attacking a website to solve a math problem  We found a trajectory where the](https://x.com/kotekjedi_ml/status/2087147204146499890)
+        - [We went through responsible disclosure with the labs, and they have already patc](https://x.com/kotekjedi_ml/status/2087147216452669839)
+        - [More cool stuff in the paper!  This was a project led by me, @DavidSchmotz and @](https://x.com/kotekjedi_ml/status/2087147228368707614)
+        - [It turns out that all the rumours are true.](https://x.com/yifanzhang_/status/2087211388263633347)
+        - [Very cool work. Haiku can read Opus' mind. That's the whole attack. Amzing that](https://x.com/ziv_ravid/status/2087228972220240168)
+    - #software
+        - [dope work from @tomgreenwald @anderslie - fully locally offline coding agent on](https://x.com/dexhorthy/status/2085798511099220195)
+}}
+
+\subtree[2026-09-25]{\mdnote{2026-09-25}{
+- #agent
+    - #web
+        - #software
+            - [All software should probably look like this](https://x.com/bentlegen/status/2087948548155297894)
+        - [hunk diff --watch --web  would anyone use this? 🤔 https://x.com/bentlegen/status](https://x.com/bentlegen/status/2087171999701323777)
+        - [I actually use Codex a lot... more than most people asking for resets in the rep](https://x.com/ishuagra02/status/2088806257759015109)
+    - #software
+        - [What the hell is the RLHF team doing???](https://x.com/odysseus0z/status/2087651956655575166)
+        - [we did it again, say hello to pi-black  go back to use your claude subscription](https://x.com/paoloanzn/status/2085786546725433795)
+- #formal
+    - #proof
+        - #lean
+            - [We have been working with Sol on a formal Lean proof of Lazard's radical solutio](https://x.com/ereliuer_eteer/status/2087276998792204449)
+            - [Congrats to @LechMazur for the solution and to Terence Tao for the digestion and](https://x.com/nasqret/status/2087859123899519184)
+            - [Leonardo de Moura &#40;@Leonard41111588&#41;  is the creator of Lean and the Z3 theorem](https://x.com/ryanlpeterman/status/2086799737663926587)
+    - #lean
+        - #sec
+            - [Formal verification should become a normal part of scientific computing.  As a s](https://x.com/PMocz/status/2085345373854282217)
+    - #web
+        - [Deep learning runs on math, but we've never had a formal language for architectu](https://x.com/GioeleZardini/status/2087881591624237220)
+    - [&#92;&quot;Mathematical Theory of Deep Learning&#92;&quot; is another excellent free resource if you](https://x.com/antoniolupetti/status/2085656393277657577)
+- #benchmark
+    - #wasm
+        - [You can use Ghostty’s WebAssembly terminal engine on Athas now, instead of xterm](https://x.com/athasdev/status/2088648237288771797)
+    - [john baez wrote a paper with some good old fashioned GUTs https://arxiv.org/abs/](https://x.com/bcubeddd/status/2086544208697905654)
+- #cg
+    - #game
+        - [Coded the next iteration of this gothic 3D world and introduced a character that](https://x.com/techartist_/status/2085538920226259394)
+}}
+
+\subtree[2026-09-26]{\mdnote{2026-09-26}{
+- #lean
+    - [We formalized the very recent Cycle Double Cover Conjecture paper from @Sebastie](https://x.com/MTHajiaghayi/status/2078328588248474094)
+    - [Recently, OpenAI disproved planar unit distance problem, first posed by Erdős. W](https://x.com/MTHajiaghayi/status/2085430210371948744)
+    - [@ChrisPeikert https://x.com/_Mira___Mira_/status/2086267679732817955  I got it u](https://x.com/_Mira___Mira_/status/2086301654547333354)
+- #game
+    - [fable btw, anthropic usually has great regex game, smh https://x.com/_can1357/st](https://x.com/_can1357/status/2087245506539889049)
+    - [My only reason to have a twitter handle back in 2011-ish is to coordinate a game](https://x.com/eldenelmanto/status/2087354088904167925)
+    - [shaping terrain with soundwaves  made an audioreactive app that turns music into](https://x.com/measure_plan/status/2085035285188927546)
+    - [Two economists mathematically proved that AI will destroy the economy.  Research](https://x.com/thesupermanmx/status/2088551268793090178)
+- #misc
+    - [Bro, WHAT   Deepseek-v4-flash-0731 procedurally generates art in the style of Gu](https://x.com/0xSero/status/2087529334445613167)
+    - [A good view at emerging theory on deep learning   https://arxiv.org/abs/2604.216](https://x.com/DarrKaMahaulHai/status/2085760028213227882)
+    - [Luna non-reasoning is a bit better than GPT 4o which was sota 2 years ago.  Luna](https://x.com/EMostaque/status/2085483036842381641)
+    - [&#92;&quot;A Panoramic View of Riemannian Geometry&#92;&quot; by Marcel Berger, one of the greatest](https://x.com/FrnkNlsn/status/2087204248543248526)
+    - [The great reformulation of algebraic geometry https://www.johndcook.com/blog/201](https://x.com/FunctorFact/status/2085760427430957213)
+    - [4,450 tokens/s with 32-way parallelism🤣 https://x.com/Hikari_07_jp/status/208491](https://x.com/Hikari_07_jp/status/2084916301638893795)
+    - [Great paper on the logic of nervous systems https://stankerstjens.github.io/coul](https://x.com/KordingLab/status/2088534313365107044)
+}}
+
+\subtree[2026-09-27]{\mdnote{2026-09-27}{
+- #misc
+    - [rumor has it: Anthropic model has much smaller vocab size https://arxiv.org/abs/](https://x.com/KyleLiang5/status/2088276037490909248)
+    - [Gradient noise may determine how a model learns representation. In our 2024 ICLR](https://x.com/LiuZiyin10/status/2085770973312123128)
+    - [推荐大家读一下DeepSeek Harness开源同时发布的这个他们北大合作的Agent新论文🔥  这次他们研究的不是模型本身，而是一个可能直接关系到下一代 A](https://x.com/MaxForAI/status/2087899312462430468)
+    - [Calculus on Graphs https://arxiv.org/abs/cs/0408028](https://x.com/NetworkFact/status/2087936014467666253)
+    - [A counterexample to the Riemann Hypothesis has been found by Grok!](https://x.com/ObhishekSaha/status/2087709142408446158)
+    - [Minor correction: mathematics requires pen, paper, and roughly $1 trillion of co](https://x.com/PI010101/status/2086101453341601792)
+    - [@gtsoukal Nice result. Mapping a combinatorial problem to continuous optimisatio](https://x.com/Rythian47/status/2088335236459344105)
+    - [A comment of Richard Feynman and the Paley-Wiener Theorem. #math #physics #calcu](https://x.com/SamuelGWalters/status/2085651715769139433)
+    - [The Loss Does Not See the Basis, but Adam Does https://arxiv.org/abs/2608.05136](https://x.com/StatMLPapers/status/2085577639331270785)
+    - [何意味！！这也在你的计划中吗 OpenAI!!  Link Below ⬇️ https://x.com/SuzunamiRei/status/20885514](https://x.com/SuzunamiRei/status/2088551421360968034)
+    - [We have recently proposed a unification of the standard model and gravitation, f](https://x.com/TEJINDER_TIFR/status/1468830950511366152)
+    - [https://x.com/i/article/2086523473858547713](https://x.com/TEJINDER_TIFR/status/2086524157152665622)
+    - [It's Learning the Shape of Something Invisible 👁️✨  #neuralnetwork #abstract #to](https://x.com/TheInfinitySI/status/2085564549407928604)
+    - [@doomslide https://en.wikipedia.org/wiki/Six_nines_in_pi](https://x.com/__alpoge__/status/2087651908932735043)
+}}
+    }
+  }
+}

--- a/trees/2026-W40.tree
+++ b/trees/2026-W40.tree
@@ -1,0 +1,124 @@
+\import{macros}
+
+\title{2026-W40}
+\date{2026-09-28}
+
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/expanded{false}
+  \subtree[2026-W40-links]{
+\title{🔗}
+
+    \scope{
+      \put\transclude/expanded{true}
+\subtree[2026-09-28]{\mdnote{2026-09-28}{
+- #misc
+    - [And a much longer article by Tim Gowers &#40;Field medalist&#41; on “What sort of maths](https://x.com/__paleologo/status/2088571944346030402)
+    - [@_skarline read through this, very outdated, but maybe you will get a hint: http](https://x.com/_can1357/status/2087365419296325759)
+    - [从前，有一个叫做Tibo的养猴人。    他每天给猴子七颗栗子，这是定例，白纸黑字。   但他心情好，隔一天就往院子里多撒一把。猴子们吃得痛快，从不留余粮——反](https://x.com/akokoi1/status/2085619790933291105)
+    - [&#92;&quot;Branch-and-Price&#92;&quot; is an excellent new Springer textbook on computational mathem](https://x.com/antoniolupetti/status/2087821302916681835)
+    - [&#92;&quot;Natural Language Processing and Large Language Models&#92;&quot; is a new open-access Spr](https://x.com/antoniolupetti/status/2088536171903123457)
+    - [Yeah, they missed the mark on this one. 40&#37; of your monthly sub for a weekly res](https://x.com/benvargas/status/2088758273122128255)
+    - [i have not read this but it looks at a glance quite good: https://arxiv.org/pdf/](https://x.com/clarejtbirch/status/2085512426972418496)
+    - [Monthly reminder.   /slow mode wen? https://x.com/eidzoku/status/208598292610194](https://x.com/eidzoku/status/2085982926101946579)
+    - [this is the right approach to open source maintenance  https://blog.rust-lang.or](https://x.com/evisdrenova/status/2085794701253415281)
+    - [i bounced off @AmpCode pretty hard the first time i tried it because it was too](https://x.com/garymjr/status/2085560993426636903)
+    - [Ghostty: We just ship faster terminal to unlock more possibilities  Gloomberg: y](https://x.com/hd_nvim/status/2088443774506557471)
+    - [https://arxiv.org/abs/2608.09777 pre-triangulatedであって三角圏でない例が（AI補助で）構成されたらしいです、ヤ](https://x.com/henomoto1025/status/2087043104172134812)
+    - [@ElliotGlazer Thank you for sharing our work! I’m one of the authors. I wrote a](https://x.com/ivanswzhang/status/2087430963450282136)
+    - [Anthropic just revised their Zeta Zeros paper. Same results, now cleaned up in 1](https://x.com/jdlichtman/status/2088049852446052416)
+}}
+
+\subtree[2026-09-29]{\mdnote{2026-09-29}{
+- #misc
+    - [Ilya’s post is interesting to me because it sees explosion of papers as a moment](https://x.com/krismicinski/status/2088290279124095100)
+    - [New blog with some interesting posts! Hoping to contribute something in the next](https://x.com/mathandcobb/status/2086796542988407188)
+    - [Excited about this solution to a long-standing puzzle in Transformer theory. Via](https://x.com/mhahn29/status/2088555726880882830)
+    - [People of pi: a significant new release, 0.84.0 is out. In settings you can now](https://x.com/mitsuhiko/status/2085324285178962137)
+    - [This kind of paper detailing the harness and the human-AI interaction used in th](https://x.com/nechita_ion/status/2088631391692927410)
+    - [Nice thread. My main contribution to this literature was to advise Andre Wibison](https://x.com/npparikh/status/2086522528294445164)
+    - [💡Axiomatizing QM: Quantum Theory From Five Reasonable Axioms, &#40;2001&#41; https://arx](https://x.com/pascalkwanten/status/2087821100549845225)
+    - [Glad we can move the needle a bit on the Grothendieck constant. Our AI approach](https://x.com/praveshkkothari/status/2088278516479435091)
+    - [https://arxiv.org/abs/2608.07222  Simple scaling law formulation that considers](https://x.com/rosinality/status/2086708534989778961)
+    - [フィールズ賞の鄧煜（Yu Deng）氏の論文（ボルツマン方程式の導出：https://arxiv.org/abs/2408.07818）の内容を一次元可逆セルオ](https://x.com/takuya_fukatsu/status/2086784057334182045)
+    - [Four distinct dimensions of chaos https://x.com/techartist_/status/2064440600473](https://x.com/techartist_/status/2085602791318487290)
+    - [Similarly, here's  100&#37; version of the Riemann Hypothesis that's easy to prove:](https://x.com/thomasfbloom/status/2088661250448195752)
+    - [I would love to help, but I don’t work at Anthropic.   It does seem odd that the](https://x.com/thsottiaux/status/2086153754525712706)
+    - [That's right, GPT-5.6 Sol is awesome and can be used pretty much anywhere, inclu](https://x.com/thsottiaux/status/2086188036493344823)
+}}
+
+\subtree[2026-09-30]{\mdnote{2026-09-30}{
+- #proof
+    - #lean
+        - #os
+            - [𝐋𝐞𝐚𝐧 𝟒.𝟑𝟑.𝟎 𝐢𝐬 𝐥𝐢𝐯𝐞! This release brings 208 changes, including a more responsiv](https://x.com/leanprover/status/2086844836011995446)
+        - [Very nice piece of mathematics:  - AI run by Lech Mazur found a proof and a form](https://x.com/prz_chojecki/status/2087845605301191030)
+    - #sci
+        - [A small episode from the AI–math battlefield:  Aug 4: a paper appears on arXiv h](https://x.com/PI010101/status/2087906727874449605)
+    - [The proof is long, but basic, here is a roadmap to it https://x.com/DimitrisPapa](https://x.com/DimitrisPapail/status/2086161060298412472)
+    - [This is so cool:D Finally](https://x.com/__alpoge__/status/2086993387845271916)
+    - [I wanted to say this is vagemathing but apparently it's just how breakthroughs i](https://x.com/mitsuhiko/status/2087647496696725993)
+- #os
+    - [smol machines is different from other VMM's like firecracker with a focus on eas](https://x.com/binsquares/status/2087659344649462062)
+- #misc
+    - [@rxmphai I'll do another performative reset on Monday](https://x.com/thsottiaux/status/2086189414292865249)
+    - [Hi.  It is done.](https://x.com/thsottiaux/status/2086972802457063486)
+    - [I previously promised a reset for every 1M in additional active users for Codex,](https://x.com/thsottiaux/status/2087423996115681767)
+    - [Old news actually from a bunch of days ago, but crossed that 15M. Enjoy a nice r](https://x.com/thsottiaux/status/2087706104814023111)
+    - [Sometimes you have have to go /ultrafast.](https://x.com/thsottiaux/status/2088019704803897705)
+    - [Let's all agree that this is the correct and final eval for agi  https://jackhop](https://x.com/tobi/status/2085525088950964670)
+    - [Algorithms by Jeff Erickson - one of the best algorithm books out there.     The](https://x.com/vivekgalatage/status/2085702814886736055)
+}}
+
+\subtree[2026-10-01]{\mdnote{2026-10-01}{
+- #proof
+    - #shader
+        - #cg
+            - [More proof that maths is beautiful.  Lorenz attractor, Hopf fibration and Aizawa](https://x.com/techartist_/status/2087320660766781589)
+    - #sci
+        - [I love how mathematicians are chasing AI proofs as if proving their abstruse con](https://x.com/postdocforever/status/2087948288930840680)
+- #rust
+    - #tui
+        - [Found a task runner that changes everything!   🌀  upmd — Turn Markdown code bloc](https://x.com/orhundev/status/2087588307072909521)
+    - [Recommended reading: Anvil. The code you verify is the code you ship.  Rust + Ve](https://x.com/DominikTornow/status/2085395476774637586)
+    - [Building a distributed ledger engine in rust  So far, I have implemented an appe](https://x.com/angshuhere/status/2086040243032252487)
+- #render
+    - #tui
+        - [soo like radar charts in the TUI? jk unless? https://x.com/anderslie/status/2088](https://x.com/anderslie/status/2088526055460176187)
+- #sci
+    - [It's hard to find a proper way to introduce yourself to ∞-category, but I've fou](https://x.com/DiracGhost/status/2085858681762316415)
+    - [@nasqret @AnthropicAI @__alpoge__ Primal Riemann Hypothesis: there are infinitel](https://x.com/ElliotGlazer/status/2087283839378882755)
+    - [I wrote a pedagogical paper which will appear in American Journal of Physics in](https://x.com/InnaVishik/status/2087350723373842793)
+    - [Another day, another counterexample  https://arxiv.org/abs/2608.07805 now Kato’s](https://x.com/PI010101/status/2087250049000734961)
+    - [AI’s ranking of open problems solved in today’s arXiv list.   AI put problems co](https://x.com/PI010101/status/2088157024068456616)
+    - [i guess it is inevitable that twitter discussion of AI math results would degene](https://x.com/QiaochuYuan/status/2087611824120500660)
+    - [Even as a non-mathematician, it's easy to notice that most of the recent AI-driv](https://x.com/adi_baradwaj/status/2087659815594275109)
+    - [&#92;&quot;Beginning in Algebraic Geometry&#92;&quot; is another free open-access textbook that prov](https://x.com/antoniolupetti/status/2087589218574839971)
+}}
+
+\subtree[2026-10-02]{\mdnote{2026-10-02}{
+- #shader
+    - #game
+        - [Proof that maths is beautiful.  • Featuring Calabi–Yau-inspired geometry, a Lidi](https://x.com/techartist_/status/2086233495022514626)
+    - [animated version https://x.com/_Wienman_/status/2084792903293878659](https://x.com/_Wienman_/status/2084792903293878659)
+- #visualization
+    - [Neural sheet awakens: flat grid folds into data’s secret geometry!  SOM &#40;Kohonen](https://x.com/matheorems/status/2085432215203127412)
+- #sec
+    - [Oh my goodness…  https://eprint.iacr.org/2026/1630](https://x.com/ChrisPeikert/status/2086784394144977106)
+- #web
+    - [Recently, I tried to explain the concept of “subspace simulation” during a convo](https://x.com/Luckyballa/status/2085969860065214777)
+- #tui
+    - [amdtop is a TUI system monitor for AMD GPUs, CPUs and XDNA NPUs.  You can monito](https://x.com/terminaltrove/status/2087281347115049189)
+- #software
+    - [&#92;&quot;Geometric Deep Learning&#92;&quot; is a free book about the mathematics of geometric deep](https://x.com/antoniolupetti/status/2085293552175546814)
+- #sci
+    - [&#92;&quot;Fundamentals of Linear Algebra&#92;&quot; is an excellent 400-page textbook on linear alg](https://x.com/antoniolupetti/status/2088920907796365629)
+    - [I stumbled across this paper on arXiv today and if you’ve ever wondered why Adam](https://x.com/gurtej__gill_/status/2086020995744461106)
+    - [This sounds like a big deal, right? https://arxiv.org/abs/2608.13291](https://x.com/hanuljeon95/status/2088138694679277702)
+    - [lovely paper. dimensional analysis is very cool.  if you spend ~1 hour learning](https://x.com/mathluvr3000/status/2088663702715158899)
+    - [Today Sang-Jun Park solved the PPT^&#123;&amp;lt; ∞&#125; problem: every PPT map, composed wit](https://x.com/nechita_ion/status/2088173665548476839)
+    - [I find myself gravitating towards research into self-supervised prediction in th](https://x.com/yacinelearning/status/2085740274488098984)
+}}
+    }
+  }
+}

--- a/trees/uts-0018.tree
+++ b/trees/uts-0018.tree
@@ -16,6 +16,102 @@
 % open links in editor by Cmd+Shift+Click , but this breaks if the line is soft wrapped
 % gf can open URL in helix, might need `mimgf` sometimes
 
+\subtree[2026]{
+\title{Year 2026}
+
+\subtree[2026-09]{
+\title{September, 2026}
+
+% Post-Sep-2025 link intake: 2026-W40
+\transclude{2026-W40}
+
+% Post-Sep-2025 link intake: 2026-W39
+\transclude{2026-W39}
+
+% Post-Sep-2025 link intake: 2026-W38
+\transclude{2026-W38}
+
+% Post-Sep-2025 link intake: 2026-W37
+\transclude{2026-W37}
+
+}
+
+\subtree[2026-08]{
+\title{August, 2026}
+
+% Post-Sep-2025 link intake: 2026-W36
+\transclude{2026-W36}
+
+% Post-Sep-2025 link intake: 2026-W35
+\transclude{2026-W35}
+
+% Post-Sep-2025 link intake: 2026-W34
+\transclude{2026-W34}
+
+% Post-Sep-2025 link intake: 2026-W33
+\transclude{2026-W33}
+
+% Post-Sep-2025 link intake: 2026-W32
+\transclude{2026-W32}
+
+}
+
+\subtree[2026-07]{
+\title{July, 2026}
+
+% Post-Sep-2025 link intake: 2026-W31
+\transclude{2026-W31}
+
+% Post-Sep-2025 link intake: 2026-W30
+\transclude{2026-W30}
+
+% Post-Sep-2025 link intake: 2026-W29
+\transclude{2026-W29}
+
+% Post-Sep-2025 link intake: 2026-W28
+\transclude{2026-W28}
+
+}
+
+\subtree[2026-06]{
+\title{June, 2026}
+
+% Post-Sep-2025 link intake: 2026-W27
+\transclude{2026-W27}
+
+% Post-Sep-2025 link intake: 2026-W26
+\transclude{2026-W26}
+
+% Post-Sep-2025 link intake: 2026-W25
+\transclude{2026-W25}
+
+% Post-Sep-2025 link intake: 2026-W24
+\transclude{2026-W24}
+
+% Post-Sep-2025 link intake: 2026-W23
+\transclude{2026-W23}
+
+}
+
+\subtree[2026-05]{
+\title{May, 2026}
+
+% Post-Sep-2025 link intake: 2026-W22
+\transclude{2026-W22}
+
+% Post-Sep-2025 link intake: 2026-W21
+\transclude{2026-W21}
+
+% Post-Sep-2025 link intake: 2026-W20
+\transclude{2026-W20}
+
+% Post-Sep-2025 link intake: 2026-W19
+\transclude{2026-W19}
+
+}
+
+}
+
 \subtree[2025]{
 \title{Year 2025}
 


### PR DESCRIPTION
## Summary
- import the reviewed, baseline-deduplicated 2,197 X links into 22 flat weekly trees
- keep each weekly link collection in-file, collapsed at `🔗`, with direct expanded daily nodes
- add an idempotent importer with Forest URL/status-ID deduplication guards

## Validation
- `just check-post-sep-2025-links /Users/utensil/projects/cog-land`
- `just chk`
- `./til.py --dry-run`
- `opam exec -- forester build --no-theme`