### PR TITLE
docs(connes): regularize note hierarchy and factor-normality account

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Agent Instructions
 
-*Last updated 2026-02-04*
+*Last updated 2026-08-23*
 
 > **Purpose** – This file is the onboarding manual[^1] for every AI assistant (Claude, Amp, Codex, Amazon Q, OpenCode, etc.) and every human who edits this repository.
 > It encodes our coding standards, guard-rails, and workflow tricks so the *human 30 %*[^2] (architecture, tests, domain judgment) stays in human hands.
@@ -47,6 +47,12 @@ ALWAYS cite the rules which have been actually followed during the reply at the 
 
 - ✅ **Should**: After editing files, before pausing and asking for further instructions, commit changes to version control system. ALWAYS commit per section "Commit discipline" below. ALL commits MUST include [AGENT] tag.
 - ❌ **Must NOT**: Commit files that are not directly related to current task. Only commit files intentionally modified as part of the specific work requested. Do not commit unrelated changes, even if they exist in working directory.
+
+### G-notes: Keep note suites structurally coherent
+
+- ✅ **Should**: For every note suite whose root is tagged both `math` and `notes`, preserve stable tree addresses, keep each hierarchy level uniform, use stable cross-references, and inspect the rendered result as described in "Note-suite discipline" below.
+- ✅ **Should**: Flag existing violations; refactors whose purpose is to bring existing suites into compliance require a human-gated PR.
+- ❌ **Must NOT**: Mix section or subsection trees with taxon cards as siblings under one parent tree.
 
 ### G-task: Follow backlog workflow for structured tasks
 
@@ -145,7 +151,17 @@ Disciplines for humans:
 
 *   **Review AI-generated code**: Never merge code you don't understand.
 
-## 4. Writing task automation scripts
+## 4. Note-suite discipline
+
+- **Scope**: These rules apply to every note suite whose root is tagged both `math` and `notes`, including draft and agent-draft suites. New or edited suite content must follow them. Report existing violations, but do not refactor an existing suite solely for compliance without a human-gated PR.
+- **Use stable addressed structure**: A suite root transcludes addressed top-level section trees. Give any reader-facing section or subsection that may be linked or moved its own tree address. Use anonymous subtrees only for deliberately local, unstable subdivisions.
+- **Keep each level homogeneous**: A parent tree may transclude either titled section or subsection trees, or taxon cards, never both. If it has subsection children, every child at that level must be a subsection. Only a leaf section, with no subsection children, may directly transclude taxon cards.
+- **Separate discussion from statements**: Definitions, lemmas, theorems, proofs, examples, and genuine mathematical remarks may be taxon cards. Put expository, design, and implementation discussion in titled non-taxon section trees. When both belong under one larger section, give the statement its own leaf subsection; do not place a taxon card beside a discussion tree.
+- **Keep internal references stable**: Link to tree addresses rather than writing rendered section numbers. Do not add reciprocal `related` links for transclusions; they duplicate the suite graph and backmatter.
+- **Mark agent-authored trees**: Every agent-authored tree in a suite must carry `\meta{agent-authored}{true}` so the public badge and draft queries remain accurate.
+- **Check the rendered hierarchy**: Build both the site and the PDF, then inspect the table of contents, heading and taxon numbering, transclusion order, and Related or Backlinks panels.
+
+## 5. Writing task automation scripts
 
 When implementing complex data processing or automation tasks, create standalone Python scripts that integrate with the project workflow.
 
@@ -217,7 +233,7 @@ just build
 
 ---
 
-## 5. Meta: Guidelines for updating AGENT.md files
+## 6. Meta: Guidelines for updating AGENT.md files
 
 This file should be updated when:
 - New major features or tools are added to the project

--- a/trees/connes-0007.tree
+++ b/trees/connes-0007.tree
@@ -24,9 +24,10 @@ the other, and #{U\delta_e=\delta_e}.}
 \leanref/connes{Connes.FactorWitness.tracialEquiv_of_spatialWitness}
 restricts unitary conjugation to the two group von Neumann algebras.
 \leanref/connes{Connes.StarAlgEquiv.isNormal}
-proves that the induced star-algebra equivalence is normal, and the equation
-#{U\delta_e=\delta_e} proves that it preserves the canonical trace. These facts
-are proved from the spatial unitary rather than supplied as extra assumptions.}
+records the automatic preservation of projection suprema by the induced
+star-algebra equivalence and its inverse. The equation #{U\delta_e=\delta_e}
+proves preservation of the canonical trace. Neither property is supplied as an
+extra assumption.}
 
 \p{For Zhou's groups, the concrete unitary composes the two Fourier models with
 the fiber shear. The measure-transport and von Neumann closure obligations are
@@ -36,4 +37,4 @@ separated in \ref{connes-000D} and \ref{connes-000E}. Together they construct
 \leanref/connes{Connes.PaperFactorClosure.paperGroupFactors_isomorphic}.
 This is the #{*}-isomorphism asserted in
 \citet{Proposition 3.4}{zhou2026icc}; the Lean statement also records its
-normality and preservation of the canonical trace.}
+projection-supremum preservation and preservation of the canonical trace.}

--- a/trees/connes-000K.tree
+++ b/trees/connes-000K.tree
@@ -80,7 +80,8 @@ require special design:}
 \ul{
   \li{the square-span certificate implemented in \ref{connes-000U};}
   \li{the Fourier-shear proof of factor equivalence: its unitary
-  implementation in \ref{connes-0007}, its normality proof in
+  implementation in \ref{connes-0007}, its automatic projection-order
+  transport in
   \ref{connes-001C}, the four conjugation identities in \ref{connes-001D},
   and the measure and closure arguments in \ref{connes-000D} and
   \ref{connes-000E};}

--- a/trees/connes-0011.tree
+++ b/trees/connes-0011.tree
@@ -6,6 +6,5 @@
 \tag{notes}
 \title{Characteristic-two tensor kernel (Zhou §2)}
 
-\transclude{connes-000C}
+\transclude{connes-001E}
 \transclude{connes-000U}
-

--- a/trees/connes-0012.tree
+++ b/trees/connes-0012.tree
@@ -6,7 +6,6 @@
 \tag{notes}
 \title{Factor equivalence by Fourier shear (Zhou §3)}
 
-\transclude{connes-0007}
+\transclude{connes-001F}
 \transclude{connes-000D}
 \transclude{connes-000E}
-

--- a/trees/connes-0013.tree
+++ b/trees/connes-0013.tree
@@ -6,10 +6,9 @@
 \tag{notes}
 \title{Property (T) by spectral transfer (Zhou §4)}
 
-\transclude{connes-0003}
+\transclude{connes-001G}
 \transclude{connes-000V}
-\transclude{connes-0004}
+\transclude{connes-001H}
 \transclude{connes-000Y}
-\transclude{connes-0005}
+\transclude{connes-001I}
 \transclude{connes-000W}
-

--- a/trees/connes-0014.tree
+++ b/trees/connes-0014.tree
@@ -6,6 +6,5 @@
 \tag{notes}
 \title{ICC by orbit displacement (Zhou §5)}
 
-\transclude{connes-0006}
+\transclude{connes-001J}
 \transclude{connes-000X}
-

--- a/trees/connes-0015.tree
+++ b/trees/connes-0015.tree
@@ -6,6 +6,5 @@
 \tag{notes}
 \title{Nonisomorphism by characteristic modules (Zhou §6)}
 
-\transclude{connes-0008}
+\transclude{connes-001K}
 \transclude{connes-000H}
-

--- a/trees/connes-0016.tree
+++ b/trees/connes-0016.tree
@@ -7,5 +7,4 @@
 \title{Theorem assembly and trust boundary (Zhou §7)}
 
 \transclude{connes-0002}
-\transclude{connes-0009}
-
+\transclude{connes-001L}

--- a/trees/connes-001C.tree
+++ b/trees/connes-001C.tree
@@ -10,9 +10,11 @@
 
 \p{Zhou's Proposition 3.4 identifies the two group factors by combining
 Fourier transform with the fiber shear
-\citet{Proposition 3.4}{zhou2026icc}. In Lean, the resulting star-algebra
-equivalence must also be proved normal. The formalization expresses this by
-requiring the equivalence and its inverse to preserve suprema of projections.}
+\citet{Proposition 3.4}{zhou2026icc}. The Lean development records two
+properties of the resulting star-algebra equivalence explicitly. Preservation
+of projection suprema in both directions follows automatically from the
+star-algebra equivalence between these concrete operator subalgebras, while
+preservation of the canonical trace is proved from the spatial unitary.}
 
 \p{The definition
 \leanref/connes{Connes.IsProjectionSupremum}

--- a/trees/connes-001E.tree
+++ b/trees/connes-001E.tree
@@ -4,6 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{notes}
-\title{Characteristic-two retraction}
+\title{Tensor retraction in characteristic two}
 
 \transclude{connes-000C}

--- a/trees/connes-001E.tree
+++ b/trees/connes-001E.tree
@@ -1,0 +1,9 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Characteristic-two retraction}
+
+\transclude{connes-000C}

--- a/trees/connes-001F.tree
+++ b/trees/connes-001F.tree
@@ -1,0 +1,9 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Spatial factor equivalence}
+
+\transclude{connes-0007}

--- a/trees/connes-001G.tree
+++ b/trees/connes-001G.tree
@@ -1,0 +1,9 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Property-(T) interface}
+
+\transclude{connes-0003}

--- a/trees/connes-001G.tree
+++ b/trees/connes-001G.tree
@@ -4,6 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{notes}
-\title{Property-(T) interface}
+\title{Qualitative property (T)}
 
 \transclude{connes-0003}

--- a/trees/connes-001H.tree
+++ b/trees/connes-001H.tree
@@ -4,6 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{notes}
-\title{Spectral transfer}
+\title{Spectral criterion for split abelian extensions}
 
 \transclude{connes-0004}

--- a/trees/connes-001H.tree
+++ b/trees/connes-001H.tree
@@ -1,0 +1,9 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Spectral transfer}
+
+\transclude{connes-0004}

--- a/trees/connes-001I.tree
+++ b/trees/connes-001I.tree
@@ -4,6 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{notes}
-\title{Elementary generation and transport}
+\title{Elementary generation of SL₃}
 
 \transclude{connes-0005}

--- a/trees/connes-001I.tree
+++ b/trees/connes-001I.tree
@@ -1,0 +1,9 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Elementary generation and transport}
+
+\transclude{connes-0005}

--- a/trees/connes-001J.tree
+++ b/trees/connes-001J.tree
@@ -1,0 +1,9 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{ICC criterion}
+
+\transclude{connes-0006}

--- a/trees/connes-001K.tree
+++ b/trees/connes-001K.tree
@@ -1,0 +1,9 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Characteristic-module obstruction}
+
+\transclude{connes-0008}

--- a/trees/connes-001L.tree
+++ b/trees/connes-001L.tree
@@ -4,6 +4,6 @@
 \tag{connes}
 \tag{lean}
 \tag{notes}
-\title{Final theorem}
+\title{Theorem A}
 
 \transclude{connes-0009}

--- a/trees/connes-001L.tree
+++ b/trees/connes-001L.tree
@@ -1,0 +1,9 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Final theorem}
+
+\transclude{connes-0009}


### PR DESCRIPTION
## Summary

- place eight mathematical statements in addressed leaf subsections so no Connes section mixes taxon cards with section siblings
- clarify that projection-supremum preservation is automatic for the concrete star-algebra equivalence, while trace preservation comes from the spatial unitary
- add the scoped `G-notes` discipline for note suites whose roots carry both `math` and `notes`

The hierarchy keeps Zhou Sections 2–7 in order. In the rendered note, each affected statement now appears inside an explicitly numbered subsection, such as §3.1 followed by Theorem 3.1.1, before §3.2.

## Verification

- `just chk`
- `just build`
- `./lize.sh connes-0001`
- all Connes transclusion levels checked for homogeneous section or taxon children
- 29-page PDF checked for heading order, taxon numbering, unresolved references, and overfull boxes
- affected pages visually inspected
- exact `utensil` author and committer identity checked on all three commits
- public metadata and privacy scan passed

This PR is human-gated. Auto-merge is not enabled.
