### PR TITLE
docs(connes): synchronize refactor and Comparator notes

### DIFF
--- a/trees/connes-0001.tree
+++ b/trees/connes-0001.tree
@@ -21,6 +21,7 @@
 \transclude{connes-0015}
 \transclude{connes-0016}
 \transclude{connes-0017}
+\transclude{connes-001M}
 \transclude{connes-0018}
 \transclude{connes-0019}
 \transclude{connes-001A}

--- a/trees/connes-000A.tree
+++ b/trees/connes-000A.tree
@@ -36,6 +36,31 @@ small structures. This prevents an exhaustive certificate, coordinate
 calculation, or normalization choice from contaminating a generic transfer
 theorem.}
 
+\p{\strong{Index shared structure by the action.}
+Zhou's two groups have the same abelian kernel and acting group, but different
+actions \citet{Sections 2–5}{zhou2026icc}. Lean therefore defines their common
+semidirect-product carrier through
+\leanref/connes/as{paperGammaOf}{Connes.Construction.PaperKernel.paperGammaOf}, then indexes the
+split extension
+\leanref/connes/as{lambdaExtension}{Connes.PaperSplitExtensions.lambdaExtension}, finite extension
+\leanref/connes/as{finiteExtension}{Connes.PaperFiniteExtensions.finiteExtension}, spectral data
+\leanref/connes/as{SpectralData}{Connes.PaperSpectralPropertyT.SpectralData}, and ICC data
+\leanref/connes/as{ActionData}{Connes.PaperICC.ActionData} by the chosen action. The final
+theorems for the two groups specialize these definitions to the two concrete
+actions. The actions and their finite certificates remain distinct, while the
+shared structural arguments are proved once.}
+
+\p{\strong{Keep the bicommutant boundary visible.}
+The group von Neumann algebra in Zhou's factor comparison is the bicommutant
+of the left regular operators \citet{Section 3 and Proposition 3.4}{zhou2026icc}.
+The definition \leanref/connes{Connes.vonNeumannClosure} still expresses that
+same bicommutant. Its Lean implementation now bundles the first
+\leanref{StarSubalgebra.centralizer} as a von Neumann algebra and applies
+\leanref{VonNeumannAlgebra.commutant} for the outer commutant. This removes a
+duplicated proof of the outer commutant's double-commutant condition; it does
+not replace the bicommutant by a topological closure or change the mathematical
+boundary.}
+
 \p{\strong{State the direct consumer boundary.}
 The external theorem is requested as property (T) of the elementary group,
 not as a stronger numerical constant. The factor bridge asks for a spatial

--- a/trees/connes-000G.tree
+++ b/trees/connes-000G.tree
@@ -9,8 +9,8 @@
 \lean{SimpleGraph.lapMatrix,SimpleGraph.posSemidef_lapMatrix}
 
 \p{The pinned Connes project uses Mathlib revision
-\href{https://github.com/leanprover-community/mathlib4/commit/062f1e3da80734a1b911a5c541d78612faf41b99}{\code{062f1e3d}}
-with Lean 4.34.0-rc1. Mathlib supplies the graph Laplacian and its positivity
+\href{https://github.com/leanprover-community/mathlib4/commit/c2d7843e04aa6cc44fa7e2b39422f24f7b725f00}{\code{c2d7843e}}
+with Lean 4.34.0-rc2. Mathlib supplies the graph Laplacian and its positivity
 theorem, exposed by the declaration links above, but not the
 Ershov–Jaikin-Zapirain graph-of-groups criterion, Kazhdan ratios, root
 gradings, codistance, or the graph argument.}
@@ -24,13 +24,16 @@ earlier quantitative development
 \citet{Sections 2–6 and Appendix A}{ershov2010noncommutative}.}
 
 \p{TauCeti at revision
-\href{https://github.com/TauCetiProject/TauCeti/commit/cc6ce758421ce3a0731ff62667b7771cfc4aa3da}{\code{cc6ce75}}
-uses Mathlib \href{https://github.com/leanprover-community/mathlib4/commit/de5ce8a9a66a4aa68a9bdbb35b63a06d34d9ca11}{\code{de5ce8a}}
+\href{https://github.com/TauCetiProject/TauCeti/commit/ac3bfb327df223b5346aabe64a89270266ebd918}{\code{ac3bfb3}}
+uses Mathlib \href{https://github.com/leanprover-community/mathlib4/commit/ac1b4db285bd145ce111b9ad357b99b1126a438a}{\code{ac1b4db}}
 and Lean 4.34.0-rc1. Its
-\href{https://github.com/TauCetiProject/TauCeti/blob/cc6ce758421ce3a0731ff62667b7771cfc4aa3da/TauCeti/LowDimTopology/Plumbing/DiagonalDominance.lean#L73-L74}{diagonal-dominance proof}
+\href{https://github.com/TauCetiProject/TauCeti/blob/ac3bfb327df223b5346aabe64a89270266ebd918/TauCeti/LowDimTopology/Plumbing/DiagonalDominance.lean#L74-L75}{diagonal-dominance proof}
 consumes the same Mathlib Laplacian facts.}
 
 \p{Its source and roadmap contain no
-direct property-(T), Kazhdan, codistance, root-graded, or magic-graph lane. It
-is therefore not a drop-in dependency for this boundary; aligning project pins
-would not reduce the missing mathematics.}
+direct property (T), Kazhdan, codistance, root-graded-group, or magic-graph
+lane. Recent
+\href{https://github.com/TauCetiProject/TauCeti/blob/ac3bfb327df223b5346aabe64a89270266ebd918/TauCeti/Algebra/AlgebraicGroup/GeneralLinear/Adjoint/RootSpace.lean}{algebraic-group root-space additions}
+do not supply the root-graded-group criterion used by EJK. TauCeti is therefore
+not a drop-in dependency for this boundary; aligning project pins would not
+reduce the missing mathematics.}

--- a/trees/connes-000K.tree
+++ b/trees/connes-000K.tree
@@ -136,9 +136,11 @@ remaining EJZK work is scoped in \ref{connes-000B}, \ref{connes-000G}, and
 background, three motivations, and design. Sections 2–7 correspond respectively
 to Zhou's Sections 2–7; their headings record that correspondence without
 reusing Zhou's section number as the note title. Section 8 collects
-proof-engineering adaptations, Sections 9–10 compare the other two proof
-architectures, Section 11 scopes the remaining EJZK formalization, and Section
-12 records the human–agent contribution and review workflow.}
+proof-engineering adaptations. The challenge and its verification role are
+described in \ref{connes-001M}; \ref{connes-0018} and \ref{connes-0019}
+compare the other two proof architectures; \ref{connes-001A} scopes the
+remaining EJZK formalization; and \ref{connes-001B} records the human–agent
+contribution and review workflow.}
 
 \p{The formalization adapts selected public Lean proof blocks and organization
 patterns from a

--- a/trees/connes-000L.tree
+++ b/trees/connes-000L.tree
@@ -43,7 +43,7 @@ The converse is nontrivial and is not part of the present interface.}
 }
 
 \p{The pinned
-\href{https://github.com/leanprover-community/mathlib4/commit/062f1e3da80734a1b911a5c541d78612faf41b99}{Mathlib}
+\href{https://github.com/leanprover-community/mathlib4/commit/c2d7843e04aa6cc44fa7e2b39422f24f7b725f00}{Mathlib}
 already contains separability of spans
 (\leanref{TopologicalSpace.IsSeparable.span}), separability of closures
 (\leanref{TopologicalSpace.IsSeparable.closure}), completeness of closed spans
@@ -51,7 +51,7 @@ already contains separability of spans
 and Hilbert-basis existence (\leanref{exists_hilbertBasis}).}
 
 \p{At the pinned
-\href{https://github.com/TauCetiProject/TauCeti/commit/cc6ce758421ce3a0731ff62667b7771cfc4aa3da}{TauCeti}
+\href{https://github.com/TauCetiProject/TauCeti/commit/ac3bfb327df223b5346aabe64a89270266ebd918}{TauCeti}
 revision, the continuous-representation library provides invariant restriction
 (\leanref/tauceti{TauCeti.ContRepresentation.subrepresentation}), unitarity
 under restriction
@@ -61,7 +61,7 @@ transport along an isometry
 
 \p{Its compact-group lane also standardizes finite-dimensional carriers
 (\leanref/tauceti{TauCeti.IrrepModel}) by an orthonormal basis, following the explicit
-\href{https://github.com/TauCetiProject/TauCetiRoadmap/blob/a7a221a1954ad303610de07179e3af5a8832f679/TauCetiRoadmap/RepresentationTheory/CompactGroups/Suggested.lean#L278-L294}{finite-dimensional universe convention}
+\href{https://github.com/TauCetiProject/TauCetiRoadmap/blob/85038d4b007ae9c16f7bad22e1cee14bb962104c/TauCetiRoadmap/RepresentationTheory/CompactGroups/Suggested.lean#L264-L284}{finite-dimensional universe convention}
 in its roadmap.}
 
 \p{Neither pinned codebase assembles the countable invariant span, gives its

--- a/trees/connes-000R.tree
+++ b/trees/connes-000R.tree
@@ -39,17 +39,34 @@ and exposition project. The division of work was concrete.}
   diagrams, cross-references, navigation, privacy, and publication wording.}
 }
 
+\p{\strong{Human direction in recent refactoring}}
+
+\ul{
+  \li{requested repeated searches against the pinned Mathlib API, simplification
+  of the challenge, and proof golf while preserving the exact theorem contract;}
+  \li{treated heartbeat overrides as performance and refactor signals, required
+  measured thresholds, and requested review of overlapping APIs and preparation
+  of the Palomar metadata; and}
+  \li{required the companion notes to track the Lean changes and identified
+  \leanref/connes{Connes.vonNeumannClosure} by manual inspection as a remaining
+  simplification candidate.}
+}
+
 \p{\strong{Agent implementation and review}}
 
 \ul{
   \li{reconciled the literature and public Lean sources, adapted attributed
   proof blocks, implemented the Lean development, and refactored its public
   interfaces;}
-  \li{ran literature, consumer-contract, provenance, semantic, and Tau Ceti
-  reviews; built the Comparator, documentation, and rendering infrastructure;
-  and repaired the resulting findings; and}
-  \li{drafted and revised the mathematical notes, diagrams, comparisons, and
-  formalization estimates under the human-specified structure and constraints.}
+  \li{implemented the resulting Mathlib reuse, action-indexed definitions,
+  challenge and proof golf, measured heartbeat cleanup, and bicommutant
+  simplification;}
+  \li{ran full builds, Linux Comparator and nanoda checks, Lean-kernel replay,
+  and clean-room reviews; reconciled the changes with the literature and public
+  source; and repaired the resulting findings; and}
+  \li{prepared the Palomar metadata and public documentation, then synchronized
+  the mathematical notes, diagrams, comparisons, and formalization estimates
+  under the human-specified structure and constraints.}
 }
 
 \p{The working cycle was: human proof and review contract

--- a/trees/connes-001M.tree
+++ b/trees/connes-001M.tree
@@ -1,0 +1,109 @@
+\import{spin-macros}
+\meta{agent-authored}{true}
+
+\tag{connes}
+\tag{lean}
+\tag{notes}
+\title{Comparator challenge and auditability}
+
+\p{The Comparator challenge is an independent statement file, not a second
+formalization of Zhou's proof. Its purpose is to make the theorem small enough
+that a reader familiar with the mathematics and Lean can inspect the
+definitions, compare them with Zhou's Sections 3–7, and check that the solution
+proves the same statement \citet{Sections 3–7}{zhou2026icc}. It therefore
+uses the following design criterion: define no more vocabulary than is needed
+to state Theorem A. General notions should come from Mathlib when its
+definitions have the required meaning; a genuinely general local construction
+is a candidate for upstreaming rather than permanent duplication. The
+\href{https://github.com/utensil/connes-rigidity/blob/dc63c594d950753a239d5d097f38c19e79349dd0/ComparatorChallenges/F_ConnesZhou.lean}{self-contained challenge at the synchronized commit}
+is the file to inspect. The declaration links below point to the mirrored
+solution-side declarations, which have the same public contracts and are
+rendered by doc-gen4.}
+
+\p{The declarations in that file divide into four groups.}
+
+\ul{
+  \li{\strong{Mathematical-domain foundation.}
+  \leanref/connes/as{groups}{Connes.CountableDiscreteGroup},
+  \leanref/connes/as{ICC}{Connes.IsICC},
+  \leanref/connes/as{representations}{Connes.UnitaryRepresentation}, their invariant and
+  almost-invariant vector predicates, and
+  \href{https://utensil.github.io/connes-rigidity/docs/find/#doc/Connes.HasKazhdanPropertyT}{property (T)}
+  state the group-theoretic side.
+  The operator-algebraic side starts from
+  \leanref/connes/as{ℓ²}{Connes.GroupL2}. It comprises the
+  \leanref/connes/as{bicommutant}{Connes.vonNeumannClosure}, the
+  \leanref/connes/as{algebra}{Connes.groupVonNeumannAlgebra} and its
+  \leanref/connes/as{carrier}{Connes.GroupVonNeumannAlgebra}, the
+  \href{https://utensil.github.io/connes-rigidity/docs/find/#doc/Connes.delta}{point mass}, the
+  \leanref/connes/as{trace}{Connes.canonicalTrace}, and the
+  \leanref/connes/as{witness}{Connes.TracialGroupFactorEquiv}.
+  The witness combines a star-algebra equivalence,
+  trace preservation, and normality. The
+  \leanref/connes/as{normality}{Connes.IsNormalStarAlgEquiv}
+  predicate defines normality by preservation of
+  \leanref/connes/as{suprema}{Connes.IsProjectionSupremum} in both directions.
+  The predicate \leanref/connes/as{isomorphism}{Connes.TracialGroupFactorsIsomorphic}
+  asks only for a nonempty equivalence structure. These definitions support
+  the factor-isomorphism proposition in the conclusion, using Mathlib's
+  conjugacy classes, unitary operators, star subalgebras, and von Neumann
+  algebras underneath.}
+
+  \li{\strong{Theorem-specific data.}
+  The abbreviations #{\mathbb F_2}, #{\mathbb F_2[t]}, and
+  #{\mathrm{SL}_3(\mathbb F_2[t])}, together with their inferred countability
+  instances, fix the coefficient ring and ambient matrix group.
+  The \leanref/connes/as{subgroup}{Connes.SpecialLinear.elementarySubgroup} and
+  \href{https://utensil.github.io/connes-rigidity/docs/find/#doc/Connes.PaperPropertyT.elementaryGroup}{EJZK group}
+  declarations name the exact
+  #{EL_3(\mathbb F_2[t])} premise from Zhou's Proposition 4.1. The declaration
+  \leanref/connes{Connes.theoremA} then states property (T) and ICC for both
+  groups, factor equivalence, and nonisomorphism from Zhou's Theorem A.}
+
+  \li{\strong{Paper-shape adaptation and transport.}
+  \leanref/connes/as{membership}{Connes.memℓp_reindex},
+  \leanref/connes/as{reindexing}{Connes.l2Reindex}, and
+  \leanref/connes/as{unitaries}{Connes.leftRegularUnitary} build
+  the operators, while
+  \leanref/connes/as{representation}{Connes.leftRegularRepresentation} turns Mathlib's general
+  #{\ell^p} carrier into the left regular #{\ell^2(G)} model used in Section 3.
+  The polynomial countability proof similarly transports an existing
+  countability instance across Mathlib's polynomial–finitely-supported-function
+  equivalence. These declarations adapt library representations; they add no
+  hypothesis to Theorem A.}
+
+  \li{\strong{Verification boundary.}
+  The challenge imports Mathlib, not the solution, and leaves only the body of
+  \leanref/connes{Connes.theoremA} unspecified. Comparator compares its
+  elaborated statement and definition closure with the solution, checks the
+  permitted axiom set, and replays the exported proof with the Lean kernel and
+  nanoda. This checks technical identity and proof acceptance. Literature
+  fidelity and the correctness of the mathematical definitions remain
+  separate review questions.}
+}
+
+\p{Recent simplifications illustrate the design. The reindexing proof now
+shares \leanref/connes{Connes.memℓp_reindex} between its forward and inverse
+maps. It keeps the two pointwise action laws in
+\leanref/connes{Connes.leftRegularRepresentation}, since they fix the
+left-action convention used in \citet{Section 3}{zhou2026icc}.}
+
+\p{Mathlib now supplies the conjugacy-class operation, the centralizer star
+subalgebra, and the commutant of a von Neumann algebra. The challenge reuses
+those APIs. In particular, \leanref/connes{Connes.vonNeumannClosure} remains
+Zhou's bicommutant construction, but its implementation can form the first
+\leanref{StarSubalgebra.centralizer} and then apply
+\leanref{VonNeumannAlgebra.commutant}; no separate proof of the outer
+commutant's double-commutant condition is needed.}
+
+\p{The concrete elementary subgroup and explicit EJZK premise are
+theorem-specific and should remain near the challenge. The trace-preserving
+factor witness is local statement vocabulary chosen to match Theorem A; it
+should remain local unless Mathlib adopts the same contract. By contrast, an
+arbitrary-index #{\ell^2} reindexing linear isometry and a bundled left regular
+unitary representation are genuinely general and plausible Mathlib
+contributions: the present library has the ingredients but no direct API with
+these contracts. If those are upstreamed, the reindexing lemma and the two
+action-law proofs can disappear from the challenge. Without that library API,
+further proof compression would mainly conceal the chosen
+left-action convention rather than remove mathematics.}


### PR DESCRIPTION
## Summary

- explain the action-indexed construction shared by Zhou's two groups and the simplified bicommutant implementation
- add an addressed Comparator section between the formalization adaptations and proof-family comparisons
- classify the challenge declarations by mathematical foundation, theorem-specific data, library adaptation, and verification role
- distinguish existing Mathlib reuse, local statement contracts, and evidence-backed upstream candidates
- refresh the exact Connes, Mathlib, Lean, TauCeti, and TauCetiRoadmap snapshots and replace shifted section numbers with stable references
- update the AI-use disclosure with concrete human direction and agent implementation, verification, and note-synchronization work from the recent refactor cycle

## Grounding

The mathematical claims remain tied to Zhou Sections 2–7. Implementation claims link the exact Connes refactor head and stable doc-gen4 declaration pages. The TauCeti outlook was rechecked against current public source and roadmap revisions. The section treats Comparator as technical statement/proof verification, not as a substitute for literature fidelity or mathematical review.

## Verification

- just chk
- exact-source Forester build with the repository TeX input path
- 31-page A4 PDF build
- no overfull boxes, unresolved references, undefined citations, or fatal LaTeX errors
- visual inspection of the changed design, Comparator, infrastructure, universe-boundary, and disclosure pages
- public URL, declaration-target, commit-identity, and privacy scans

This PR is human-gated. Auto-merge is disabled.