### PR TITLE
docs(ftip): add finite consequences and obstructions

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -25,15 +25,17 @@ a broader capability. A claim must name the base artifact, training procedure,
 feedback source, resource budget, inference procedure, and independent
 evaluation law.}
 
-\p{This version develops the background needed to state that question. It
-starts with text probabilities and decoder-only Transformer architecture,
+\p{This version develops the background needed to state that question and
+begins with finite consequences of the resulting setup. It starts with text
+probabilities and decoder-only Transformer architecture,
 then introduces pretraining and the task--environment interface. Fine-tuning
 and instruction tuning receive separate sections. Later sections distinguish
 preference modeling from reinforcement learning (RL), then examine alignment
 training as a declared role. Concrete routes include reinforcement learning
 from human feedback (RLHF), Direct Preference Optimization (DPO), and
 reinforcement learning with verifiable rewards (RLVR). The final sections
-formulate costed evaluation questions and finite falsifiers.}
+formulate costed evaluation questions, finite falsifiers, and the first proved
+finite statements.}
 
 \p{The RLVR route begins with DeepSeekMath
 \citef{shao2024deepseekmath} and DeepSeek-R1
@@ -64,3 +66,4 @@ that combination.}
 \transclude{ftip-004Y}
 \transclude{ftip-005C}
 \transclude{ftip-005T}
+\transclude{ftip-0075}

--- a/trees/ftip-0075.tree
+++ b/trees/ftip-0075.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Finite consequences and obstructions}
+\tag{ftip}
+\tag{research-programme}
+
+\p{This section turns parts of the preceding setup into finite mathematical
+statements. The results concern declared probability spaces, finite decision
+sets, recorded feedback, or explicitly stated matrix models. They do not by
+themselves establish a scaling law for language-model capability.}
+
+\p{Four status descriptions are used. A \strong{source reconstruction}
+restates a named result with its source assumptions. An \strong{FTIP-proved}
+statement is derived in these notes from the displayed finite setup. A
+\strong{finite counterexample} exhibits a concrete obstruction. An
+\strong{open direction} records a target whose assumptions or proof are not
+yet supplied.}
+
+\p{We begin with discovery and support, then study proxy rewards and
+verifiers. The third subsection asks what can be learned
+from a fixed feedback transcript. The last subsection reconstructs the
+available DGG inequalities before introducing trajectory-compression
+diagnostics and counterexamples.}
+
+\transclude{ftip-0076}
+\transclude{ftip-007F}
+\transclude{ftip-007P}
+\transclude{ftip-007Y}

--- a/trees/ftip-0076.tree
+++ b/trees/ftip-0076.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Finite discovery and support}
+\tag{ftip}
+\tag{support}
+
+\p{A successful continuation can have positive probability and still be
+difficult to observe within a finite rollout budget. This subsection separates
+the probability of observing a success from support, coverage, and capability
+acquisition.}
+
+\transclude{ftip-0077}
+\transclude{ftip-0078}
+\transclude{ftip-0079}
+\transclude{ftip-007A}
+\transclude{ftip-007B}
+\transclude{ftip-007C}
+\transclude{ftip-007D}
+\transclude{ftip-007E}

--- a/trees/ftip-0077.tree
+++ b/trees/ftip-0077.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Convention}
+\title{Repeated attempts and the discovery event}
+\tag{ftip}
+\tag{probability}
+\tag{rollout}
+
+\p{Fix a task instance, evaluator, success threshold, and a joint law for
+#{B\geq1} attempts. Let #{E_i} be the event that attempt #{i} succeeds. The
+\newvocab{discovery event} by attempt #{B} is}
+
+##{
+ D_B=\bigcup_{i=1}^{B}E_i.
+}
+
+\p{Write #{p_i=\Pr(E_i)}. Independence is an additional property of the
+declared joint law; it is not implied by repeated decoding, a shared model, or
+a common environment. In the independent and identically distributed case,
+write #{p_i=p}. When the attempt law is the one fixed in
+\ref{ftip-005U}, this #{p} is the corresponding successful-support
+probability.}

--- a/trees/ftip-0078.tree
+++ b/trees/ftip-0078.tree
@@ -1,0 +1,32 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Discovery under independent attempts}
+\tag{ftip}
+\tag{probability}
+\tag{rollout}
+
+\p{Assume the events #{E_1,\ldots,E_B} of \ref{ftip-0077} are independent.
+Then}
+
+##{
+ \Pr(D_B)=1-\prod_{i=1}^{B}(1-p_i).
+}
+
+\p{In particular, independent attempts with a common success probability
+#{p} satisfy}
+
+##{
+ \Pr(D_B)=1-(1-p)^B.
+}
+
+\proof{
+\p{The complement of discovery is
+#{D_B^{\mathsf c}=\bigcap_{i=1}^{B}E_i^{\mathsf c}}. Independence gives
+#{\Pr(D_B^{\mathsf c})=\prod_i\Pr(E_i^{\mathsf c})
+=\prod_i(1-p_i)}. Taking complements proves the first identity; substituting
+#{p_i=p} proves the specialization.}}
+
+\p{This is an FTIP-proved finite statement. The calculation in
+\ref{ftip-0067} is its ten-attempt numerical preview.}

--- a/trees/ftip-0079.tree
+++ b/trees/ftip-0079.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{A rollout budget for target discovery probability}
+\tag{ftip}
+\tag{probability}
+\tag{rollout}
+
+\p{This is an FTIP-proved corollary of \ref{ftip-0078}.}
+
+\p{Let #{0<\delta<1}. Under the independent and identically distributed
+setup of \ref{ftip-0078}, suppose first that #{0<p<1}. The least positive
+integer budget whose discovery failure probability is at most #{\delta} is}
+
+##{
+ B_{\min}
+ =\left\lceil\frac{\log\delta}{\log(1-p)}\right\rceil.
+}
+
+\p{If #{p=0}, no finite positive budget reaches failure probability below
+one. If #{p=1}, one attempt suffices.}
+
+\proof{
+\p{For #{0<p<1}, \ref{ftip-0078} gives failure probability #{(1-p)^B}.
+The inequality #{(1-p)^B\leq\delta} is equivalent to
+#{B\geq\frac{\log\delta}{\log(1-p)}} because both logarithms are negative. The least
+integer solution is the displayed ceiling. The two boundary cases follow
+directly from #{(1-p)^B}.}}

--- a/trees/ftip-007A.tree
+++ b/trees/ftip-007A.tree
@@ -1,0 +1,42 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Lemma}
+\title{Discovery bounds from conditional success rates}
+\tag{ftip}
+\tag{probability}
+\tag{rollout}
+
+\p{Put #{D_0=\varnothing}. Whenever
+#{\Pr(D_{i-1}^{\mathsf c})>0}, define the surviving conditional success rate}
+
+##{
+ q_i=\Pr(E_i\mid D_{i-1}^{\mathsf c}).
+}
+
+\p{If these rates are defined through step #{B}, then}
+
+##{
+ \Pr(D_B^{\mathsf c})=\prod_{i=1}^{B}(1-q_i).
+}
+
+\p{Consequently, if
+#{0\leq\underline q\leq q_i\leq\overline q\leq1} for every surviving
+step, then}
+
+##{
+ 1-(1-\underline q)^B
+ \leq \Pr(D_B)
+ \leq 1-(1-\overline q)^B.
+}
+
+\proof{
+\p{The chain rule gives
+#{\Pr(D_i^{\mathsf c})=\Pr(D_{i-1}^{\mathsf c})(1-q_i)}. Iteration proves
+the product identity, and the coordinatewise bounds on #{1-q_i} give the two
+discovery bounds.}}
+
+\p{No independence assumption is used. The conditional rates may change with
+the earlier failures, an adaptive decoder, or a changing environment state.}
+
+\p{This is an FTIP-proved finite statement.}

--- a/trees/ftip-007B.tree
+++ b/trees/ftip-007B.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Discovery is neither acquisition nor coverage}
+\tag{ftip}
+\tag{support}
+\tag{acquisition}
+
+\p{The discovery event concerns whether a declared sampling procedure
+observes at least one success. Increasing its probability can be an
+elicitation effect in the sense of \ref{ftip-0005}: more attempts expose
+behaviour that already had positive probability. It is not by itself the
+independent before--after comparison required by \ref{ftip-0007}.}
+
+\p{Successful-support coverage in \ref{ftip-005V} integrates an
+instance-level threshold over a task law. A large discovery probability on one
+instance therefore does not establish broad coverage or the uniform
+task-family witness of \ref{ftip-005X}.}

--- a/trees/ftip-007C.tree
+++ b/trees/ftip-007C.tree
@@ -1,0 +1,31 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Finite exponential tilting preserves support}
+\tag{ftip}
+\tag{support}
+\tag{optimization}
+
+\p{Fix a prompt #{x}, a finite response set #{\mathcal Y}, a reference policy
+#{\pi_{\mathrm{ref}}}, a finite real reward #{r(x,y)}, and #{\beta>0}. Let
+#{\pi_r} be the normalized exponential tilt of \ref{ftip-003O}. Then, for
+every #{y\in\mathcal Y},}
+
+##{
+ \pi_r(y\mid x)>0
+ \quad\Longleftrightarrow\quad
+ \pi_{\mathrm{ref}}(y\mid x)>0.
+}
+
+\proof{
+\p{The multiplier #{\exp(r(x,y)/\beta)} is finite and strictly positive.
+The finite normalizer #{Z_r(x)} is also strictly positive. Multiplication by
+the first quantity and division by the second therefore preserve whether the
+reference mass is zero or positive.}}
+
+\p{The source policy form appears as equation (4) in
+\citet{Section 4}{rafailov2023direct}; this theorem is its FTIP-proved
+corollary. Infinite rewards,
+non-normalizable response spaces, approximate optimization, and changes to the
+generation mechanism lie outside the statement.}

--- a/trees/ftip-007D.tree
+++ b/trees/ftip-007D.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Formal support and operational discoverability}
+\tag{ftip}
+\tag{support}
+\tag{decoding}
+
+\p{Support preservation is a statement about exact positive probability. A
+response can remain in mathematical support while its mass becomes too small
+to observe within the available rollout budget. The identities in
+\ref{ftip-0078} and \ref{ftip-0079} quantify this distinction for declared
+independent attempts.}
+
+\p{Top-#{k} truncation, nucleus sampling, finite numerical precision, context
+limits, and parser constraints can also remove an operational route even when
+the underlying softmax law assigns it positive mass. Claims about elicitation
+must therefore name both the policy law and the executable inference
+procedure.}

--- a/trees/ftip-007E.tree
+++ b/trees/ftip-007E.tree
@@ -1,0 +1,32 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: Equal one-shot success, unequal successful coverage}
+\tag{ftip}
+\tag{support}
+\tag{evaluation}
+
+\p{Let the evaluation law be uniform on two instances #{x_1,x_2}. Consider
+protocols #{P} and #{P'} with successful-support probabilities}
+
+##{
+ \bigl(p_P(x_1),p_P(x_2)\bigr)
+ =\left(\frac12,\frac12\right),
+ \qquad
+ \bigl(p_{P'}(x_1),p_{P'}(x_2)\bigr)
+ =(1,0).
+}
+
+\p{Both protocols have mean one-shot success #{1/2}. At threshold
+#{\alpha=1/2}, however, \ref{ftip-005V} gives}
+
+##{
+ \operatorname{Cov}_{1/2}(P)=1,
+ \qquad
+ \operatorname{Cov}_{1/2}(P')=\frac12.
+}
+
+\p{Thus average success does not determine successful-support coverage. The
+example is finite and uses the same task law and threshold for both protocols;
+it does not compare their training costs or establish acquisition.}

--- a/trees/ftip-007F.tree
+++ b/trees/ftip-007F.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Proxy reward and verifier fidelity}
+\tag{ftip}
+\tag{reward}
+\tag{verifier}
+
+\p{A proxy can guide an update or rank sampled candidates without agreeing
+with the independently declared utility of the resulting output. This
+subsection separates pointwise proxy error from average error under a shifted
+law. It then distinguishes repeated false-accept events from the output of a
+candidate selector. Pointwise approximation and explicit probability
+assumptions support different guarantees; an average audit number alone
+supplies neither.}
+
+\transclude{ftip-007G}
+\transclude{ftip-007H}
+\transclude{ftip-007I}
+\transclude{ftip-007J}
+\transclude{ftip-007K}
+\transclude{ftip-007L}
+\transclude{ftip-007M}
+\transclude{ftip-007N}
+\transclude{ftip-007O}

--- a/trees/ftip-007G.tree
+++ b/trees/ftip-007G.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Uniform proxy approximation}
+\tag{ftip}
+\tag{reward}
+\tag{evaluation}
+
+\p{Let #{\mathcal Y_0} be a nonempty finite set of candidate outcomes. Let
+#{U:\mathcal Y_0\to\mathbb R} be an independently declared utility and
+#{\widehat U:\mathcal Y_0\to\mathbb R} a proxy score. The proxy is a
+\newvocab{uniform approximation} to #{U} on #{\mathcal Y_0} with error
+#{\varepsilon} when #{\varepsilon\geq0} and}
+
+##{
+ \sup_{y\in\mathcal Y_0}\lvert \widehat U(y)-U(y)\rvert\leq\varepsilon.
+}
+
+\p{The candidate set is part of the claim. Approximation on training
+outcomes, on one policy's support, or in expectation is not uniform
+approximation on a larger set reached after optimization.}

--- a/trees/ftip-007H.tree
+++ b/trees/ftip-007H.tree
@@ -1,0 +1,40 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Uniform proxy error gives two-epsilon selection regret}
+\tag{ftip}
+\tag{reward}
+\tag{regret}
+
+\p{Under the conditions of \ref{ftip-007G}, choose}
+
+##{
+ y^\star\in\operatorname*{arg\,max}_{y\in\mathcal Y_0}U(y),
+ \qquad
+ \widehat y\in\operatorname*{arg\,max}_{y\in\mathcal Y_0}\widehat U(y).
+}
+
+\p{Then the utility regret of selecting by the proxy satisfies}
+
+##{
+ 0\leq U(y^\star)-U(\widehat y)\leq2\varepsilon.
+}
+
+\proof{
+\p{Optimality of #{\widehat y} for the proxy and the two pointwise error
+bounds give}
+
+##{
+\begin{aligned}
+U(y^\star)
+&\leq \widehat U(y^\star)+\varepsilon\\
+&\leq \widehat U(\widehat y)+\varepsilon\\
+&\leq U(\widehat y)+2\varepsilon.
+\end{aligned}
+}
+
+\p{Optimality of #{y^\star} for #{U} gives the lower bound.}
+}
+
+\p{This is an FTIP-proved finite statement.}

--- a/trees/ftip-007I.tree
+++ b/trees/ftip-007I.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{The two-epsilon theorem is a decision bound}
+\tag{ftip}
+\tag{reward}
+\tag{scope}
+
+\p{\ref{ftip-007H} is an elementary note-local consequence of the
+uniform approximation condition, not a theorem imported from a particular
+post-training paper. It compares two maximizers on one fixed finite candidate
+set. It does not describe how either score was learned or how a policy changes
+when that score becomes a training objective.}
+
+\p{The result is useful because its transfer assumption is visible. To apply
+it after an update or a larger search, the uniform bound must hold on the
+outcomes that the new procedure can actually select. The verifier evidence of
+\ref{ftip-0047} can support such an audit, but reproducible evidence alone does
+not establish the bound.}

--- a/trees/ftip-007J.tree
+++ b/trees/ftip-007J.tree
@@ -1,0 +1,38 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: Small average proxy error fails after distribution shift}
+\tag{ftip}
+\tag{reward}
+\tag{distribution-shift}
+
+\p{Let the finite decision set be
+#{\mathcal Y_0=\{y_{\rm safe},y_{\rm exploit}\}}. Define its utility and
+proxy utility by the following table.}
+
+##{
+\begin{array}{c|cc}
+ &y_{\rm safe}&y_{\rm exploit}\\ \hline
+U&1&0\\
+\widehat U&1&2.
+\end{array}
+}
+
+\p{For #{0<\delta<1}, let a reference law #{P_\delta} assign probability
+#{\delta} to #{y_{\rm exploit}}. Its mean absolute proxy error is}
+
+##{
+ \mathbb E_{P_\delta}\lvert \widehat U-U\rvert=2\delta,
+}
+
+\p{which tends to zero with #{\delta}. Nevertheless, proxy maximization
+selects #{y_{\rm exploit}} and incurs utility regret #{1}. Under the shifted
+law concentrated on that selected outcome, the mean error is #{2}. Thus no
+vanishing selection-regret bound can depend only on average error under the
+reference law.}
+
+\p{This two-outcome construction isolates the distribution-shift warning in
+\ref{ftip-0061}. It does not claim that a particular learned verifier has this
+error profile; \ref{ftip-0060} gives a source-linked checker instance with the
+same proxy-versus-utility separation.}

--- a/trees/ftip-007K.tree
+++ b/trees/ftip-007K.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Repeated verifier audit}
+\tag{ftip}
+\tag{verifier}
+\tag{inference}
+
+\p{A \newvocab{repeated verifier audit} of size #{N\geq1} records pairs
+#{(S_i,A_i)\in\{0,1\}^2} for candidates #{1\leq i\leq N}. Here #{S_i} is
+an independently defined success label and #{A_i} is the verifier decision,
+as in \ref{ftip-005Z}. Define}
+
+##{
+ C_i^{\rm fa}=\{S_i=0,\ A_i=1\},
+ \qquad
+ \mathcal E_N^{\rm fa}=\bigcup_{i=1}^N C_i^{\rm fa}.
+}
+
+\p{The event #{\mathcal E_N^{\rm fa}} says that at least one invalid
+candidate was accepted.
+It does not say which candidate a downstream selector returns. Write
+#{\phi_i=\Pr(C_i^{\rm fa})}. When #{\iota_i=\Pr(S_i=0)>0}, the conditional false-accept rate
+#{\eta_{+,i}=\Pr(A_i=1\mid S_i=0)} is defined and
+#{\phi_i=\iota_i\eta_{+,i}}.}

--- a/trees/ftip-007L.tree
+++ b/trees/ftip-007L.tree
@@ -1,0 +1,44 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Independent false accepts amplify with candidate count}
+\tag{ftip}
+\tag{verifier}
+\tag{probability}
+
+\p{In the repeated audit of \ref{ftip-007K}, suppose the pairs
+#{(S_i,A_i)} are independent and identically distributed. Assume}
+
+##{
+ \iota=\Pr(S_i=0)>0,
+ \qquad
+ \eta_+=\Pr(A_i=1\mid S_i=0).
+}
+
+\p{Then the probability that at least one accepted invalid candidate exists
+among the #{N} audited candidates is}
+
+##{
+ \Pr(\mathcal E_N^{\rm fa})=1-(1-\iota\eta_+)^N.
+}
+
+\p{It is strictly increasing in #{N} when #{0<\iota\eta_+<1}, and it
+converges to #{1} when #{\iota\eta_+>0}.}
+
+\proof{
+\p{Each #{C_i^{\rm fa}} has probability #{\iota\eta_+}. Independence of the
+audited pairs makes the events #{C_i^{\rm fa}} independent. Therefore}
+
+##{
+ \Pr\left((\mathcal E_N^{\rm fa})^c\right)
+ =\Pr\left(\bigcap_{i=1}^N (C_i^{\rm fa})^c\right)
+ =\prod_{i=1}^N(1-\iota\eta_+)
+ =(1-\iota\eta_+)^N.
+}
+
+\p{Taking complements gives the equality. The monotonicity and limit follow
+from the elementary powers of #{1-\iota\eta_+}.}
+}
+
+\p{This is an FTIP-proved finite statement.}

--- a/trees/ftip-007M.tree
+++ b/trees/ftip-007M.tree
@@ -1,0 +1,34 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{A false-accept union bound without independence}
+\tag{ftip}
+\tag{verifier}
+\tag{probability}
+
+\p{For any joint law of a repeated verifier audit,}
+
+##{
+ \Pr(\mathcal E_N^{\rm fa})\leq\sum_{i=1}^N \phi_i.
+}
+
+\p{If #{\iota_i=\Pr(S_i=0)>0} for every #{i}, this becomes}
+
+##{
+ \Pr(\mathcal E_N^{\rm fa})\leq\sum_{i=1}^N \iota_i\eta_{+,i}.
+}
+
+\proof{
+\p{Apply the union bound to
+#{\mathcal E_N^{\rm fa}=\bigcup_i C_i^{\rm fa}}. The factorization
+#{\phi_i=\iota_i\eta_{+,i}} follows from conditional probability whenever
+#{\iota_i>0}. If #{\iota_i=0}, then #{\phi_i=0} while the corresponding conditional rate
+is undefined, so the first display remains the unconditional statement.}
+}
+
+\p{Without a dependence assumption, matching marginal error rates do not
+give the equality in \ref{ftip-007L}; the events #{C_i^{\rm fa}} could
+coincide.}
+
+\p{This is an FTIP-proved finite statement.}

--- a/trees/ftip-007N.tree
+++ b/trees/ftip-007N.tree
@@ -1,0 +1,40 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Weight updates and candidate selection are different proxy operators}
+\tag{ftip}
+\tag{reward}
+\tag{inference}
+
+\p{A proxy score can enter a training operator or a selection operator. In
+the first route it changes the policy; in the second it ranks a finite sample
+from a policy whose weights remain fixed.}
+
+\tikzfig{\begin{tikzpicture}[
+  box/.style={draw, rounded corners=2pt, align=center, font=\scriptsize,
+    text width=19mm, minimum height=8mm},
+  flow/.style={-{Stealth[length=1.8mm]}, thick}
+]
+\node[box] (tr-roll) at (0,1.15) {training\\rollouts from $\pi$};
+\node[box] (tr-score) at (2.6,1.15) {proxy\\rewards};
+\node[box] (tr-update) at (5.2,1.15) {parameter\\update};
+\node[box] (tr-policy) at (7.8,1.15) {new policy\\$\pi'$};
+\node[box] (in-policy) at (0,-1.15) {inference\\fixed $\pi$};
+\node[box] (in-sample) at (2.6,-1.15) {$N$ sampled\\candidates};
+\node[box] (in-score) at (5.2,-1.15) {proxy\\ranking};
+\node[box] (in-output) at (7.8,-1.15) {selected\\output};
+\draw[flow] (tr-roll) -- (tr-score);
+\draw[flow] (tr-score) -- (tr-update);
+\draw[flow] (tr-update) -- (tr-policy);
+\draw[flow] (in-policy) -- (in-sample);
+\draw[flow] (in-sample) -- (in-score);
+\draw[flow] (in-score) -- (in-output);
+\end{tikzpicture}}
+
+\p{The lifecycle accounting of \ref{ftip-005H} places the first route's
+rollout and update work in separate coordinates. The second route incurs
+rollout and evaluation work but no parameter update. Consequently, the event
+#{\mathcal E_N^{\rm fa}} in \ref{ftip-007K} concerns the candidate set
+presented to selection;
+it is not a claim about the selected output or a training-time policy change.}

--- a/trees/ftip-007O.tree
+++ b/trees/ftip-007O.tree
@@ -1,0 +1,28 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{What verifier error rates do not identify}
+\tag{ftip}
+\tag{verifier}
+\tag{evaluation}
+
+\p{The rates in \ref{ftip-005Z} are properties of a declared audit law.
+They do not identify where errors occur within the task family, how error
+events depend across repeated candidates, or which accepted candidate a
+selector returns. \ref{ftip-007L} adds identical marginals and independence;
+\ref{ftip-007M} retains only the union bound.}
+
+\p{Nor do these rates determine the effect of optimizing against the
+verifier. That effect depends on how the induced policy or selection law moves
+mass toward particular outcomes. The incomplete-checker example
+\ref{ftip-0060} demonstrates one such movement, while \ref{ftip-007J} shows
+why an average reference-law error cannot rule it out. These are local finite
+statements. Any claim about a named verifier still requires its own audit
+distribution, evidence, and transfer argument.}
+
+\p{The deterministic regret lemma \ref{ftip-007H}, the independent-audit
+identity \ref{ftip-007L}, and the union bound \ref{ftip-007M} are elementary
+note-local results. Their role is to expose assumptions needed by later
+source-theorem reconstructions, not to attribute these statements to the
+papers used for the surrounding verifier examples.}

--- a/trees/ftip-007P.tree
+++ b/trees/ftip-007P.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Feedback identifiability and fixed records}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{A training protocol can respond only to distinctions present in its
+observations. The following finite setup makes that restriction precise before
+considering stronger, model-specific limits on preference data.}
+
+\transclude{ftip-007Q}
+\transclude{ftip-008C}
+\transclude{ftip-008D}
+\transclude{ftip-007R}
+\transclude{ftip-007S}
+\transclude{ftip-007T}
+\transclude{ftip-007U}
+\transclude{ftip-007V}
+\transclude{ftip-007W}
+\transclude{ftip-007X}

--- a/trees/ftip-007Q.tree
+++ b/trees/ftip-007Q.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Finite declared feedback protocol}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{Fix a horizon #{N\geq 0}, finite action sets #{\mathcal A_n}, finite
+feedback sets #{\mathcal F_n}, and a finite internal-seed set #{\mathcal U}
+with a declared law #{\lambda}. A \strong{finite declared protocol}
+#{\mathsf P} consists of selection maps}
+
+##{
+a_n:\mathcal U\times\prod_{j<n}(\mathcal A_j\times\mathcal F_j)
+\longrightarrow\mathcal A_n
+\qquad(0\leq n<N).
+}
+
+\p{An action may specify the task, rollout record, feedback request, or
+sampling choice made at that round. The protocol can depend on earlier exposed
+feedback and its declared seed, but it cannot depend on a latent world field
+that has not entered those arguments.}

--- a/trees/ftip-007R.tree
+++ b/trees/ftip-007R.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Observational equivalence for a declared protocol}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{Let #{\mathcal T_{\mathsf P}} be the finite set of possible transcripts
+for a declared protocol #{\mathsf P}. Two feedback worlds #{w_0,w_1} are
+\newvocab{observationally equivalent} for #{\mathsf P}, written
+#{w_0\equiv_{\mathsf P}w_1}, when}
+
+##{
+\Pr(T_{w_0}^{\mathsf P}=t)=\Pr(T_{w_1}^{\mathsf P}=t)
+\qquad\text{for every }t\in\mathcal T_{\mathsf P}.
+}
+
+\p{The relation is protocol-relative. Another protocol may issue a different
+feedback request and thereby separate the same worlds. Equality only on the
+realized transcript is weaker than this definition, which compares the whole
+finite transcript law.}

--- a/trees/ftip-007S.tree
+++ b/trees/ftip-007S.tree
@@ -1,0 +1,39 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Post-training cannot distinguish observationally equivalent worlds}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{Let #{w_0\equiv_{\mathsf P}w_1}. For any finite output set #{\mathcal Y}
+and any readout #{h:\mathcal T_{\mathsf P}\to\mathcal Y},}
+
+##{
+h_{\#}\operatorname{Law}(T_{w_0}^{\mathsf P})
+=h_{\#}\operatorname{Law}(T_{w_1}^{\mathsf P}).
+}
+
+\p{Thus a final artifact stamp, update decision, or test chosen solely from
+the declared protocol's transcript has the same distribution in both worlds.}
+
+\proof{
+\p{For every #{y\in\mathcal Y}, finiteness gives}
+
+##{
+\begin{aligned}
+\Pr\left(h(T_{w_0}^{\mathsf P})=y\right)
+&=\sum_{\substack{t\in\mathcal T_{\mathsf P}\\h(t)=y}}
+  \Pr(T_{w_0}^{\mathsf P}=t)\\
+&=\sum_{\substack{t\in\mathcal T_{\mathsf P}\\h(t)=y}}
+  \Pr(T_{w_1}^{\mathsf P}=t)
+=\Pr\left(h(T_{w_1}^{\mathsf P})=y\right).
+\end{aligned}
+}
+
+\p{The middle equality is observational equivalence from \ref{ftip-007R}.
+These point probabilities determine the two pushforward laws.}
+}
+
+\p{This is an FTIP-proved finite statement.}

--- a/trees/ftip-007S.tree
+++ b/trees/ftip-007S.tree
@@ -7,6 +7,16 @@
 \tag{feedback}
 \tag{identifiability}
 
+\p{For a finite random variable #{X}, write #{\operatorname{Law}(X)} for its
+probability law. If #{h} maps the value space of #{X} to a finite set
+#{\mathcal Y}, its pushforward law #{h_{\#}\operatorname{Law}(X)} is
+characterized by
+##{
+\bigl(h_{\#}\operatorname{Law}(X)\bigr)(\{y\})
+=\Pr(h(X)=y),\qquad y\in\mathcal Y.
+}
+}
+
 \p{Let #{w_0\equiv_{\mathsf P}w_1}. For any finite output set #{\mathcal Y}
 and any readout #{h:\mathcal T_{\mathsf P}\to\mathcal Y},}
 

--- a/trees/ftip-007T.tree
+++ b/trees/ftip-007T.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{A no-free-feedback result, not a no-learning result}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{\ref{ftip-007S} says that the declared observations supply no
+information that distinguishes #{w_0} from #{w_1}. It does not say that the
+output must equal the initial model, that the parameters cannot change, or that
+performance cannot improve in both worlds. Pretraining, inductive bias,
+computation on the observed records, and generalization may still produce an
+improvement shared by the two worlds.}
+
+\p{Calling the theorem a no-learning result would therefore erase the central
+condition: only world-dependent conclusions unavailable from the common
+transcript are ruled out.}

--- a/trees/ftip-007U.tree
+++ b/trees/ftip-007U.tree
@@ -1,0 +1,30 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{Replaying a fixed pool supplies no new feedback information}
+\tag{ftip}
+\tag{feedback}
+\tag{replay}
+
+\p{Fix a realized finite replay pool #{d} as in \ref{ftip-0056}. Let
+#{\mathcal V} be a finite seed set, and let #{V\in\mathcal V} be a
+replay-and-update seed with the same declared law in two feedback worlds and
+whose law does not depend on the world. If a replay-only procedure makes no new
+environment or feedback query, then its output has the form #{Y=h(d,V)}. The
+law of #{Y} is the same in the two worlds.}
+
+\proof{
+\p{For every output #{y},}
+
+##{
+\Pr(h(d,V)=y)=
+\sum_{\substack{v\in\mathcal V\\h(d,v)=y}}\Pr(V=v).
+}
+
+\p{The fixed pool, seed law, and readout are identical in the two worlds, so
+the displayed sum is identical. Equivalently, this is the pushforward argument
+of \ref{ftip-007S} applied after conditioning on the realized pool.}
+}
+
+\p{This is an FTIP-proved finite statement.}

--- a/trees/ftip-007V.tree
+++ b/trees/ftip-007V.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Reuse can change optimization without enlarging evidence}
+\tag{ftip}
+\tag{feedback}
+\tag{replay}
+
+\p{A replay schedule can reweight records, reduce optimization error on the
+fixed pool, or produce a different update proposal in the sense of
+\ref{ftip-006C}. Those are genuine computational effects. They do not add a
+label, preference, verifier result, or environment transition to the fixed
+evidence. Fresh optimizer randomness is likewise not feedback about the latent
+world.}
+
+\p{This distinction prevents sample reuse from being counted as feedback
+acquisition. It does not imply that replay is useless; it isolates the source
+of any benefit as further computation on already acquired records.}

--- a/trees/ftip-007W.tree
+++ b/trees/ftip-007W.tree
@@ -1,0 +1,38 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: An off-query utility reversal}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{Let the response set be #{\{a,b\}}. A one-round protocol queries only
+#{x_0}; both worlds return the preference #{a\succ b}. The protocol therefore
+has the same transcript law in both worlds. Fix a deterministic
+transcript-to-policy readout that chooses #{a} also at an unqueried #{x_1}.
+The worlds agree on every observed field but reverse utility at #{x_1}:}
+
+\tikzfig{\begin{tikzpicture}[
+  box/.style={draw, rounded corners=2pt, align=center, font=\small,
+    text width=27mm, minimum height=10mm},
+  leaf/.style={draw, rounded corners=2pt, align=center, font=\small,
+    text width=36mm, minimum height=12mm},
+  flow/.style={-{Stealth[length=2mm]}, thick}
+]
+\node[box] (query) at (-3.5,1.4) {query only $x_0$};
+\node[box] (feedback) at (0,1.4) {observed in both\\$a\succ b$};
+\node[box] (policy) at (3.5,1.4) {same output\\$\pi(a\mid x_1)=1$};
+\node[leaf] (plus) at (-2,-1.3) {world $w_+$\\$u(x_1,a)=1,\ u(x_1,b)=0$};
+\node[leaf] (minus) at (2,-1.3) {world $w_-$\\$u(x_1,a)=0,\ u(x_1,b)=1$};
+\draw[flow] (query) -- (feedback);
+\draw[flow] (feedback) -- (policy);
+\draw[flow] (policy) -- (plus);
+\draw[flow] (policy) -- (minus);
+\end{tikzpicture}}
+
+\p{The transcript laws are identical, so \ref{ftip-007S} applies, while the
+deterministic readout returns the same output in both worlds. That output is
+optimal in #{w_+} and suboptimal in #{w_-} on #{x_1}. The example does not
+show that generalization always fails. It shows that a claim about unqueried
+utility requires an assumption connecting observed feedback to that utility.}

--- a/trees/ftip-007X.tree
+++ b/trees/ftip-007X.tree
@@ -14,6 +14,7 @@ positive result using a limited number of cardinal queries. The exact
 quantifiers, model-class restrictions, asymptotic conditions, and cardinal
 query count in those theorems are not reconstructed here.}
 
-\p{The finite pushforward theorem \ref{ftip-007S} and counterexample
-\ref{ftip-007W} isolate a generic observational obstruction. They are neither
-proofs nor special cases of the paper's distortion results.}
+\p{\ref{ftip-007S} gives a finite pushforward theorem, while
+\ref{ftip-007W} gives a counterexample to identification from an incomplete
+transcript. They are neither proofs nor special cases of the paper's
+distortion results.}

--- a/trees/ftip-007X.tree
+++ b/trees/ftip-007X.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{From finite indistinguishability to preference-data limits}
+\tag{ftip}
+\tag{feedback}
+\tag{preference}
+
+\p{\citet{Theorems 3.3--3.5}{zhao2025limits} study a more structured
+post-training model. They give ordinal-preference distortion lower bounds,
+including a lower bound under Bradley--Terry noise with linear scores, and a
+positive result using a limited number of cardinal queries. The exact
+quantifiers, model-class restrictions, asymptotic conditions, and cardinal
+query count in those theorems are not reconstructed here.}
+
+\p{The finite pushforward theorem \ref{ftip-007S} and counterexample
+\ref{ftip-007W} isolate a generic observational obstruction. They are neither
+proofs nor special cases of the paper's distortion results.}

--- a/trees/ftip-007Y.tree
+++ b/trees/ftip-007Y.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Replay monitors and trajectory compression}
+\tag{ftip}
+\tag{replay}
+\tag{trajectory}
+
+\p{Reusing a rollout and jumping along a predicted checkpoint path save
+different kinds of work. The first changes how often recorded feedback enters
+an update. The second replaces some realized training steps by a parameter
+forecast. This subsection records what their proposed monitors establish and,
+separately, what remains unmeasured.}
+
+\transclude{ftip-007Z}
+\transclude{ftip-0080}
+\transclude{ftip-0081}
+\transclude{ftip-0082}
+\transclude{ftip-0083}
+\transclude{ftip-0084}
+\transclude{ftip-0085}
+\transclude{ftip-0086}
+\transclude{ftip-0087}
+\transclude{ftip-0088}
+\transclude{ftip-0089}
+\transclude{ftip-008A}
+\transclude{ftip-008B}

--- a/trees/ftip-007Z.tree
+++ b/trees/ftip-007Z.tree
@@ -1,0 +1,46 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Per-token DGG gradient factorization}
+\tag{ftip}
+\tag{replay}
+\tag{gradient}
+
+\p{\strong{Source reconstruction.} This statement reconstructs
+\citet{Section 4.2.1, Proposition 1, and Appendix A.1}{miao2026when}.}
+
+\p{Consider an active token #{i} on the unclipped branch of the GRPO
+objective. Let #{a_i} be the sampled token, #{\widehat A_i} its normalized
+advantage, and
+##{
+r_i=\frac{\pi_\theta(a_i\mid h_{L,i})}
+{\pi_{\rm old}(a_i\mid h_{L,i})}.
+}
+Write #{h_{L,i}} for the hidden state entering the language-model head,
+#{x_i^{\rm int}} for the input to an intermediate linear layer, and
+#{J_i=\partial z_i/\partial y_i} for the Jacobian from that layer's output to
+the logits. Define
+##{
+E_i=r_i\widehat A_i
+\left(e_{a_i}-\pi_\theta(\mathord\cdot\mid h_{L,i})\right).
+}
+Then the two weight gradients factor as rank-one matrices:
+##{
+G_i^{\rm lm}=E_i h_{L,i}^{\mathsf T},
+\qquad
+G_i^{\rm int}=(J_i^{\mathsf T}E_i)(x_i^{\rm int})^{\mathsf T}.
+}
+}
+
+\proof{
+\p{For the unclipped token objective, differentiation through the softmax
+gives #{\nabla_{z_i}\mathcal L_i=E_i}. Since
+#{z_i=W_{\rm lm}h_{L,i}}, the outer-product rule gives the first identity.
+The chain rule gives #{\nabla_{y_i}\mathcal L_i=J_i^{\mathsf T}E_i}; applying
+the same rule to #{y_i=W_{\rm int}x_i^{\rm int}} gives the second.}
+}
+
+\p{This is the source proposition specialized to the active, unclipped token
+whose gradient appears in its equation (3). Clipped or inactive tokens require
+their own derivative or mask and are not covered by the displayed identities.}

--- a/trees/ftip-007Z.tree
+++ b/trees/ftip-007Z.tree
@@ -17,6 +17,17 @@ advantage, and
 r_i=\frac{\pi_\theta(a_i\mid h_{L,i})}
 {\pi_{\rm old}(a_i\mid h_{L,i})}.
 }
+Treat #{\widehat A_i} and the behavior-policy denominator as fixed during
+this token update. Let #{e_{a_i}\in\mathbb R^{|\mathcal V|}} be the standard
+basis vector for the sampled token, and define the active-token objective and
+its two weight gradients by
+##{
+\mathcal L_i(\theta)=r_i(\theta)\widehat A_i,
+\qquad
+G_i^{\rm lm}=\nabla_{W_{\rm lm}}\mathcal L_i,
+\qquad
+G_i^{\rm int}=\nabla_{W_{\rm int}}\mathcal L_i.
+}
 Write #{h_{L,i}} for the hidden state entering the language-model head,
 #{x_i^{\rm int}} for the input to an intermediate linear layer, and
 #{J_i=\partial z_i/\partial y_i} for the Jacobian from that layer's output to

--- a/trees/ftip-0080.tree
+++ b/trees/ftip-0080.tree
@@ -1,0 +1,65 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{DGG intermediate-to-head gradient-energy bound}
+\tag{ftip}
+\tag{replay}
+\tag{gradient}
+
+\p{\strong{Source reconstruction.} This statement reconstructs
+\citet{Section 4.2.1, Lemma 1, Assumption 1, Theorem 1, and Appendix A.3}{miao2026when}.}
+
+\p{Use the per-token quantities of \ref{ftip-007Z}. Assume positive constants
+#{\alpha_{\min}}, #{\beta_{\max}}, and #{C} satisfy
+##{
+\|h_{L,i}\|_2^2\geq \alpha_{\min}d_{\rm model},
+\qquad
+\|x_i^{\rm int}\|_2^2\leq \beta_{\max}d_{\rm model},
+}
+and the two logit-sensitivity bounds
+##{
+\mathbb E_{j\sim\pi_\theta(\mathord\cdot\mid h_{L,i})}
+ \|(J_i)_{j,:}\|_2^2\leq C,
+\qquad
+\|(J_i)_{a_i,:}\|_2^2\leq C.
+}
+If #{\widehat A_i\neq0} and #{\pi_\theta(a_i\mid h_{L,i})<1}, then
+##{
+\frac{\|G_i^{\rm int}\|_F^2}{\|G_i^{\rm lm}\|_F^2}
+\leq
+\frac{\mathcal C_{\rm struct}}
+{(1-\pi_\theta(a_i\mid h_{L,i}))^2},
+\qquad
+\mathcal C_{\rm struct}
+=\frac{4\beta_{\max}C}{\alpha_{\min}}.
+}
+}
+
+\proof{
+\p{The sampled-token coordinate of #{E_i} and the lower activation bound give
+##{
+\|G_i^{\rm lm}\|_F^2
+=\|E_i\|_2^2\|h_{L,i}\|_2^2
+\geq
+r_i^2\widehat A_i^2
+(1-\pi_\theta(a_i\mid h_{L,i}))^2
+\alpha_{\min}d_{\rm model}.
+}
+Expanding #{J_i^{\mathsf T}E_i}, applying
+#{(a-b)^2\leq2a^2+2b^2}, and then using both logit-sensitivity bounds yields
+#{\|J_i^{\mathsf T}E_i\|_2^2\leq4r_i^2\widehat A_i^2C}. Hence
+##{
+\|G_i^{\rm int}\|_F^2
+\leq4r_i^2\widehat A_i^2C\,
+\beta_{\max}d_{\rm model}.
+}
+The source's softmax probabilities make #{r_i>0}; the nonzero-advantage and
+nonunit-probability hypotheses make the head lower bound positive. Division
+and cancellation give the displayed ratio.}
+}
+
+\p{The activation inequalities reproduce the source's Lemma 1, while the two
+row-energy inequalities reproduce its Assumption 1. The conclusion is an
+upper bound on an intermediate-to-head gradient-energy ratio. It does not say
+that either gradient is small, and it does not compare evaluation scores.}

--- a/trees/ftip-0081.tree
+++ b/trees/ftip-0081.tree
@@ -1,0 +1,54 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{DGG finite-batch head-gradient inequality}
+\tag{ftip}
+\tag{replay}
+\tag{gradient}
+
+\p{\strong{Source reconstruction.} This statement reconstructs
+\citet{Section 4.2.2, Lemma 2, Theorem 2, and Appendix B}{miao2026when}.}
+
+\p{For #{T\geq1} active, unclipped tokens, let
+##{
+G^{\rm lm}=\frac1T\sum_{i=1}^T G_i^{\rm lm},
+\qquad
+\overline{r^2}=\frac1T\sum_{i=1}^T r_i^2,
+}
+and set
+##{
+c_{\max}=
+\max_{1\leq i\leq T}
+\widehat A_i^2
+\|e_{a_i}-\pi_\theta(\mathord\cdot\mid h_{L,i})\|_2^2
+\|h_{L,i}\|_2^2.
+}
+Then
+##{
+\|G^{\rm lm}\|_F^2\leq c_{\max}\overline{r^2}
+=c_{\max}(1+\widehat\chi^2),
+}
+where #{\widehat\chi^2} is the statistic of \ref{ftip-0066}. If
+#{c_{\max}>0}, rearrangement gives the source's equivalent direction
+##{
+\widehat\chi^2\geq
+\frac{\|G^{\rm lm}\|_F^2}{c_{\max}}-1.
+}
+}
+
+\proof{
+\p{Convexity of the squared Frobenius norm and the factorization in
+\ref{ftip-007Z} give
+##{
+\left\|\frac1T\sum_iG_i^{\rm lm}\right\|_F^2
+\leq\frac1T\sum_i\|G_i^{\rm lm}\|_F^2
+\leq\frac{c_{\max}}T\sum_i r_i^2.
+}
+The identity #{\overline{r^2}=1+\widehat\chi^2} follows directly from
+\ref{ftip-0066}; division by positive #{c_{\max}} gives the final form.}
+}
+
+\p{The inequality points from observed head-gradient energy to a lower bound
+on this finite-batch squared-ratio statistic. It is not a converse: cancellation
+can make the batch gradient small even when individual ratios are large.}

--- a/trees/ftip-0082.tree
+++ b/trees/ftip-0082.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{DGG monitors update geometry, not evaluation safety}
+\tag{ftip}
+\tag{replay}
+\tag{evaluation}
+
+\p{The identities in \ref{ftip-007Z}--\ref{ftip-0081} concern gradients,
+importance ratios, activations, and a logit Jacobian. None of their hypotheses
+mentions the fixed independent-evaluation functional #{J_{\rm ev}} of
+\ref{ftip-005E}. They therefore cannot imply that accepting an update preserves
+#{J_{\rm ev}}, or that rejecting one would have prevented a decrease.}
+
+\p{DGG adds an empirical policy on top of those identities: it monitors the
+increment in head-gradient energy, standardizes that increment against a
+trailing window, and rejects some reused updates before the optimizer step
+\citet{Section 5 and Algorithm 1}{miao2026when}. Its reported experiments relate
+that policy to observed training stability. They do not turn the Z-score into
+a calibrated test of independent-evaluation safety.}

--- a/trees/ftip-0083.tree
+++ b/trees/ftip-0083.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: empirical squared-ratio excess can be negative}
+\tag{ftip}
+\tag{replay}
+\tag{counterexample}
+
+\p{Take one observed action #{a} with
+#{\pi_{\rm old}(a)=1/2} and #{\pi_\theta(a)=1/4}. The batch contains only
+that action, so #{T=1} and #{r_1=1/2}. Hence
+##{
+\widehat\chi^2=r_1^2-1=-\frac34.
+}
+Both policies can be completed on a two-action space by assigning their
+remaining mass to the other action.}
+
+\p{Thus the finite-batch statistic in \ref{ftip-0066} need not share the
+nonnegativity of the population Pearson divergence. Theorem
+\ref{ftip-0081} remains valid: its right side contains
+#{1+\widehat\chi^2=1/4=\overline{r^2}}.}

--- a/trees/ftip-0084.tree
+++ b/trees/ftip-0084.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: batch cancellation can hide stale ratios}
+\tag{ftip}
+\tag{replay}
+\tag{counterexample}
+
+\p{Fix #{R>1}. On a two-token vocabulary, let both observed tokens have
+#{a_i=1}, current probability #{\pi_\theta(1)=1/2}, and behavior probability
+#{\pi_{\rm old}(1)=1/(2R)}. Take scalar hidden states #{h_{L,1}=h_{L,2}=1}
+and normalized advantages #{\widehat A_1=1}, #{\widehat A_2=-1}. Then
+#{r_1=r_2=R}, but the factors in \ref{ftip-007Z} satisfy
+##{
+G_1^{\rm lm}=R(1/2,-1/2)^{\mathsf T},
+\qquad
+G_2^{\rm lm}=-G_1^{\rm lm}.
+}
+Consequently #{G^{\rm lm}=0}, while
+#{\widehat\chi^2=R^2-1} can be arbitrarily large.}
+
+\p{The example does not contradict \ref{ftip-0081}: that theorem upper-bounds
+batch-gradient energy by a ratio moment. It supplies no lower bound on the
+gradient and no converse from a quiet monitor to fresh data.}

--- a/trees/ftip-0085.tree
+++ b/trees/ftip-0085.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: a Z-score gate is not an evaluation-safety certificate}
+\tag{ftip}
+\tag{replay}
+\tag{evaluation}
+\tag{counterexample}
+
+\p{Let two consecutive proposed reused updates have the same monitored energy,
+#{g_{t-1}=g_t=1}. With trailing-window increment mean #{\mu_t=0}, any
+positive scale #{\sigma_t+\varepsilon}, and any positive threshold, DGG's
+score is
+##{
+z_t=\frac{(g_t-g_{t-1})-\mu_t}{\sigma_t+\varepsilon}=0,
+}
+so the gate accepts the proposal. Now choose a fixed evaluation interface for
+which the artifact before the accepted update has performance #{J_{\rm ev}=1}
+and the artifact after it has performance #{J_{\rm ev}=0}.}
+
+\p{This is consistent because the gate rule of \ref{ftip-005A} imposes no
+mathematical relation between its scalar monitor and #{J_{\rm ev}}. A safety
+claim would need an additional assumption connecting proposed updates to the
+independent evaluation law; the Z-score calculation alone cannot provide it.}

--- a/trees/ftip-0086.tree
+++ b/trees/ftip-0086.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Leading squared singular-energy share}
+\tag{ftip}
+\tag{trajectory}
+\tag{linear-algebra}
+
+\p{Let #{\Delta W\in\mathbb R^{m\times n}} be nonzero, set
+#{q=\min(m,n)}, and order its singular values as
+#{\sigma_1\geq\cdots\geq\sigma_q\geq0}. Its
+\strong{leading squared singular-energy share} is
+##{
+\rho_1(\Delta W)
+=\frac{\sigma_1(\Delta W)^2}{\sum_{j=1}^q\sigma_j(\Delta W)^2}
+=\frac{\sigma_1(\Delta W)^2}{\|\Delta W\|_F^2}.
+}
+The nonzero hypothesis prevents an undefined #{0/0}; the value lies in
+#{[1/q,1]}.}
+
+\p{NExt instead reports
+#{E_1=\sigma_1/\sum_j\sigma_j} in Section 3.2
+\citef{chen2026lowrank}. That nuclear-share statistic and
+#{\rho_1} answer different questions. We use the squared share when
+``energy'' means contribution to squared Frobenius norm.}

--- a/trees/ftip-0087.tree
+++ b/trees/ftip-0087.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Leading spectral gap}
+\tag{ftip}
+\tag{trajectory}
+\tag{linear-algebra}
+
+\p{For #{\Delta W\in\mathbb R^{m\times n}} with
+#{q=\min(m,n)\geq2}, its \strong{leading spectral gap} is
+##{
+\operatorname{gap}_1(\Delta W)
+=\sigma_1(\Delta W)-\sigma_2(\Delta W).
+}
+A positive gap makes the leading left and right one-dimensional singular
+subspaces unique, although each chosen singular vector still has an arbitrary
+sign. When the gap is zero, a single leading vector is not intrinsic.}
+
+\p{We leave the quantity undefined when #{q=1} rather than inventing a
+second singular value. Later projector comparisons require a positive gap at
+every compared checkpoint.}

--- a/trees/ftip-0088.tree
+++ b/trees/ftip-0088.tree
@@ -1,0 +1,31 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Leading-subspace projector drift}
+\tag{ftip}
+\tag{trajectory}
+\tag{linear-algebra}
+
+\p{Let #{\Delta W_t} and #{\Delta W_s} be nonzero matrices of the same shape,
+each with positive leading spectral gap. If #{u_1(t)} and #{u_1(s)} are unit
+leading left singular vectors, define their \strong{leading-subspace
+projector drift} by
+##{
+d_{\rm proj}(t,s)
+=\|\Pi_t^{\rm svd}-\Pi_s^{\rm svd}\|_F,
+\qquad
+\Pi_t^{\rm svd}=u_1(t)u_1(t)^{\mathsf T},
+\quad
+\Pi_s^{\rm svd}=u_1(s)u_1(s)^{\mathsf T}.
+}
+The definition is independent of both singular-vector signs and takes values
+in #{[0,\sqrt{2}]}.}
+
+\p{This is a note-local trajectory diagnostic, not a definition or claim from
+NExt.}
+
+\p{A large value of #{\rho_1} from \ref{ftip-0086} says that one
+singular mode dominates a particular difference matrix. It does not say that
+the dominant subspace remains fixed across checkpoints; #{d_{\rm proj}}
+measures that separate question.}

--- a/trees/ftip-0089.tree
+++ b/trees/ftip-0089.tree
@@ -1,0 +1,33 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Path-emulation regret}
+\tag{ftip}
+\tag{trajectory}
+\tag{evaluation}
+
+\p{Fix the evaluation interface of \ref{ftip-005D}. Let
+#{P_{t+s}^{\rm act}} be the protocol that returns the artifact reached after
+#{s\geq1} additional realized training steps from checkpoint #{t}. Let
+#{\mathcal K_{\leq t}} be the saved checkpoint history available through
+#{t}, and let #{\widehat P_{t+s}(\mathcal K_{\leq t})} instead return the
+artifact forecast from that history. Their \strong{signed path-emulation regret}
+and \strong{absolute path-emulation regret} are
+##{
+\begin{aligned}
+\operatorname{Reg}^{\rm path}_{\rm ev}(t,s)
+&=J_{\rm ev}(P_{t+s}^{\rm act})
+-J_{\rm ev}(\widehat P_{t+s}(\mathcal K_{\leq t})),\\
+\operatorname{AReg}^{\rm path}_{\rm ev}(t,s)
+&=\left|\operatorname{Reg}^{\rm path}_{\rm ev}(t,s)\right|.
+\end{aligned}
+}
+}
+
+\p{The sign distinguishes an optimistic forecast from a pessimistic one; the
+absolute value measures discrepancy without cancellation across checkpoints.
+Both use the same task law, inference budget, and evaluator. Parameter error
+alone is not substituted for evaluation error. NExt's extrapolation and
+recovery schedule in Sections 4.1--4.3 and 5.1 motivates this comparison
+\citef{chen2026lowrank}, but the paper does not state this regret definition.}

--- a/trees/ftip-0089.tree
+++ b/trees/ftip-0089.tree
@@ -28,6 +28,7 @@ and \strong{absolute path-emulation regret} are
 \p{The sign distinguishes an optimistic forecast from a pessimistic one; the
 absolute value measures discrepancy without cancellation across checkpoints.
 Both use the same task law, inference budget, and evaluator. Parameter error
-alone is not substituted for evaluation error. NExt's extrapolation and
-recovery schedule in Sections 4.1--4.3 and 5.1 motivates this comparison
-\citef{chen2026lowrank}, but the paper does not state this regret definition.}
+alone is not substituted for evaluation error. The NExt extrapolation and
+recovery schedule described in Sections 4.1--4.3 and 5.1 motivates this
+comparison \citef{chen2026lowrank}, but the paper does not state this regret
+definition.}

--- a/trees/ftip-008A.tree
+++ b/trees/ftip-008A.tree
@@ -1,0 +1,40 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: early low-rank agreement does not determine continuation}
+\tag{ftip}
+\tag{trajectory}
+\tag{counterexample}
+
+\p{In a two-dimensional matrix chart, set
+#{P=e_1e_1^{\mathsf T}} and #{Q=e_2e_2^{\mathsf T}}. Two paths share the
+entire observed history
+##{
+W_0=0,\qquad W_1=P,\qquad W_2=2P.
+}
+Every observed local difference is the same rank-one matrix #{P}. The paths
+then fork: path A takes #{W_3^A=3P}, whereas path B takes
+#{W_3^B=2P+Q}. Each next local difference is again rank one.}
+
+\tikzfig{\begin{tikzpicture}[
+  state/.style={draw, rounded corners=2pt, align=center, font=\small,
+    text width=21mm, minimum height=10mm},
+  flow/.style={-{Stealth[length=2mm]}, thick}
+]
+\node[state] (w0) at (0,0) {$W_0=0$};
+\node[state] (w1) at (2.8,0) {$W_1=P$};
+\node[state] (w2) at (5.6,0) {$W_2=2P$};
+\node[state] (wa) at (8.8,1.15) {$W_3^A=3P$};
+\node[state] (wb) at (8.8,-1.15) {$W_3^B=2P+Q$};
+\draw[flow] (w0) -- node[font=\scriptsize, fill=white] {$+P$} (w1);
+\draw[flow] (w1) -- node[font=\scriptsize, fill=white] {$+P$} (w2);
+\draw[flow] (w2) -- node[font=\scriptsize, fill=white] {$+P$} (wa);
+\draw[flow] (w2) -- node[font=\scriptsize, fill=white] {$+Q$} (wb);
+\end{tikzpicture}}
+
+\p{A deterministic history-only forecaster must return the same matrix
+#{\widehat W_3} in both worlds. Since
+#{\|W_3^A-W_3^B\|_F=\|P-Q\|_F=\sqrt{2}}, the triangle inequality forces its
+Frobenius error to be at least #{1/\sqrt{2}} on one continuation. Low-rank early
+motion therefore does not identify the next subspace or the next checkpoint.}

--- a/trees/ftip-008A.tree
+++ b/trees/ftip-008A.tree
@@ -7,7 +7,8 @@
 \tag{trajectory}
 \tag{counterexample}
 
-\p{In a two-dimensional matrix chart, set
+\p{Let #{e_1=(1,0)^{\mathsf T}} and #{e_2=(0,1)^{\mathsf T}} be the standard
+basis vectors of #{\mathbb R^2}. In a two-dimensional matrix chart, set
 #{P=e_1e_1^{\mathsf T}} and #{Q=e_2e_2^{\mathsf T}}. Two paths share the
 entire observed history
 ##{

--- a/trees/ftip-008B.tree
+++ b/trees/ftip-008B.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Compression of a charted path is not capability acquisition}
+\tag{ftip}
+\tag{trajectory}
+\tag{evaluation}
+
+\p{NExt extracts global, local, and target differences from LoRA checkpoint
+matrices, keeps leading singular factors, learns a nonlinear predictor, jumps
+in that parameter chart, and resumes RLVR
+\citet{Sections 3.2, 4.1--4.3, and 5.1}{chen2026lowrank}. Its reported results are empirical;
+the paper states no theorem that a leading subspace remains stable or that a
+forecast preserves a policy.}
+
+\p{The quantities in \ref{ftip-0086}--\ref{ftip-0089} separate four tests.
+Squared singular-energy share concerns one matrix, spectral gap controls
+whether its leading subspace is identifiable, projector drift compares those
+subspaces over time, and path-emulation regret returns to fixed independent
+evaluation. None, by itself, is evidence that new feedback was acquired or
+that a new capability was learned. Such a claim must use a declared
+post-training gain such as \ref{ftip-005F} and must charge forecast training,
+the parameter jump, and recovery updates.}

--- a/trees/ftip-008C.tree
+++ b/trees/ftip-008C.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Finite feedback world}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{For the action and feedback sets of \ref{ftip-007Q}, a \strong{finite
+feedback world} #{w} supplies, for each round #{0\leq n<N}, a probability
+kernel #{K_{n,w}} from a generic action--feedback history
+#{(a_0,f_0,\ldots,a_n)} ending in #{a_n\in\mathcal A_n} to
+#{\mathcal F_n}. Thus, whenever
+#{a_j\in\mathcal A_j} and #{f_j\in\mathcal F_j},}
+
+##{
+K_{n,w}(\,\cdot\mid a_0,f_0,\ldots,a_n)
+\in\Delta(\mathcal F_n).
+}
+
+\p{Two worlds may agree on every feedback kernel queried by a protocol while
+differing in latent utility, unrequested labels, or unobserved environment
+facts. Those latent fields are not feedback until a declared query exposes
+them.}

--- a/trees/ftip-008D.tree
+++ b/trees/ftip-008D.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Observed feedback transcript}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{Fix a finite declared protocol #{\mathsf P} from \ref{ftip-007Q} and a
+finite feedback world #{w} from \ref{ftip-008C}. Draw #{U\sim\lambda} and,
+for #{0\leq n<N}, set}
+
+##{
+\begin{aligned}
+A_n&=a_n(U,A_0,F_0,\ldots,A_{n-1},F_{n-1}),\\
+F_n&\sim K_{n,w}(\,\cdot\mid A_0,F_0,\ldots,A_n).
+\end{aligned}
+}
+
+\p{The resulting \newvocab{observed feedback transcript} is}
+
+##{
+T_w^{\mathsf P}=(U,A_0,F_0,\ldots,A_{N-1},F_{N-1}).
+}
+
+\p{All protocol randomness is included in #{U}. Immutable rollout records
+and typed feedback events may be components of the finite action and feedback
+sets, as in \ref{ftip-0051} and \ref{ftip-0053}.}

--- a/trees/refs/zhao2025limits.tree
+++ b/trees/refs/zhao2025limits.tree
@@ -1,0 +1,18 @@
+% ["reinforcement learning", "preference data", "post-training"]
+\title{The limits of preference data for post-training}
+\date{2025}
+\author/literal{Eric Zhao}
+\author/literal{Jessica Dai}
+\author/literal{Pranjal Awasthi}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2505.19964}
+
+\meta{bibtex}{\startverb
+@article{zhao2025limits,
+  title = {The Limits of Preference Data for Post-Training},
+  author = {Zhao, Eric and Dai, Jessica and Awasthi, Pranjal},
+  year = {2025},
+  url = {https://arxiv.org/abs/2505.19964},
+  journal = {arXiv preprint arXiv:2505.19964}
+}
+\stopverb}


### PR DESCRIPTION
## Summary

- append a new FTIP section on finite consequences and obstructions without renumbering the 256-tree foundation
- prove finite discovery, proxy-error, verifier-audit, and feedback-indistinguishability results
- reconstruct the exact DGG gradient inequalities and separate them from its empirical gate
- add local trajectory-compression diagnostics and counterexamples while keeping NExt empirical
- add three worked diagrams and a primary reference for the preference-feedback lower-bound route

## Claim status

The section labels source reconstructions, FTIP-proved finite statements, finite counterexamples, and open or empirical limits separately. DeepSeek, OLMo, DGG, and NExt remain instantiations or falsification contexts rather than model-selection claims.

## Verification

- independent formal/content review: PASS, including the bounded self-containment repair
- independent source-fidelity review against primary HTML: PASS
- `just chk`: PASS
- full `CI=1 just build`: PASS
- `just verify-render`: PASS (1,774 XML/HTML pairs)
- 301/301 trees root-reachable exactly once; no missing, forward, duplicate, or cyclic references
- targeted PDF/output/date/strict-log gates: PASS
- 112-page PDF and affected theorem/example pages inspected at 180 dpi: PASS
- PDF SHA-256: `837373c7a3ed85092746892498c408851b0a1d0b1ef70a37a4eb692859d5a664`

No build-system changes, generated artifacts, or PDFs are committed.