### PR TITLE
FTIP alignment gain and preference information limits

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -67,3 +67,4 @@ that combination.}
 \transclude{ftip-005C}
 \transclude{ftip-005T}
 \transclude{ftip-0075}
+\transclude{ftip-008E}

--- a/trees/ftip-008E.tree
+++ b/trees/ftip-008E.tree
@@ -1,0 +1,28 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Alignment gain and preference information}
+\tag{ftip}
+\tag{alignment}
+\tag{preference-data}
+
+\p{This section reconstructs two finite source models that ask different
+questions about post-training. The first assumes an exact KL-regularized
+optimizer and characterizes the reward gain that its exponential tilt can
+produce. The second asks what ordinal comparisons reveal when post-training
+may reroute a fixed set of response circuits.}
+
+\p{A \strong{source reconstruction} preserves the cited source's objects,
+quantifiers, and hypotheses after an explicit notation translation. An
+\strong{FTIP-proved} result is derived in these notes from the displayed
+finite setup. A \strong{source discrepancy} records text that cannot be
+silently made consistent across the main statement, appendix, or inherited
+result.}
+
+\p{Neither source model is a general account of neural post-training. The
+first assumes exact optimization of a declared scalar reward. The second is a
+stylized routing model with a fixed circuit set. Their conclusions therefore
+enter FTIP as checkable conditional statements and transfer limits.}
+
+\transclude{ftip-008F}
+\transclude{ftip-008X}

--- a/trees/ftip-008F.tree
+++ b/trees/ftip-008F.tree
@@ -1,0 +1,34 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Finite KL-regularized alignment}
+\tag{ftip}
+\tag{alignment}
+\tag{optimization}
+
+\p{This subsection studies an exact, finite optimization model. A reference
+law is exponentially tilted by a declared scalar reward. In this setting,
+reward gain admits two exact descriptions: a Jeffreys-divergence identity and
+a covariance under the reference law.}
+
+\p{The statements do not model approximate optimization, neural training
+cost, reward validity, or independent capability evaluation. Those boundaries
+are stated before and after the source reconstructions.}
+
+\transclude{ftip-008G}
+\transclude{ftip-008H}
+\transclude{ftip-008I}
+\transclude{ftip-008J}
+\transclude{ftip-008K}
+\transclude{ftip-008L}
+\transclude{ftip-008M}
+\transclude{ftip-008N}
+\transclude{ftip-008O}
+\transclude{ftip-008P}
+\transclude{ftip-008Q}
+\transclude{ftip-008R}
+\transclude{ftip-008S}
+\transclude{ftip-008T}
+\transclude{ftip-008U}
+\transclude{ftip-008V}
+\transclude{ftip-008W}

--- a/trees/ftip-008G.tree
+++ b/trees/ftip-008G.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Source status and theorem boundary for finite alignment}
+\tag{ftip}
+\tag{alignment}
+\tag{provenance}
+
+\p{The direct source is the recent v1 preprint
+\citek{paes2026theoretical}. Its Theorems 1 and 2 concern an exactly optimal
+KL-regularized policy and a fixed query. The present subsection reconstructs
+those two identities on a finite response set, where every expectation and
+normalizer is an ordinary finite sum.}
+
+\p{This is a \strong{finite source reconstruction}. It does not transfer the
+paper's empirical comparisons among best-of-#{N}, PPO, and GRPO. It also does
+not treat the source's later proxy-reward and ensemble statements, whose
+quantifiers require a separate audit.}

--- a/trees/ftip-008H.tree
+++ b/trees/ftip-008H.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Notation}
+\title{Translating the alignment source notation}
+\tag{ftip}
+\tag{alignment}
+\tag{notation}
+
+\p{The source writes #{\lambda>0} for the KL penalty. Here we write
+#{\beta>0}, matching the DPO notation in \ref{ftip-003M}--\ref{ftip-003O}.
+This avoids collision with the generalized-advantage parameter in
+\ref{ftip-003E} and the protocol law in \ref{ftip-007Q}.}
+
+\p{The source's gain #{\Delta(r,r')} is written #{G_p(r;s)}: #{r} is the
+reward used to tilt the reference law #{p}, while #{s} is the reward used to
+evaluate the tilted law. This avoids collision with both the simplex notation
+#{\Delta(X)} of \ref{ftip-000A} and the paired DPO margin of
+\ref{ftip-003M}. For a finite set #{\mathcal Y}, a law
+#{p\in\Delta(\mathcal Y)}, and functions #{f,g:\mathcal Y\to\mathbb R}, set}
+
+##{
+ \operatorname{Cov}_p(f,g)
+ =\mathbb E_{y\sim p}[f(y)g(y)]
+ -\mathbb E_{y\sim p}[f(y)]\,
+  \mathbb E_{y\sim p}[g(y)].
+}

--- a/trees/ftip-008I.tree
+++ b/trees/ftip-008I.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Finite KL-alignment instance}
+\tag{ftip}
+\tag{alignment}
+\tag{optimization}
+
+\p{A \newvocab{finite KL-alignment instance} consists of a nonempty finite
+response set #{\mathcal Y}, a reference law #{p\in\Delta(\mathcal Y)}, a
+penalty #{\beta>0}, and finite real functions
+#{r,s:\mathcal Y\to\mathbb R}. The reference support is}
+
+##{
+ S_p=\{y\in\mathcal Y:p(y)>0\}.
+}
+
+\p{A prompt is fixed and suppressed. The function #{r} determines the
+alignment update; #{s} measures its result. They may coincide, but they need
+not. Finiteness makes every exponential weight and expectation below finite.}
+
+\p{\strong{Status: source-adapted definition.} The objects specialize the
+fixed-query setting in \citet{Section 2, equations (2.1)--(2.2)}{paes2026theoretical};
+they are not a definition of alignment in general.}

--- a/trees/ftip-008J.tree
+++ b/trees/ftip-008J.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Exponential weight and partition function}
+\tag{ftip}
+\tag{alignment}
+\tag{probability}
+
+\p{For a finite KL-alignment instance, define the \newvocab{exponential
+weight} and \newvocab{partition function} by}
+
+##{
+ a_r(y)=\exp\left(\frac{r(y)}{\beta}\right),
+ \qquad
+ Z_r=\mathbb E_{y\sim p}[a_r(y)].
+}
+
+\p{Every #{a_r(y)} is finite and strictly positive. Since #{p} is a
+probability law on a nonempty finite set, #{0<Z_r<\infty}.}
+
+\p{\strong{Status: source reconstruction.} This is the fixed-query form of
+the weight and normalizer in
+\citet{Equation (2.2)}{paes2026theoretical}.}

--- a/trees/ftip-008K.tree
+++ b/trees/ftip-008K.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Aligned law in finite-source notation}
+\tag{ftip}
+\tag{alignment}
+\tag{optimization}
+
+\p{The \newvocab{aligned law} induced by #{r} is #{q_r\in\Delta(\mathcal Y)}
+given by}
+
+##{
+ q_r(y)=\frac{p(y)a_r(y)}{Z_r}.
+}
+
+\p{Normalization follows from the definition of #{Z_r}. Moreover,
+#{q_r(y)>0} exactly when #{p(y)>0}. This is the finite notation for the same
+exponential-tilt optimizer stated in \ref{ftip-003O}; support preservation was
+proved in \ref{ftip-007C}.}
+
+\p{\strong{Status: source reconstruction.} The formula is
+\citet{Equation (2.2)}{paes2026theoretical}. It assumes the exact optimizer,
+not an iterate returned by a particular training algorithm.}

--- a/trees/ftip-008L.tree
+++ b/trees/ftip-008L.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Cross-reward gain under an alignment reward}
+\tag{ftip}
+\tag{alignment}
+\tag{evaluation}
+
+\p{The \newvocab{cross-reward gain} from aligning with #{r} and evaluating
+with #{s} is}
+
+##{
+ G_p(r;s)
+ =\mathbb E_{y\sim q_r}[s(y)]
+ -\mathbb E_{y\sim p}[s(y)].
+}
+
+\p{The semicolon records two roles. Its left argument changes the response
+law; its right argument scores both laws. Thus #{G_p(r;s)} is not an
+independent evaluation unless #{s} has separately been declared to serve that
+role.}
+
+\p{\strong{Status: source reconstruction.} This is the finite notation for
+#{\Delta(r,r')} in Theorem 2, equation (3.4), of
+\citef{paes2026theoretical}.}

--- a/trees/ftip-008M.tree
+++ b/trees/ftip-008M.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Jeffreys divergence}
+\tag{ftip}
+\tag{probability}
+\tag{alignment}
+
+\p{For probability laws #{p} and #{q} for which both terms are finite, their
+\newvocab{Jeffreys divergence} is}
+
+##{
+ J(p,q)
+ =D_{\mathrm{KL}}(p\Vert q)
+ +D_{\mathrm{KL}}(q\Vert p).
+}
+
+\p{The KL divergence and its argument order are defined in
+\ref{ftip-006X}. Unlike either directed term, #{J(p,q)=J(q,p)}. In the finite
+tilt of \ref{ftip-008K}, #{p} and #{q_r} have the same support, so both terms
+are finite.}
+
+\p{\strong{Status: standard definition used by the source.} See
+\citet{Theorem 1, equation (3.2)}{paes2026theoretical}.}

--- a/trees/ftip-008N.tree
+++ b/trees/ftip-008N.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Lemma}
+\title{Log-density ratio of the exact tilt}
+\tag{ftip}
+\tag{alignment}
+\tag{optimization}
+
+\p{For every #{y\in S_p}, the aligned law satisfies}
+
+##{
+ \log\frac{q_r(y)}{p(y)}
+ =\frac{r(y)}{\beta}-\log Z_r.
+}
+
+\proof{
+\p{On #{S_p}, both #{p(y)} and #{q_r(y)} are positive. Dividing the formula
+of \ref{ftip-008K} by #{p(y)} and taking logarithms gives the identity.}}
+
+\p{\strong{Status: source reconstruction.} This is equation (B.1) followed
+by the logarithmic step in
+\citet{Appendix B.1, equations (B.1)--(B.2)}{paes2026theoretical}.}

--- a/trees/ftip-008O.tree
+++ b/trees/ftip-008O.tree
@@ -1,0 +1,33 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Exact reward gain equals scaled Jeffreys divergence}
+\tag{ftip}
+\tag{alignment}
+\tag{optimization}
+
+\p{For a finite KL-alignment instance,}
+
+##{
+ G_p(r;r)=\beta J(p,q_r).
+}
+
+\proof{
+\p{Rearranging \ref{ftip-008N} gives
+#{r(y)=\beta\log(q_r(y)/p(y))+\beta\log Z_r} on the common support. Taking
+expectation first under #{q_r} and then under #{p} yields}
+
+##{
+\begin{aligned}
+ \mathbb E_{q_r}[r]
+ &=\beta D_{\mathrm{KL}}(q_r\Vert p)+\beta\log Z_r,\\
+ \mathbb E_p[r]
+ &=-\beta D_{\mathrm{KL}}(p\Vert q_r)+\beta\log Z_r.
+\end{aligned}
+}
+
+\p{Subtracting cancels the common normalizer and gives the result.}}
+
+\p{\strong{Status: source reconstruction.} This is the finite form of
+\citet{Theorem 1, equation (3.2), with proof in Appendix B.1}{paes2026theoretical}.}

--- a/trees/ftip-008P.tree
+++ b/trees/ftip-008P.tree
@@ -1,0 +1,17 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{What the Jeffreys identity does and does not identify}
+\tag{ftip}
+\tag{alignment}
+\tag{interpretation}
+
+\p{The identity \ref{ftip-008O} is an equality inside one declared model. It says
+that exact gain in the optimizing reward equals a symmetric divergence from
+the reference law. It does not say that a larger divergence improves a
+different utility, nor that a training algorithm reaches the exact tilt.}
+
+\p{The identity accounts for neither rollout and update work nor the cost of
+obtaining #{r}. Consequently it is not, by itself, a bound on the costed
+post-training potential of \ref{ftip-005M}.}

--- a/trees/ftip-008Q.tree
+++ b/trees/ftip-008Q.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Cross-reward gain is a base-law covariance}
+\tag{ftip}
+\tag{alignment}
+\tag{probability}
+
+\p{For a finite KL-alignment instance,}
+
+##{
+ G_p(r;s)
+ =\operatorname{Cov}_p\left(s,\frac{a_r}{Z_r}\right).
+}
+
+\proof{
+\p{The aligned expectation can be written under the reference law as
+#{\mathbb E_{q_r}[s]=\mathbb E_p[s a_r/Z_r]}. Also
+#{\mathbb E_p[a_r/Z_r]=1}. Substituting these two identities into
+\ref{ftip-008L} gives the covariance defined in \ref{ftip-008H}.}}
+
+\p{\strong{Status: source reconstruction.} This is the finite form of
+Theorem 2, equation (3.4), in \citef{paes2026theoretical}. Its proof is in
+Appendix B.1, equations (B.5)--(B.7).}

--- a/trees/ftip-008R.tree
+++ b/trees/ftip-008R.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{The covariance is predictive only for a declared reward}
+\tag{ftip}
+\tag{alignment}
+\tag{evaluation}
+
+\p{The identity \ref{ftip-008Q} expresses exact tilted-law gain using expectations
+under #{p}. This makes the population quantity accessible from the reference
+law in principle. A finite-sample estimator still needs its own sampling law,
+moment assumptions, and error analysis.}
+
+\p{The formula also remains indexed by both #{r} and #{s}. It cannot turn a
+proxy reward into an independent utility. If #{s=r}, it measures improvement
+in the same quantity that defined the exact optimizer; if #{s\ne r}, its sign
+is determined by the displayed covariance.}

--- a/trees/ftip-008S.tree
+++ b/trees/ftip-008S.tree
@@ -1,0 +1,46 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{A two-response alignment identity}
+\tag{ftip}
+\tag{alignment}
+\tag{example}
+
+\p{Take #{\mathcal Y=\{a,b\}}, #{p=(1/2,1/2)}, #{\beta=1}, and
+#{r(a)=0}, #{r(b)=\log 3}. Exponential weighting changes the reference law
+as follows.}
+
+\tikzfig{\begin{tikzpicture}[
+  box/.style={draw, rounded corners=2pt, align=center, font=\small,
+    text width=27mm, minimum height=10mm},
+  flow/.style={-{Stealth[length=2mm]}, thick}
+]
+\node[box] (base) at (0,0) {reference\\$p=(1/2,1/2)$};
+\node[box] (weight) at (3.8,0) {weights\\$a_r=(1,3)$};
+\node[box] (tilt) at (7.6,0) {aligned law\\$q_r=(1/4,3/4)$};
+\draw[flow] (base) -- node[above,font=\scriptsize] {$Z_r=2$} (weight);
+\draw[flow] (weight) -- (tilt);
+\end{tikzpicture}}
+
+\p{The reward gain is}
+
+##{
+ G_p(r;r)
+ =\left(\frac34-\frac12\right)\log 3
+ =\frac14\log 3.
+}
+
+\p{Direct calculation gives}
+
+##{
+\begin{aligned}
+ D_{\mathrm{KL}}(q_r\Vert p)
+ &=\frac14\log\frac12+\frac34\log\frac32,\\
+ D_{\mathrm{KL}}(p\Vert q_r)
+ &=\frac12\log2+\frac12\log\frac23,
+\end{aligned}
+}
+
+\p{whose sum is #{\frac14\log3}. Thus the example checks
+\ref{ftip-008O} exactly; it is not an empirical alignment result.}

--- a/trees/ftip-008T.tree
+++ b/trees/ftip-008T.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{Averaging the fixed-query identity over prompts}
+\tag{ftip}
+\tag{alignment}
+\tag{probability}
+
+\p{Let #{\mathcal X} be finite with prompt law #{\mu}. For each
+#{x\in\mathcal X}, let #{p_x}, #{r_x}, and #{q_{r_x}} be a finite
+KL-alignment instance with the same penalty #{\beta>0}. Then}
+
+##{
+ \sum_{x\in\mathcal X}\mu(x)G_{p_x}(r_x;r_x)
+ =\beta\sum_{x\in\mathcal X}\mu(x)J(p_x,q_{r_x}).
+}
+
+\proof{
+\p{Apply \ref{ftip-008O} at each prompt and take the finite
+#{\mu}-weighted sum.}}
+
+\p{\strong{Status: FTIP-proved corollary.} The source theorem is stated for
+each fixed query. This corollary performs only finite averaging; it does not
+introduce a shared neural parameterization across prompts.}

--- a/trees/ftip-008U.tree
+++ b/trees/ftip-008U.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Lemma}
+\title{Additive reward shifts leave the aligned law unchanged}
+\tag{ftip}
+\tag{alignment}
+\tag{reward}
+
+\p{For constants #{c,d\in\mathbb R},}
+
+##{
+ q_{r+c}=q_r,
+ \qquad
+ G_p(r+c;s+d)=G_p(r;s).
+}
+
+\proof{
+\p{The shifted weight is #{a_{r+c}=e^{c/\beta}a_r}, while its partition
+function is #{Z_{r+c}=e^{c/\beta}Z_r}; the common factor cancels in the
+aligned law. Adding #{d} to the evaluation reward adds #{d} to both
+expectations in the gain, so it also cancels.}}
+
+\p{\strong{Status: FTIP-proved finite lemma.} It records the same
+prompt-dependent additive non-identifiability that appears in the DPO
+reparameterization of \ref{ftip-003P}.}

--- a/trees/ftip-008V.tree
+++ b/trees/ftip-008V.tree
@@ -1,0 +1,30 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{A penalty coefficient is not a hard KL budget}
+\tag{ftip}
+\tag{alignment}
+\tag{optimization}
+
+\p{For fixed #{\beta}, the exponential tilt solves the penalized problem}
+
+##{
+ \max_{q\in\Delta(\mathcal Y)}
+ \left\{\mathbb E_q[r]
+ -\beta D_{\mathrm{KL}}(q\Vert p)\right\}
+}
+
+\p{under the conventions of \ref{ftip-008I}. This is not the same
+specification as choosing a number #{\kappa} and solving}
+
+##{
+ \max_q\mathbb E_q[r]
+ \quad\text{subject to}\quad
+ D_{\mathrm{KL}}(q\Vert p)\leq\kappa.
+}
+
+\p{A Lagrange multiplier can relate the two problems when the relevant
+duality and activity conditions hold. The coefficient #{\beta} alone does not
+declare a hard budget, and the identities \ref{ftip-008O}--\ref{ftip-008Q} do not
+supply those conditions.}

--- a/trees/ftip-008W.tree
+++ b/trees/ftip-008W.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Source discrepancies and transfer stop gates}
+\tag{ftip}
+\tag{alignment}
+\tag{provenance}
+
+\p{The source setup writes rewards as #{r(\mathbf x,\mathbf y)}, while the
+display of Theorem 1 reverses the two arguments in places. This subsection
+uses the setup order and then suppresses the fixed prompt. The source also
+moves between a dataset-level penalized objective and fixed-query identities.
+The finite-averaging result \ref{ftip-008T} makes that step explicit.}
+
+\p{The arXiv record labels the paper v1, submitted 8 May 2026, while the HTML
+manuscript displays a later internal date. All locators here point to the
+versioned v1 HTML. The response law is restricted to a finite set; no claim is
+made that the paper's full sequence-space wording has been reconstructed
+beyond this specialization.}
+
+\p{Finally, exact exponential tilting is a distributional optimizer. It does
+not account for rollout, gradient, optimizer, or systems cost, and it does not
+show that PPO, GRPO, DPO, or any frontier training run attains the displayed
+law. These are stop gates on every later FTIP use of the two identities.}

--- a/trees/ftip-008X.tree
+++ b/trees/ftip-008X.tree
@@ -1,0 +1,41 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Preference-feedback distortion}
+\tag{ftip}
+\tag{preference-data}
+\tag{lower-bound}
+
+\p{This subsection reconstructs the finite routing model and distortion
+results in Sections 2--3 and Appendix A of \citef{zhao2025limits}. It then
+checks the positive cardinal-query result against its original source
+\citef{amanatidis2021peeking}.}
+
+\p{The order is deliberate. We first type the source's queries, circuits,
+routing maps, utility, feedback profile, algorithm, and comparator class. Only
+then do we state the noiseless and Bradley--Terry lower bounds.}
+
+\transclude{ftip-008Y}
+\transclude{ftip-008Z}
+\transclude{ftip-0090}
+\transclude{ftip-0091}
+\transclude{ftip-0092}
+\transclude{ftip-0093}
+\transclude{ftip-0094}
+\transclude{ftip-0095}
+\transclude{ftip-0096}
+\transclude{ftip-0097}
+\transclude{ftip-0098}
+\transclude{ftip-0099}
+\transclude{ftip-009A}
+\transclude{ftip-009B}
+\transclude{ftip-009C}
+\transclude{ftip-009D}
+\transclude{ftip-009E}
+\transclude{ftip-009F}
+\transclude{ftip-009G}
+\transclude{ftip-009H}
+\transclude{ftip-009I}
+\transclude{ftip-009J}
+\transclude{ftip-009K}
+\transclude{ftip-009L}

--- a/trees/ftip-008Y.tree
+++ b/trees/ftip-008Y.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Source status and model boundary for preference limits}
+\tag{ftip}
+\tag{preference-data}
+\tag{source-status}
+
+\p{The results below come from the v1 preprint \citef{zhao2025limits}. Its
+model treats a pretrained system as a finite collection of response circuits
+plus learned maps that route queries to those circuits. Post-training changes
+the routing maps while retaining the circuit collection.}
+
+\p{This is a source assumption, not an architectural theorem about language
+models. In particular, the lower bounds do not prove that real post-training
+creates no circuits, that a neural network decomposes into the displayed
+objects, or that every preference-learning algorithm is subject to the same
+bound outside this model.}

--- a/trees/ftip-008Z.tree
+++ b/trees/ftip-008Z.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Notation}
+\title{Translating the preference source notation}
+\tag{ftip}
+\tag{notation}
+\tag{preference-data}
+
+\p{To avoid collisions with earlier FTIP notation, we translate the source
+symbols as follows:}
+
+##{
+ \mathcal Q\mapsto Q,\qquad
+ \mathcal R\mapsto Y,\qquad
+ \mathcal S_0\mapsto C_0,\qquad
+ \mathcal Z\mapsto H,
+}
+
+##{
+ \Phi\mapsto\mathfrak E,\qquad
+ \mathcal D\mapsto\mu_Q,\qquad
+ M\mapsto\mathfrak m.
+}
+
+\p{Thus #{H} denotes the source's finite internal-representation set, not a
+public interaction history. The family #{\mathfrak E} contains admissible
+query encoders and is unrelated to the costed potential #{\Phi} of
+\ref{ftip-005M}. Source locators continue to use the paper's original symbols.}

--- a/trees/ftip-0090.tree
+++ b/trees/ftip-0090.tree
@@ -1,0 +1,17 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Queries, responses, and retained circuits}
+\tag{ftip}
+\tag{preference-data}
+\tag{routing}
+
+\p{Following the formal model in Section 2 of \citef{zhao2025limits}, let
+#{Q} be a finite nonempty query set and #{Y} a response set. A
+\newvocab{response circuit} is a function #{c:Q\to Y}. The finite nonempty set
+#{C_0} contains the circuits retained from the pretrained model.}
+
+\p{The word ``circuit'' is source terminology for this abstract function. No
+claim is made here that an element of #{C_0} is localized in a neural network
+or corresponds to one human-named capability.}

--- a/trees/ftip-0091.tree
+++ b/trees/ftip-0091.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Query representation and circuit routing}
+\tag{ftip}
+\tag{preference-data}
+\tag{routing}
+
+\p{Let #{H} be a finite nonempty representation set and
+#{\mathfrak E\subseteq H^Q} a finite nonempty family of admissible encoders.
+A \newvocab{query encoder} is #{e\in\mathfrak E}. A
+\newvocab{circuit router} is a map}
+
+##{
+ h:H\longrightarrow\Delta(C_0).
+}
+
+\p{For a query #{\xi\in Q}, the composition #{h(e(\xi))} is a law on the
+retained circuits. Sampling #{c\sim h(e(\xi))} and returning #{c(\xi)} gives
+the response law. These are the two routing components in the source model
+\citet{Section 2, ``Formal model''}{zhao2025limits}.}

--- a/trees/ftip-0092.tree
+++ b/trees/ftip-0092.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Pretrained and post-trained routing models}
+\tag{ftip}
+\tag{preference-data}
+\tag{routing}
+
+\p{A \newvocab{routing model} is a triple
+#{\mathfrak m=(e,h,C_0)} with the types fixed in
+\ref{ftip-0090}--\ref{ftip-0091}. The pretrained model is
+#{\mathfrak m_0=(e_0,h_0,C_0)}. In the source intervention, a post-trained
+model may replace #{e_0} and #{h_0}, but it retains exactly #{C_0}.}
+
+\p{Write #{\mathfrak m(\xi)} for the random response obtained by sampling
+#{c\sim h(e(\xi))} and returning #{c(\xi)}. The source sometimes writes this
+as though the router selected a circuit rather than a distribution; the
+stochastic reading follows its declared codomain #{\Delta(C_0)}.}

--- a/trees/ftip-0093.tree
+++ b/trees/ftip-0093.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Utility and the uniform query law}
+\tag{ftip}
+\tag{preference-data}
+\tag{utility}
+
+\p{The source fixes the uniform probability law #{\mu_Q} on #{Q} and a
+utility function}
+
+##{
+ u:Q\times Y\longrightarrow\mathbb R.
+}
+
+\p{For a routing model #{\mathfrak m}, its expected utility is}
+
+##{
+ U_u(\mathfrak m)
+ =\mathbb E_{\xi\sim\mu_Q}
+   \mathbb E\left[u\left(\xi,\mathfrak m(\xi)\right)\mid\xi\right].
+}
+
+\p{This is the outcome objective in \citet{Section 2, ``Outcome-based
+optimization with preference data''}{zhao2025limits}. It is an assumed
+cardinal utility, not something ordinal comparisons directly reveal.}

--- a/trees/ftip-0094.tree
+++ b/trees/ftip-0094.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Complete noiseless ordinal preference profile}
+\tag{ftip}
+\tag{preference-data}
+\tag{ordinal-feedback}
+
+\p{For this noiseless lane, assume that distinct retained circuits never tie
+at a query. For each #{\xi\in Q}, utility then induces a strict comparison by}
+
+##{
+ c_i\succ_{\xi,u}c_j
+ \quad\Longleftrightarrow\quad
+ u\left(\xi,c_i(\xi)\right)
+ >u\left(\xi,c_j(\xi)\right).
+}
+
+\p{The \newvocab{complete noiseless ordinal profile} is
+#{\succ_u=(\succ_{\xi,u})_{\xi\in Q}}. The source gives the learner unlimited,
+unbiased access to every such comparison
+\citet{Section 2, final paragraph}{zhao2025limits}. Utilities with ties require
+a separately declared deterministic tie-break; the theorem lane below uses the
+tie-free constructions of the source.}

--- a/trees/ftip-0095.tree
+++ b/trees/ftip-0095.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Full preference data and an online oracle expose the same source information}
+\tag{ftip}
+\tag{preference-data}
+\tag{ordinal-feedback}
+
+\p{Within this finite model, a table containing every comparison in
+#{\succ_u} and a noiseless online oracle that answers every possible query
+expose the same ordinal information. The source deliberately grants this
+ideal access so that its obstruction is not caused by finite sampling or an
+offline split \citet{Section 2}{zhao2025limits}.}
+
+\p{This equivalence does not price the number of queries, labeler time, or
+adaptivity. It therefore cannot be transferred to a finite-feedback protocol
+without a separate query-complexity statement.}

--- a/trees/ftip-0096.tree
+++ b/trees/ftip-0096.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Preference-only post-training algorithm and attainable route class}
+\tag{ftip}
+\tag{preference-data}
+\tag{algorithm}
+
+\p{A \newvocab{preference-only post-training algorithm} #{\mathcal A} maps
+the pretrained routing model and the complete profile to}
+
+##{
+ \mathfrak m_{\mathcal A}(u)
+ =\mathcal A(\mathfrak m_0,\succ_u).
+}
+
+\p{The deterministic comparator class displayed in the source theorems is}
+
+##{
+ \mathcal M_{\rm det}(C_0)
+ =\left\{(e,h,C_0):e\in\mathfrak E,
+ h:H\to C_0\right\}.
+}
+
+\p{The source's formal model initially permits stochastic routers
+#{h:H\to\Delta(C_0)}, but its theorem comparator uses deterministic
+#{h:H\to C_0}. We preserve that distinction rather than silently enlarging
+the comparator class.}

--- a/trees/ftip-0097.tree
+++ b/trees/ftip-0097.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Multiplicative post-training distortion}
+\tag{ftip}
+\tag{preference-data}
+\tag{distortion}
+
+\p{Let #{\mathcal B} be any post-training algorithm with output
+#{\mathfrak m_{\mathcal B}(u)} under the feedback law induced by #{u}. When the
+denominator is positive, define its \newvocab{multiplicative post-training
+distortion} by}
+
+##{
+ \operatorname{Dist}_u(\mathcal B;\mathfrak m_0)
+ =\frac{
+   \max_{\mathfrak m^*\in\mathcal M_{\rm det}(C_0)}U_u(\mathfrak m^*)
+ }{
+   U_u(\mathfrak m_{\mathcal B}(u))
+ }.
+}
+
+\p{If the numerator is positive and the denominator is zero, set the ratio
+to #{+\infty}. The source lower bounds construct bounded nonnegative utilities
+for which the comparison is well defined
+\citet{Equation (2) and Appendix A}{zhao2025limits}. Distortion measures loss
+relative to the declared comparator class; it is not an absolute capability
+score.}

--- a/trees/ftip-0098.tree
+++ b/trees/ftip-0098.tree
@@ -1,0 +1,28 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Borda count}
+\tag{ftip}
+\tag{preference-data}
+\tag{social-choice}
+
+\p{Let #{m=|C_0|}, and suppose each #{\succ_{\xi,u}} is a strict total order
+on #{C_0}. If #{\operatorname{rank}_{\succ_{\xi,u}}(c)} places the most
+preferred circuit at rank one, its \newvocab{Borda score} is}
+
+##{
+ B_{\xi}(c)=m-\operatorname{rank}_{\succ_{\xi,u}}(c).
+}
+
+\p{The \newvocab{Borda-count choice} is any circuit in}
+
+##{
+ \operatorname*{arg\,max}_{c\in C_0}
+ \sum_{\xi\in Q}B_{\xi}(c).
+}
+
+\p{This reconstructs \citet{Definition 3.1}{zhao2025limits}. The source
+cites a prior equivalence between a standard RLHF model and Borda count; the
+definition here does not assert that every RLHF implementation is a Borda
+rule.}

--- a/trees/ftip-0099.tree
+++ b/trees/ftip-0099.tree
@@ -1,0 +1,49 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{A repaired compromise-circuit example}
+\tag{ftip}
+\tag{preference-data}
+\tag{social-choice}
+
+\p{Example 3.2 of \citef{zhao2025limits} prints only #{a\geq0} and #{2a<b},
+but those conditions do not force its stated rankings or Borda totals. We use
+the local repaired specialization #{0<a<1/2} and #{2a<b<1}. Take three
+queries, three circuits, and a singleton representation set, so every query
+must use one common circuit. Set}
+
+##{
+\begin{array}{c|ccc}
+ &c_A&c_B&c_C\\ \hline
+ \xi_1&1&0&1-a\\
+ \xi_2&1&0&1-a\\
+ \xi_3&0&1&b
+\end{array}
+}
+
+\p{The repaired inequalities give the rankings #{c_A\succ c_C\succ c_B} for
+#{\xi_1,\xi_2} and #{c_B\succ c_C\succ c_A} for #{\xi_3}. Hence the Borda
+totals are #{(4,2,3)}, so the ordinal rule selects #{c_A}. The utility totals are
+#{(2,1,2-2a+b)}. Since #{2a<b}, circuit #{c_C} has strictly greater total
+utility than #{c_A}.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=27mm,
+ minimum height=9mm,font=\small},
+ arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}
+]
+\node[box] (q) at (-3.5,1.3) {three queries\\$\xi_1,\xi_2,\xi_3$};
+\node[box] (h) at (0,1.3) {one shared\\representation};
+\node[box] (a) at (-1.8,-1.3) {Borda choice\\$c_A$};
+\node[box] (c) at (1.8,-1.3) {utility choice\\$c_C$};
+\draw[arr] (q) -- (h);
+\draw[arr] (h) -- node[lab,left]{ordinal totals} (a);
+\draw[arr] (h) -- node[lab,right]{utility totals} (c);
+\end{tikzpicture}}
+
+\p{This repaired finite example isolates information lost by ranking. The compromise circuit
+is never first for an individual query, yet its aggregate utility is largest.
+It does not show that Borda is always suboptimal or that a neural model must
+collapse all queries to one representation.}

--- a/trees/ftip-009A.tree
+++ b/trees/ftip-009A.tree
@@ -1,0 +1,53 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{General noiseless preference-distortion lower bound}
+\tag{ftip}
+\tag{preference-data}
+\tag{lower-bound}
+
+\p{Call #{C_0} \newvocab{pointwise response-separating} when}
+
+##{
+ c_i\neq c_j\quad\Longrightarrow\quad
+ c_i(\xi)\neq c_j(\xi)
+ \qquad(\xi\in Q).
+}
+
+\p{\strong{Conditional source reconstruction.} Assume pointwise response
+separation. Then the statement of Appendix Theorem A.1, equation (3), in
+\citef{zhao2025limits} yields: for every pretrained routing model
+#{\mathfrak m_0} and every preference-only algorithm #{\mathcal A}, there
+exists a utility #{u} such that post-training on the complete noiseless profile
+satisfies}
+
+##{
+ R_{Q,\mathfrak E,H}
+ =\frac{|Q|}
+ {\sqrt{|Q|(\log|\mathfrak E|+|H|)}+|H|},
+}
+
+##{
+ \operatorname{Dist}_u(\mathcal A;\mathfrak m_0)
+ \geq
+ \Omega\left(
+ \min\left\{\sqrt{|C_0|},R_{Q,\mathfrak E,H}\right\}
+ \right).
+}
+
+\p{The source states that the construction can keep utilities in #{[0,1]}
+and can additionally enforce}
+
+##{
+ \sum_{c\in C_0}u\left(\xi,c(\xi)\right)=1
+ \qquad(\xi\in Q).
+}
+
+\p{The source states the result for every pretrained model without the added
+separation hypothesis. Its appendix proof orders circuit indices and assigns
+utilities circuitwise; if two circuits return the same response at one query,
+that assignment need not descend to a function on #{Q\times Y}. We therefore
+state only the response-separating transfer that the typed FTIP model supports.
+The quantifier remains worst-case and existential in #{u}, and the comparator
+is the deterministic class in \ref{ftip-0096}.}

--- a/trees/ftip-009B.tree
+++ b/trees/ftip-009B.tree
@@ -1,0 +1,33 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{A square-root corollary under explicit query growth}
+\tag{ftip}
+\tag{preference-data}
+\tag{lower-bound}
+
+\p{\strong{FTIP-proved corollary.} Under the response-separation hypothesis of
+\ref{ftip-009A}, assume the explicit condition}
+
+##{
+ R_{Q,\mathfrak E,H}\geq\sqrt{|C_0|}.
+}
+
+\p{Then for every #{\mathfrak m_0} and #{\mathcal A}, the utility supplied by
+\ref{ftip-009A} satisfies}
+
+##{
+ \operatorname{Dist}_u(\mathcal A;\mathfrak m_0)
+ \geq\Omega\left(\sqrt{|C_0|}\right).
+}
+
+\proof{\p{Under the displayed condition, the minimum in \ref{ftip-009A} is
+#{\sqrt{|C_0|}}.}}
+
+\p{This formal condition replaces the informal large-query regime in
+Theorem 3.3 of \citef{zhao2025limits}. The square root is present in the
+source equation's TeX annotation and
+MathML. Flattened HTML text drops the radical and can misleadingly display a
+linear rate. The exact finite dependence before this regime is the minimum in
+\ref{ftip-009A}.}

--- a/trees/ftip-009C.tree
+++ b/trees/ftip-009C.tree
@@ -1,0 +1,33 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Proof dependencies of the noiseless lower bound}
+\tag{ftip}
+\tag{preference-data}
+\tag{proof-route}
+
+\p{Appendix A.1 of \citef{zhao2025limits} constructs one preference profile
+that is compatible with many cardinal utilities. Its proof then chooses a
+utility after seeing the algorithm's routing behavior and compares that
+behavior with an attainable deterministic route.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=27mm,
+ minimum height=9mm,font=\small},
+ arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}
+]
+\node[box] (l) at (-3.5,1.25) {Lemma A.2\\routing partition};
+\node[box] (c) at (0,1.25) {Claim A.3 and\\Fact A.4};
+\node[box] (u) at (-1.75,-1.25) {adversarial bounded\\utility};
+\node[box] (t) at (2.8,-1.25) {Theorem A.1\\distortion};
+\draw[arr] (l) -- (c);
+\draw[arr] (l) -- (u);
+\draw[arr] (c) -- (u);
+\draw[arr] (u) -- node[lab,above]{compare routes} (t);
+\end{tikzpicture}}
+
+\p{This diagram records the source proof route; it is not a new proof. In
+particular, the adversarial choice of utility is essential to the theorem's
+worst-case quantifiers.}

--- a/trees/ftip-009D.tree
+++ b/trees/ftip-009D.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Bradley--Terry preference from a score map}
+\tag{ftip}
+\tag{preference-data}
+\tag{bradley-terry}
+
+\p{Fix a query #{\xi} and nonnegative circuit scores #{a_{\xi,c}\geq0} such
+that #{a_{\xi,c_i}+a_{\xi,c_j}>0} for every compared pair. The
+\newvocab{Bradley--Terry comparison law} is}
+
+##{
+ \Pr(c_i\succ_{\xi}c_j)
+ =\frac{a_{\xi,c_i}}
+ {a_{\xi,c_i}+a_{\xi,c_j}}.
+}
+
+\p{Only score ratios are identified: multiplying every score for a fixed
+query by the same positive constant leaves all comparison probabilities
+unchanged. The next two cards distinguish two link choices discussed in
+\citet{Section 3.2}{zhao2025limits}.}

--- a/trees/ftip-009E.tree
+++ b/trees/ftip-009E.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Exponential-score Bradley--Terry feedback}
+\tag{ftip}
+\tag{preference-data}
+\tag{bradley-terry}
+
+\p{The \newvocab{exponential-score link} sets}
+
+##{
+ a_{\xi,c}=\exp\left(u(\xi,c(\xi))\right).
+}
+
+\p{For this link, exact comparison probabilities reveal pairwise utility
+differences through}
+
+##{
+ \log\frac{\Pr(c_i\succ_{\xi}c_j)}
+ {\Pr(c_j\succ_{\xi}c_i)}
+ =u(\xi,c_i(\xi))-u(\xi,c_j(\xi)).
+}
+
+\p{This algebra explains why a known link and infinite noiseless frequency
+information can expose more than an ordinal order. It does not apply when the
+link is unknown or misspecified.}

--- a/trees/ftip-009F.tree
+++ b/trees/ftip-009F.tree
@@ -1,0 +1,33 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Linear-score Bradley--Terry feedback}
+\tag{ftip}
+\tag{preference-data}
+\tag{bradley-terry}
+
+\p{The \newvocab{linear-score link} sets}
+
+##{
+ a_{\xi,c}=u(\xi,c(\xi)),
+ \qquad
+ \Pr(c_i\succ_{\xi}c_j)
+ =\frac{u(\xi,c_i(\xi))}
+ {u(\xi,c_i(\xi))+u(\xi,c_j(\xi))}.
+}
+
+\p{Write #{p^u_{\xi,ij}} for the displayed probability and define the complete
+pairwise-probability profile}
+
+##{
+ P_u^{\rm lin}
+ =\left(p^u_{\xi,ij}\right)_{\xi\in Q,\,c_i\neq c_j\in C_0}.
+}
+
+\p{This requires nonnegative utilities and a positive denominator for each
+queried pair. A linear-score algorithm #{\mathcal A_{\rm lin}} takes
+#{(\mathfrak m_0,P_u^{\rm lin})} as input and returns
+#{\mathfrak m_{\mathcal A_{\rm lin}}(u)}. The following lower bound concerns
+this specific link; it is not a lower bound for every stochastic preference
+model.}

--- a/trees/ftip-009G.tree
+++ b/trees/ftip-009G.tree
@@ -1,0 +1,37 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{General linear-score noisy preference lower bound}
+\tag{ftip}
+\tag{preference-data}
+\tag{lower-bound}
+
+\p{\strong{Conditional source reconstruction.} This is a conditional form of
+Appendix Theorem A.5 in \citef{zhao2025limits}.}
+
+\p{Assume pointwise response separation as defined in \ref{ftip-009A}. For
+every pretrained routing model and linear-score algorithm
+#{\mathcal A_{\rm lin}}, there exists a utility}
+
+##{
+ u:Q\times Y\longrightarrow[0,1].
+}
+
+\p{Post-training from even the complete comparison-probability profile of the
+linear-score link then satisfies}
+
+##{
+ \operatorname{Dist}_u(\mathcal A_{\rm lin};\mathfrak m_0)
+ \geq
+ \widetilde\Omega\left(
+ \min\left\{|C_0|,R_{Q,\mathfrak E,H}\right\}
+ \right),
+}
+
+\p{where #{R_{Q,\mathfrak E,H}} is defined in \ref{ftip-009A}. The theorem is
+again existential in #{u} and uses the source's deterministic comparator. The
+same circuitwise-utility issue recorded in \ref{ftip-009A} prevents us from
+asserting the source's unrestricted pretrained-model quantifier here. Its noise
+is informative because probabilities depend on cardinal scores; the
+obstruction survives under the particular linear link.}

--- a/trees/ftip-009H.tree
+++ b/trees/ftip-009H.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{The noisy main theorem and appendix have different asymptotic notation}
+\tag{ftip}
+\tag{preference-data}
+\tag{source-discrepancy}
+
+\p{The main-text Theorem 3.4 of \citef{zhao2025limits} displays
+#{\Omega(|C_0|)} in its stated large-query regime. Appendix Theorem A.5
+displays the general bound with #{\widetilde\Omega} and the minimum in
+\ref{ftip-009G}. The tilde can hide logarithmic factors, so these statements
+are not textually identical.}
+
+\p{We retain the appendix notation for the exact general theorem and record
+the main-text statement here. Removing the tilde or deriving one display from
+the other would require an additional argument not supplied in the note.}

--- a/trees/ftip-009I.tree
+++ b/trees/ftip-009I.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Cardinal value query}
+\tag{ftip}
+\tag{preference-data}
+\tag{query-complexity}
+
+\p{In the social-choice source, agents rank alternatives and also have
+nonnegative cardinal values. A \newvocab{value query} takes an agent #{i} and
+an alternative #{j} and returns #{v_{ij}}
+\citet{Definition 1}{amanatidis2021peeking}.}
+
+\p{Under the routing analogy, a query #{\xi\in Q} plays the role of an agent
+and a circuit #{c\in C_0} plays the role of an alternative. A cardinal query
+therefore reveals one value #{u(\xi,c(\xi))}. Query counts inherited from the
+social-choice theorem are per query/agent, not totals across #{Q}.}

--- a/trees/ftip-009J.tree
+++ b/trees/ftip-009J.tree
@@ -1,0 +1,30 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Acceptable Range Voting information--distortion tradeoff}
+\tag{ftip}
+\tag{preference-data}
+\tag{query-complexity}
+
+\p{\strong{Source reconstruction.} Let #{m} be the number of alternatives
+and let #{k\in\{1,\ldots,m\}}. Theorem 4 of
+\citef{amanatidis2021peeking} states that
+#{k}-Acceptable Range Voting uses}
+
+##{
+ O(k\log m)
+}
+
+\p{value queries per agent and has distortion}
+
+##{
+ O\left(m^{1/(k+1)}\right).
+}
+
+\p{This is a social-choice mechanism theorem. It transfers directly to the
+singleton-representation specialization #{|H|=1}, where every query must use
+one common circuit. Under that restriction, queries are agents and circuits
+are alternatives as in \ref{ftip-009I}. The theorem does not by itself cover a
+routing comparator that may choose different circuits for different
+representations, and it is not an implementation of neural post-training.}

--- a/trees/ftip-009K.tree
+++ b/trees/ftip-009K.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{Constant distortion with logarithmically many value queries per query}
+\tag{ftip}
+\tag{preference-data}
+\tag{query-complexity}
+
+\p{Taking #{k} proportional to #{\log m} in \ref{ftip-009J} yields constant
+distortion with}
+
+##{
+ O(\log^2 m)
+}
+
+\p{value queries per agent. This is Corollary 2 of
+\citef{amanatidis2021peeking}, inherited as Theorem 3.5 by
+\citef{zhao2025limits}. Under the routing analogy, the count is per query, so
+a full table over #{|Q|} queries can require #{O(|Q|\log^2m)} values. The
+statement is an upper bound for the named mechanism in the common-circuit
+specialization of \ref{ftip-009J}. It is not a result for the full routing
+comparator, nor a lower bound saying that this many values are necessary.}

--- a/trees/ftip-009L.tree
+++ b/trees/ftip-009L.tree
@@ -1,0 +1,41 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{What the two source families establish for FTIP}
+\tag{ftip}
+\tag{alignment}
+\tag{preference-data}
+
+\p{The two source families expose distinct information models. The diagram
+places them in parallel lanes; it does not order them by information content.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=24mm,
+ minimum height=12mm,font=\small},
+ arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}
+]
+\node[box] (r) at (-3.6,1.3) {exact scalar reward};
+\node[box] (t) at (0,1.3) {exponential tilt\\gain identities};
+\node[box] (o) at (-3.6,-1.3) {ordinal or linked\\preference feedback};
+\node[box] (c) at (0,-1.3) {common-circuit\\cardinal queries};
+\draw[arr] (r) -- node[lab,above]{optimize} (t);
+\draw[arr] (o) -- node[lab,below,align=center]{different\\model} (c);
+\draw[dashed] (2.0,-2.1) -- (2.0,2.1);
+\node[align=left,font=\scriptsize] at (3.5,0) {no general\\information order};
+\end{tikzpicture}}
+
+\p{The KL identities characterize the exact optimizer for a declared scalar
+reward. The preference lower bounds are worst-case statements inside a fixed-
+circuit routing model. Bradley--Terry conclusions depend on the chosen score
+link. In the common-circuit specialization, cardinal queries change the
+information modality and admit a positive mechanism result. Outside that
+specialization, the preference and cardinal-query results are not directly
+comparable without further assumptions.}
+
+\p{None of these statements derives the finite transcript theorem
+\ref{ftip-007S}, and none proves that benchmark gain is capability
+acquisition. Their FTIP role is narrower: they identify which information is
+assumed, which optimizer or comparator is exact, and where transfer to a
+training system must stop.}

--- a/trees/refs/amanatidis2021peeking.tree
+++ b/trees/refs/amanatidis2021peeking.tree
@@ -1,0 +1,19 @@
+% ["social choice", "distortion", "cardinal queries"]
+\title{Peeking behind the ordinal curtain: Improving distortion via cardinal queries}
+\date{2021}
+\author/literal{Georgios Amanatidis}
+\author/literal{Georgios Birmpas}
+\author/literal{Aris Filos-Ratsikas}
+\author/literal{Alexandros A. Voudouris}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/1907.08165v3}
+
+\meta{bibtex}{\startverb
+@article{amanatidis2021peeking,
+  title = {Peeking Behind the Ordinal Curtain: Improving Distortion via Cardinal Queries},
+  author = {Amanatidis, Georgios and Birmpas, Georgios and Filos-Ratsikas, Aris and Voudouris, Alexandros A.},
+  year = {2021},
+  url = {https://arxiv.org/abs/1907.08165v3},
+  journal = {arXiv preprint arXiv:1907.08165}
+}
+\stopverb}

--- a/trees/refs/paes2026theoretical.tree
+++ b/trees/refs/paes2026theoretical.tree
@@ -1,0 +1,19 @@
+% ["alignment", "reward model", "information theory"]
+\title{Theoretical limits of language model alignment}
+\date{2026}
+\author/literal{Lucas Monteiro Paes}
+\author/literal{Natalie Mackraz}
+\author/literal{Barry-John Theobald}
+\author/literal{Federico Danieli}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2605.07105v1}
+
+\meta{bibtex}{\startverb
+@article{paes2026theoretical,
+  title = {Theoretical Limits of Language Model Alignment},
+  author = {Paes, Lucas Monteiro and Mackraz, Natalie and Theobald, Barry-John and Danieli, Federico},
+  year = {2026},
+  url = {https://arxiv.org/abs/2605.07105v1},
+  journal = {arXiv preprint arXiv:2605.07105}
+}
+\stopverb}

--- a/trees/refs/zhao2025limits.tree
+++ b/trees/refs/zhao2025limits.tree
@@ -5,14 +5,14 @@
 \author/literal{Jessica Dai}
 \author/literal{Pranjal Awasthi}
 \taxon{Reference}
-\meta{external}{https://arxiv.org/abs/2505.19964}
+\meta{external}{https://arxiv.org/abs/2505.19964v1}
 
 \meta{bibtex}{\startverb
 @article{zhao2025limits,
   title = {The Limits of Preference Data for Post-Training},
   author = {Zhao, Eric and Dai, Jessica and Awasthi, Pranjal},
   year = {2025},
-  url = {https://arxiv.org/abs/2505.19964},
+  url = {https://arxiv.org/abs/2505.19964v1},
   journal = {arXiv preprint arXiv:2505.19964}
 }
 \stopverb}


### PR DESCRIPTION
## Summary

This stacked PR appends 44 FTIP trees, bringing the suite from 301 to 345 entries. It reconstructs finite KL-regularized alignment identities and develops a separate preference-information lane around fixed-circuit routing lower bounds and a cardinal-query upper-bound specialization.

The source route is deliberately bounded:

- Paes et al. arXiv:2605.07105v1, equations 2.1–2.2, Theorems 1–2, and Appendix B
- Zhao, Dai, and Awasthi arXiv:2505.19964v1, Sections 2–3 and Appendix A
- Amanatidis et al. arXiv:1907.08165v3, Theorem 4 and Corollary 2

The note records source discrepancies and transfer conditions instead of silently repairing them. In particular, the Zhao reconstruction is conditional on pointwise response separation, its compromise-circuit example uses an explicit repaired specialization, and the positive cardinal-query result is restricted to the common-circuit specialization. Four compact diagrams illustrate the finite identities and information models.

## Stack dependency

This PR is stacked on PR #149 and targets its feature branch. The corrected PR #149 parent is now merged into this branch and its bounded self-containment re-review passes. The stack order remains: PR #149 must land before this PR.

## Verification

- independent content review: PASS
- independent source-fidelity review: PASS
- corrected-parent integration review: PASS
- `just chk` and `git diff --check`: PASS
- full `CI=1 just build` and `just verify-render`: PASS
- targeted PDF/output/date and strict-log gates: PASS
- 345 trees root-reachable exactly once
- final PDF: 129 A4 pages, 905,545 bytes
- PDF SHA-256: `032ec3c71ecdd73340660eb4ac329195a84df824224ee84de7bfbb3133624c87`
- affected parent pages re-inspected at 180 dpi; prior four-diagram source/render review remains PASS

No Lean formalization, broad model-family survey, or capability-acquisition claim is included.