### PR TITLE
FTIP controlled coverage and feedback resolution

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -68,3 +68,4 @@ that combination.}
 \transclude{ftip-005T}
 \transclude{ftip-0075}
 \transclude{ftip-008E}
+\transclude{ftip-009M}

--- a/trees/ftip-009M.tree
+++ b/trees/ftip-009M.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Controlled coverage, feedback resolution, and prompt breadth}
+\tag{ftip}
+\tag{reinforcement-learning}
+\tag{feedback}
+
+\p{This section studies finite measurements and controlled comparisons that
+separate starting-policy coverage from the information supplied by a reward.
+It also records how a training prompt law limits the scope of an observed
+post-training effect.}
+
+\p{The empirical route is a controlled language-model post-training study.
+Its reported outcomes remain experiment-specific observations. Theorems in
+this section are elementary finite-probability consequences of assumptions
+stated in the notes; they are not promoted from the empirical results.}
+
+\transclude{ftip-009N}
+\transclude{ftip-009X}
+\transclude{ftip-00A8}
+\transclude{ftip-00AK}

--- a/trees/ftip-009N.tree
+++ b/trees/ftip-009N.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Starting-policy interventions}
+\tag{ftip}
+\tag{policy}
+\tag{intervention}
+
+\p{A comparison among starting policies is meaningful only after the task,
+training grid, feedback rule, and evaluation procedure have been declared.
+This subsection types those experimental coordinates before recording any
+observed difference.}
+
+\transclude{ftip-009O}
+\transclude{ftip-009P}
+\transclude{ftip-009Q}
+\transclude{ftip-009R}
+\transclude{ftip-009S}
+\transclude{ftip-009T}
+\transclude{ftip-009U}
+\transclude{ftip-009V}
+\transclude{ftip-009W}

--- a/trees/ftip-009O.tree
+++ b/trees/ftip-009O.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{The source experiment as an intervention matrix}
+\tag{ftip}
+\tag{intervention}
+\tag{reinforcement-learning}
+
+\p{\citet{Sections 4.1--4.3 and Figure 1}{clay2026demystifying} organize the
+reported experiments along three
+declared axes: a starting model distribution, a training-prompt distribution,
+and a reward function. Each reported measurement therefore belongs to a cell
+of a matrix rather than to an unqualified ``RL post-training'' condition. The
+source holds its broad training recipe fixed while varying selected axes; it
+does not study variation among RL algorithms.}
+
+\p{For FTIP, a source cell must retain the model, task, prompt law, reward-rule
+identifier, training budget, and evaluation procedure attached to it. This is
+especially important here because the main text and Appendix C do not state
+identical sparse-reward semantics. Section 4.2 describes target containment
+with a length penalty. Appendix C's prose says an exact target receives unit
+reward, but its displayed equation requires the response to be strictly
+longer than the target for any positive reward. The note suite records this
+discrepancy instead of choosing an implementation on the source's behalf.}

--- a/trees/ftip-009P.tree
+++ b/trees/ftip-009P.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Target-response event}
+\tag{ftip}
+\tag{evaluation}
+\tag{target-response}
+
+\p{Fix an evaluation instance #{x}, a response space #{\mathcal Y_x}, and a
+declared target predicate #{h_x^\star:\mathcal Y_x\to\{0,1\}}. For a sampled
+response #{Y}, the \newvocab{target-response event} is}
+
+##{
+ E_x^\star=\{h_x^\star(Y)=1\}.
+}
+
+\p{The predicate is part of the evaluation specification. It may test exact
+string equality after a declared normalization, containment of a target
+substring, equality of a parsed answer, or another explicitly typed
+condition. These predicates are not interchangeable. The movie-quote and
+AIME experiments in \citet{Sections 4.1--4.2}{clay2026demystifying} use
+different response objects and therefore
+require different target predicates.}

--- a/trees/ftip-009Q.tree
+++ b/trees/ftip-009Q.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Exact-string success and task utility are different predicates}
+\tag{ftip}
+\tag{evaluation}
+\tag{utility}
+
+\p{Let #{y_x^\star} be a designated string and let #{N_x} be a declared
+normalizer. Exact-string success is the specialization
+#{h_x^\star(y)=\mathbf 1\{N_x(y)=N_x(y_x^\star)\}} of
+\ref{ftip-009P}. A task utility may instead accept semantically equivalent
+answers, assign partial credit, invoke a verifier, or depend on evaluator
+randomness as in \ref{ftip-005D}.}
+
+\p{Consequently, a change in target-string match rate is not automatically a
+change in task utility. \citet{Sections 4.1--4.2}{clay2026demystifying}
+deliberately use narrow target behaviours to
+study controlled coverage. Transferring their measurements to broader
+capability requires a separately justified evaluator.}

--- a/trees/ftip-009R.tree
+++ b/trees/ftip-009R.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Base, SFT-positive, and SFT-negative starting-policy triple}
+\tag{ftip}
+\tag{policy}
+\tag{supervised-fine-tuning}
+
+\p{For one declared model family and target predicate, a
+\newvocab{starting-policy triple} is}
+
+##{
+ \left(\pi^{\mathrm{base}},\pi^+,\pi^-\right).
+}
+
+\p{Here #{\pi^{\mathrm{base}}} is the unmodified starting policy,
+#{\pi^+} is obtained by a declared supervised update intended to increase
+target-response frequency, and #{\pi^-} is obtained by a declared update
+intended to decrease it. The superscripts name producing interventions, not
+mathematical order relations between the resulting policies.}
+
+\p{\citet{Section 4.1}{clay2026demystifying} instantiates the triple with
+the source's Base, SFT-positive, and SFT-negative checkpoints. For the movie
+quote, its SFT mixture places twenty percent weight on the target quote and
+eighty percent on other quotes from the Cornell Movie-Dialogs corpus; the
+negative intervention maximizes cross-entropy loss on the target.}

--- a/trees/ftip-009S.tree
+++ b/trees/ftip-009S.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{SFT-positive and SFT-negative are composite weight interventions}
+\tag{ftip}
+\tag{intervention}
+\tag{supervised-fine-tuning}
+
+\p{The policies #{\pi^+} and #{\pi^-} of \ref{ftip-009R} are produced by
+optimization. Their weights, output probabilities, representations, and
+off-target behaviours can all change together. Calling one intervention
+``positive'' and the other ``negative'' describes its intended effect on the
+declared target response; it does not assert that only one probability mass
+was edited.}
+
+\p{The comparisons in \citet{Sections 4.1 and 5.1}{clay2026demystifying}
+therefore test dependence on three constructed
+starting checkpoints. They do not identify a causal effect of initial target
+probability alone without an additional intervention model.}

--- a/trees/ftip-009T.tree
+++ b/trees/ftip-009T.tree
@@ -1,0 +1,31 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Controlled post-training experiment cell}
+\tag{ftip}
+\tag{experiment}
+\tag{post-training}
+
+\p{A \newvocab{controlled post-training experiment cell} is a record}
+
+##{
+ \mathfrak c=
+ (M,\pi^{\mathrm{init}},\mathsf T,\mathcal D_{\mathrm{tr}},
+ r^{\mathrm{id}},\mathcal A,b_{\mathrm{tr}},\mathsf E),
+}
+
+\p{where #{M} identifies the model architecture and checkpoint lineage,
+#{\pi^{\mathrm{init}}} is its starting policy, #{\mathsf T} is the task,
+#{\mathcal D_{\mathrm{tr}}} is the training-prompt law, #{r^{\mathrm{id}}}
+identifies an executable reward rule and version, #{\mathcal A} is the update
+procedure, #{b_{\mathrm{tr}}} is the training budget, and #{\mathsf E} is the
+evaluation interface. Random seeds and hyperparameters belong to the relevant
+record fields even when suppressed from the notation.}
+
+\p{\citet{Figure 1 and Sections 4.1--4.3}{clay2026demystifying} motivates the
+coordinates. The source varies
+starting distribution, prompt distribution, and reward while using a common
+broad RL setup. Because its main-text and Appendix-C sparse rewards differ,
+the reward field is an identifier for an executable rule, not merely the word
+``sparse.''}

--- a/trees/ftip-009U.tree
+++ b/trees/ftip-009U.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Matched cells and held-fixed coordinates}
+\tag{ftip}
+\tag{experiment}
+\tag{comparison}
+
+\p{Let #{J} index the coordinates of an experiment cell
+#{\mathfrak c} from \ref{ftip-009T}. For #{S\subseteq J}, two cells
+#{\mathfrak c} and #{\mathfrak c'} are \newvocab{matched outside #{S}} when}
+
+##{
+ \mathfrak c_j=\mathfrak c'_j\qquad\text{for every }j\in J\setminus S.
+}
+
+\p{The coordinates in #{J\setminus S} are the
+\newvocab{held-fixed coordinates}; those in #{S} are the declared
+intervention coordinates. Equality means equality at the resolution recorded
+by the experiment, including evaluation sample size when that size affects
+the reported statistic.}
+
+\p{A matched comparison licenses a contrast between the recorded cells. It
+does not show that a named coordinate is internally atomic. In particular,
+matching outside the starting-policy coordinate leaves the composite-checkpoint
+qualification of \ref{ftip-009S} in force.}

--- a/trees/ftip-009V.tree
+++ b/trees/ftip-009V.tree
@@ -1,0 +1,36 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Three starting laws under one declared training grid}
+\tag{ftip}
+\tag{experiment}
+\tag{example}
+
+\p{A source comparison may place the three starting policies of
+\ref{ftip-009R} into cells matched outside the starting-policy coordinate.
+The shared boxes below mean equality of the declared grid fields, not that the
+three checkpoints differ in only one scalar probability.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners=2pt,align=center,font=\scriptsize,
+   text width=20mm,minimum height=8mm},
+ shared/.style={draw,rounded corners=2pt,align=center,font=\scriptsize,
+   text width=27mm,minimum height=12mm},
+ flow/.style={-{Stealth[length=1.8mm]},thick}
+]
+\node[box] (base) at (0,1.4) {Base\\$\pi^{\mathrm{base}}$};
+\node[box] (plus) at (0,0) {SFT-positive\\$\pi^+$};
+\node[box] (minus) at (0,-1.4) {SFT-negative\\$\pi^-$};
+\node[shared] (grid) at (3.7,0) {same declared task,\\prompts, reward,\\update, and budget};
+\node[shared] (eval) at (7.4,0) {same evaluation\\interface and\\sample size};
+\draw[flow] (base) -- (grid);
+\draw[flow] (plus) -- (grid);
+\draw[flow] (minus) -- (grid);
+\draw[flow] (grid) -- (eval);
+\end{tikzpicture}}
+
+\p{This is the comparison pattern used in
+\citet{Sections 4.1 and 5.1}{clay2026demystifying}. An actual cell still needs its model, task,
+reward implementation, and numerical record; the diagram is not a claim that
+all experiments in the paper instantiate one identical grid.}

--- a/trees/ftip-009W.tree
+++ b/trees/ftip-009W.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{What the starting-policy comparison can and cannot identify}
+\tag{ftip}
+\tag{intervention}
+\tag{causal-scope}
+
+\p{Within a declared model, task, training grid, and evaluation procedure,
+the three-cell comparison can establish that the measured post-training
+outcome differs across the source's constructed starting checkpoints. The
+movie-quote and AIME entries in
+\citet{Section 5.1, Tables 1--2}{clay2026demystifying} are empirical records
+of that form.}
+
+\p{The comparison does not isolate initial target probability from every
+other SFT-induced weight change, prove that an observed zero has zero support,
+or establish acquisition of a broader capability. Nor should its inventory be
+silently generalized from the prose model list:
+\citet{Section 4.1}{clay2026demystifying} names OLMo 3,
+Qwen2-7B, Qwen3-1.7B, and Qwen2.5-7B-Instruct, while Table 1 and Appendix G
+also report Qwen3-8B and Qwen2-1.5B. The source-specific model and table row
+must remain attached to each claim.}

--- a/trees/ftip-009X.tree
+++ b/trees/ftip-009X.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Finite initial-coverage measurement}
+\tag{ftip}
+\tag{coverage}
+\tag{evaluation}
+
+\p{A finite evaluation records hits, not mathematical support. This
+subsection introduces the hit count and its sampling law, derives the exact
+zero-hit bound under independent sampling, and then returns to the limits of
+the source measurement.}
+
+\transclude{ftip-009Y}
+\transclude{ftip-009Z}
+\transclude{ftip-00A0}
+\transclude{ftip-00A1}
+\transclude{ftip-00A2}
+\transclude{ftip-00A3}
+\transclude{ftip-00A4}
+\transclude{ftip-00A5}
+\transclude{ftip-00A6}
+\transclude{ftip-00A7}

--- a/trees/ftip-009Y.tree
+++ b/trees/ftip-009Y.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Initial evaluation hit count}
+\tag{ftip}
+\tag{evaluation}
+\tag{statistics}
+
+\p{Fix a starting policy, an evaluation sampling law, and the target predicate
+of \ref{ftip-009P}. Before post-training, draw evaluation records
+#{(X_j,Y_j)_{j=1}^m}. Define the hit indicators and the
+\newvocab{initial evaluation hit count} by}
+
+##{
+ I_j^\star=h_{X_j}^\star(Y_j),
+ \qquad
+ K_m=\sum_{j=1}^{m}I_j^\star.
+}
+
+\p{The sampling law determines whether the instances #{X_j} are fixed,
+resampled, or stratified. The adjective ``initial'' locates the measurement
+before the post-training intervention; it does not assert that the samples
+are independent or that the starting policy is a foundation checkpoint.}

--- a/trees/ftip-009Z.tree
+++ b/trees/ftip-009Z.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Empirical initial success rate}
+\tag{ftip}
+\tag{evaluation}
+\tag{statistics}
+
+\p{For a nonempty initial evaluation sample of size #{m}, the
+\newvocab{empirical initial success rate} is}
+
+##{
+ \widehat p_m=\frac{K_m}{m}
+ =\widehat{\mathbb E}_{j\in\{1,\ldots,m\}}[I_j^\star],
+}
+
+\p{using the empirical-average convention of \ref{ftip-006Z}. This is a
+statistic of the declared sample. It is not, without a sampling model and an
+uncertainty statement, the exact successful-support probability
+#{p_P(x)} of \ref{ftip-005U}.}

--- a/trees/ftip-00A0.tree
+++ b/trees/ftip-00A0.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Zero observed hits are not zero probability}
+\tag{ftip}
+\tag{statistics}
+\tag{support}
+
+\p{The equality #{K_m=0} says that no target response occurred in one finite
+sample. Every success probability #{0\leq p<1} assigns positive probability
+#{(1-p)^m} to this observation under independent Bernoulli sampling. Thus
+#{\widehat p_m=0} does not imply #{p=0}, absence from mathematical support, or
+impossibility of discovery under a larger budget.}
+
+\p{The entries printed as 0.00 percent in
+\citet{Section 5.1, Tables 1--2}{clay2026demystifying} are empirical rates at the stated evaluation
+sizes. They must not be rewritten as exact support claims.}

--- a/trees/ftip-00A1.tree
+++ b/trees/ftip-00A1.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Zero-hit likelihood under iid evaluation}
+\tag{ftip}
+\tag{probability}
+\tag{statistics}
+
+\p{Assume the hit indicators from \ref{ftip-009Y} are independent Bernoulli
+variables with a common success probability #{p}. Then
+#{K_m} has the binomial law and}
+
+##{
+ \Pr_p(K_m=0)=(1-p)^m.
+}
+
+\proof{
+\p{The event #{K_m=0} is
+#{\bigcap_{j=1}^m\{I_j^\star=0\}}. Independence and
+#{\Pr_p(I_j^\star=0)=1-p} give the displayed product.}}
+
+\p{This is an FTIP-proved finite statement. Applying it to a source table
+requires the additional iid and stationary-success assumptions stated above.}

--- a/trees/ftip-00A2.tree
+++ b/trees/ftip-00A2.tree
@@ -1,0 +1,28 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{Exact one-sided bound after zero hits}
+\tag{ftip}
+\tag{probability}
+\tag{statistics}
+
+\p{Assume \ref{ftip-00A1} and fix #{0<\delta<1}. If #{K_m=0}, inversion of
+the exact zero-count likelihood gives the one-sided upper endpoint}
+
+##{
+ u_{m,\delta}=1-\delta^{1/m}.
+}
+
+\p{Indeed, #{\Pr_{u_{m,\delta}}(K_m=0)=\delta}, and for every
+#{p>u_{m,\delta}} one has #{\Pr_p(K_m=0)<\delta}. Thus the observed zero
+count excludes probabilities above #{u_{m,\delta}} at exact level
+#{\delta} under the declared iid model.}
+
+\proof{
+\p{By \ref{ftip-00A1}, the zero-count likelihood is #{(1-p)^m}, which is
+strictly decreasing in #{p}. Solving #{(1-p)^m=\delta} gives the endpoint and
+the stated strict inequality.}}
+
+\p{This is an FTIP-proved likelihood inversion, not a source theorem and not
+a support certificate.}

--- a/trees/ftip-00A3.tree
+++ b/trees/ftip-00A3.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{The 128-sample zero-hit bound}
+\tag{ftip}
+\tag{probability}
+\tag{calculation}
+
+\p{Take #{m=128} and #{\delta=0.05} in \ref{ftip-00A2}. After zero hits,
+the exact one-sided upper endpoint is}
+
+##{
+ u_{128,0.05}
+ =1-0.05^{1/128}
+ \approx 0.02313.
+}
+
+\p{Under the iid Bernoulli model, probabilities above approximately
+2.313 percent make a zero count less than five percent likely. The calculation
+does not turn a recorded #{0/128} into proof that the true probability is
+zero, and it does not apply if the 128 evaluations have a different joint
+sampling law.}

--- a/trees/ftip-00A4.tree
+++ b/trees/ftip-00A4.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{First positive sparse-reward time}
+\tag{ftip}
+\tag{reward}
+\tag{rollout}
+
+\p{Fix an executable sparse-reward rule and let #{r_j^{\mathrm{sp}}} be the
+reward returned on rollout #{j}. The \newvocab{first positive sparse-reward
+time} is the extended-valued index}
+
+##{
+ J_+=\inf\{j\geq1:r_j^{\mathrm{sp}}>0\},
+ \qquad \inf\varnothing:=\infty.
+}
+
+\p{This definition concerns the reward implementation named by an experiment
+cell. The event #{r_j^{\mathrm{sp}}>0} coincides with a target-response event
+only when that equality is part of the declared reward semantics. In
+particular, a length penalty or partial-credit rule can separate positive
+reward from exact target match.}

--- a/trees/ftip-00A5.tree
+++ b/trees/ftip-00A5.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{Sparse-reward discovery within a rollout budget}
+\tag{ftip}
+\tag{reward}
+\tag{rollout}
+
+\p{Suppose the events #{\{r_j^{\mathrm{sp}}>0\}} are independent and have a
+common probability #{q}. For every positive rollout budget #{B},}
+
+##{
+ \Pr(J_+\leq B)=1-(1-q)^B.
+}
+
+\proof{
+\p{Apply the independent-attempt theorem \ref{ftip-0078} with
+#{E_j=\{r_j^{\mathrm{sp}}>0\}}. Its discovery event is exactly
+#{\{J_+\leq B\}}.}}
+
+\p{This is an FTIP-proved specialization. It does not supply independence,
+stationarity, or the value of #{q} for a training run, and it does not equate
+positive proxy reward with task utility.}

--- a/trees/ftip-00A6.tree
+++ b/trees/ftip-00A6.tree
@@ -1,0 +1,60 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{The AIME 128-sample measurement record}
+\tag{ftip}
+\tag{evaluation}
+\tag{empirical-record}
+
+\p{\citet{Section 5.1, Table 2}{clay2026demystifying} reports the
+following empirical target-answer rates for AIME Problem 4 with
+Qwen2.5-7B-Instruct and evaluation size #{m=128}. The task asks for the number
+of integer pairs #{(x,y)\in[-100,100]^2} satisfying
+#{12x^2-xy-6y^2=0}; the target answer is #{117}.}
+
+##{
+\begin{array}{c|ccc}
+ &\mathrm{SFT{+}}&\mathrm{Base}&\mathrm{SFT{-}}\\ \hline
+\text{No Reward}&26.6&3.92&0.00\\
+\text{Sparse Reward}&85.9&10.2&0.00\\
+\text{Dense Reward}&86.7&92.2&0.00
+\end{array}
+}
+
+\p{Every entry in the displayed array is a percentage.}
+
+\tikzfig{\begin{tikzpicture}[
+ cell/.style={draw,align=center,font=\scriptsize,text width=17mm,
+   minimum height=7mm},
+ row/.style={draw,align=left,font=\scriptsize,text width=21mm,
+   minimum height=7mm}
+]
+\node[font=\scriptsize] at (0,1.65) {source row};
+\node[font=\scriptsize] at (2.25,1.65) {SFT+};
+\node[font=\scriptsize] at (4.15,1.65) {Base};
+\node[font=\scriptsize] at (6.05,1.65) {SFT-};
+\node[row] at (0,0.8) {No Reward};
+\node[cell] at (2.25,0.8) {26.6 percent};
+\node[cell] at (4.15,0.8) {3.92 percent};
+\node[cell] at (6.05,0.8) {0.00 percent};
+\node[row] at (0,0) {Sparse Reward};
+\node[cell] at (2.25,0) {85.9 percent};
+\node[cell] at (4.15,0) {10.2 percent};
+\node[cell] at (6.05,0) {0.00 percent};
+\node[row] at (0,-0.8) {Dense Reward};
+\node[cell] at (2.25,-0.8) {86.7 percent};
+\node[cell] at (4.15,-0.8) {92.2 percent};
+\node[cell] at (6.05,-0.8) {0.00 percent};
+\node[font=\scriptsize,align=center] at (3.1,-1.65)
+ {Qwen2.5-7B-Instruct, AIME Problem 4, evaluation $m=128$};
+\end{tikzpicture}}
+
+\p{These are source-reported empirical percentages, not exact policy
+probabilities. ``No Reward'' is retained as the source's row label; the table
+alone does not define it as a post-training protocol. The three zero entries
+for SFT-negative are finite observations and remain subject to
+\ref{ftip-00A0}. Appendix Figure 5's caption prints a different set of
+Qwen2.5-7B-Instruct values that duplicates the neighbouring movie-quote
+caption and is incompatible with Table 2. This card preserves the exact
+Table 2 record and does not silently reconcile that source discrepancy.}

--- a/trees/ftip-00A7.tree
+++ b/trees/ftip-00A7.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{An observed plateau is not a universal probability threshold}
+\tag{ftip}
+\tag{optimization}
+\tag{empirical-record}
+
+\p{\citet{Section 5.2 and Figure 2}{clay2026demystifying} report that the
+Qwen3-1.7B Base movie-quote cell, whose initial empirical match rate is about
+0.5 percent, does not optimize under the source's sparse-reward run, whereas its
+dense-reward run rises toward fifty percent.
+\citet{Appendix Figure 8}{clay2026demystifying} gives final match rates
+10.0 percent for sparse reward and 48.8 percent for dense reward. Thus
+``failed'' here means failure of the reported sparse run to optimize as
+intended, not zero final matches.}
+
+\p{A plateau is indexed by the model, target, reward implementation,
+optimizer, sampling process, and budget in its experiment cell. One observed
+transition therefore does not identify a universal initial-probability
+threshold for RL learning, support, or capability acquisition.}

--- a/trees/ftip-00A8.tree
+++ b/trees/ftip-00A8.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Sparse, dense, and process feedback}
+\tag{ftip}
+\tag{reward}
+\tag{feedback}
+
+\p{Sparse, dense, and process rewards expose different observations about a
+response. This subsection treats that difference as a change in the feedback
+channel, rather than as a free change in the smoothness of one fixed
+objective.}
+
+\transclude{ftip-00A9}
+\transclude{ftip-00AA}
+\transclude{ftip-00AB}
+\transclude{ftip-00AC}
+\transclude{ftip-00AD}
+\transclude{ftip-00AE}
+\transclude{ftip-00AF}
+\transclude{ftip-00AG}
+\transclude{ftip-00AH}
+\transclude{ftip-00AI}
+\transclude{ftip-00AJ}

--- a/trees/ftip-00A9.tree
+++ b/trees/ftip-00A9.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Sparse exact reward}
+\tag{ftip}
+\tag{reward}
+\tag{sparse-feedback}
+
+\p{Let #{\mathcal Y} be a finite response set and fix a target response
+#{\tau\in\mathcal Y}. The \newvocab{sparse exact reward} is the map
+#{r_{\rm exact}:\mathcal Y\to\{0,1\}} defined by}
+
+##{
+ r_{\rm exact}(y)=\mathbf 1\{y=\tau\}.
+}
+
+\p{This is a locally owned idealization. It exposes one bit: whether the whole
+response equals the target. It does not expose a prefix, edit location, or
+partial milestone. The movie-quote source uses related but textually
+inconsistent substring and length-penalized rewards; the following remark keeps
+those formulas separate.}

--- a/trees/ftip-00AA.tree
+++ b/trees/ftip-00AA.tree
@@ -1,0 +1,38 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Main-text and Appendix-C sparse-reward discrepancy}
+\tag{ftip}
+\tag{reward}
+\tag{source-discrepancy}
+
+\p{Section 4.2 of \citef{clay2026demystifying} displays a substring indicator
+#{\mathbf 1\{\tau\subseteq y\}} and says that a length penalty is applied.
+In Appendix C, #{n} is the maximum generation length and #{s} is the number of
+tokens beyond the target. The appendix first defines the excess-length penalty}
+
+##{
+ p(s)=
+ \begin{cases}
+  0,&s=0,\\
+  s/n,&s>0,
+ \end{cases}
+}
+
+\p{and then gives Equation (3):}
+
+##{
+ r_{\rm C}(y,\tau)=
+ \begin{cases}
+  \max\{0.5,1-p(s)\},&\tau\text{ occurs in }y
+    \text{ and }|y|>|\tau|,\\
+  0,&\text{otherwise}.
+ \end{cases}
+}
+
+\p{As printed, Equation (3) assigns zero when #{y=\tau}, because its first
+branch requires strict excess length. This conflicts with the immediately
+preceding Appendix-C prose, which assigns base reward one when the target is
+generated, and it is not the exact-match reward of \ref{ftip-00A9}. We record
+the discrepancy rather than silently repairing the source implementation.}

--- a/trees/ftip-00AB.tree
+++ b/trees/ftip-00AB.tree
@@ -1,0 +1,36 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Edit-distance reward}
+\tag{ftip}
+\tag{reward}
+\tag{dense-feedback}
+
+\p{Let #{y=y_1\cdots y_m} and a nonempty target
+#{\tau=\tau_1\cdots\tau_n} be finite strings. Their \newvocab{Levenshtein
+distance} is determined by #{D(0,j)=j}, #{D(i,0)=i}, and, for #{i,j>0},}
+
+##{
+ D(i,j)=\min\left\{
+ \begin{aligned}
+  &D(i-1,j)+1,\\
+  &D(i,j-1)+1,\\
+  &D(i-1,j-1)+\mathbf 1\{y_i\neq\tau_j\}
+ \end{aligned}
+ \right\}.
+}
+
+\p{Set #{L(y,\tau)=\max\{|y|,|\tau|\}}. The \newvocab{edit-distance reward}
+is}
+
+##{
+ r_{\rm edit}(y,\tau)
+ =\max\left\{0,1-\frac{D(|y|,|\tau|)}{L(y,\tau)}\right\}.
+}
+
+\p{The recurrence is Equation (1) in the main text and Equation (4) in
+Appendix C of \citef{clay2026demystifying}; the normalized reward is its
+Equation (5). The nonempty-target assumption makes the displayed denominator
+positive. This is a source reconstruction, not a claim that edit similarity is
+the correct utility for a different task.}

--- a/trees/ftip-00AC.tree
+++ b/trees/ftip-00AC.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Dense reward imports target structure}
+\tag{ftip}
+\tag{reward}
+\tag{feedback}
+
+\p{The edit reward of \ref{ftip-00AB} is not obtained from the binary value in
+\ref{ftip-00A9} by a numerical smoothing operation. It also receives the target
+string, a character-level edit model, and the ordering of symbols. Two
+non-target responses that both receive sparse reward zero can therefore receive
+different edit rewards.}
+
+\p{That extra resolution can improve credit assignment, but it changes the
+feedback channel and its assumptions. The source calls edit distance a dense
+proxy and reports controlled movie-quote experiments
+\citet{Sections 4.2 and 5.2}{clay2026demystifying}. Neither the formula nor
+those observations establish that edit proximity is an independent measure of
+general response quality.}

--- a/trees/ftip-00AD.tree
+++ b/trees/ftip-00AD.tree
@@ -1,0 +1,35 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Milestone process reward}
+\tag{ftip}
+\tag{reward}
+\tag{process-feedback}
+
+\p{For the source's fixed AIME problem, let}
+
+##{
+ M(y)=(m_1(y),\ldots,m_5(y))\in\{0,1\}^5
+}
+
+\p{record whether a completed response contains five declared milestones: a
+valid algebraic setup, correct root relations, correct integer bounds, a
+correct count for at least one branch, and correct subtraction of the overlap
+at the origin. With}
+
+##{
+ (w_1,\ldots,w_5)=(0.05,0.05,0.10,0.15,0.25),
+}
+
+\p{the \newvocab{milestone process reward} is}
+
+##{
+ r_{\rm proc}(y)=\sum_{i=1}^{5}w_i m_i(y).
+}
+
+\p{Appendix D.1 of \citef{clay2026demystifying} gives Equation (6) and the
+milestone list reconstructed here. In the experiment, a 32-billion-parameter
+instruction-tuned model classifies the completed trajectory. The displayed
+map is therefore richer than a deterministic final-answer verifier, even
+though it returns one scalar after the rollout.}

--- a/trees/ftip-00AE.tree
+++ b/trees/ftip-00AE.tree
@@ -1,0 +1,40 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Process feedback assumptions and milestone-weight discrepancy}
+\tag{ftip}
+\tag{process-feedback}
+\tag{source-discrepancy}
+
+\p{Appendix D.2 of \citef{clay2026demystifying} supplements
+#{r_{\rm proc}} with an extracted-answer override and two penalties. Translating
+its notation, let #{\tau=117}, #{\tau_{\rm near}=118}, and define}
+
+##{
+ r_{\rm base}(y)=
+ \begin{cases}
+  1.0,&\operatorname{extract}(y)=\tau,\\
+  0.6,&\operatorname{extract}(y)=\tau_{\rm near},\\
+  r_{\rm proc}(y),&\text{otherwise}.
+ \end{cases}
+}
+
+\p{Let #{p_{\rm loop}(y)=-0.3} when the judge flags a loop without the exact
+answer, and zero otherwise. Let #{p_{\rm format}(y)=-0.5} when the response
+lacks the required boxed delimiter, and zero otherwise. Equations (7)--(8)
+then give}
+
+##{
+ r_{\rm PRM}(y)
+ =\max\{0,r_{\rm base}(y)+p_{\rm loop}(y)+p_{\rm format}(y)\}.
+}
+
+\p{These clauses assume a reliable milestone judge, parser, near-miss choice,
+loop flag, and formatting rule. They are part of the feedback definition, not
+consequences of reinforcement learning. The main text describes
+``exponentially increasing'' dense rewards, and Appendix D calls the weights
+``exponential scaling.'' The printed vector
+#{(0.05,0.05,0.10,0.15,0.25)} is neither strictly increasing at every
+milestone nor a geometric progression. We preserve the exact weights and do
+not infer an exponential law from that wording.}

--- a/trees/ftip-00AF.tree
+++ b/trees/ftip-00AF.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Reward-induced observational equivalence}
+\tag{ftip}
+\tag{reward}
+\tag{identifiability}
+
+\p{Let #{\mathcal Y} be a finite response set and #{r:\mathcal Y\to\mathcal R}
+any reward map. Two responses are \newvocab{observationally equivalent under
+#{r}}, written #{y\sim_r y'}, when}
+
+##{
+ y\sim_r y'\quad\Longleftrightarrow\quad r(y)=r(y').
+}
+
+\p{Equality makes #{\sim_r} an equivalence relation. Its quotient
+#{\mathcal Y/{\sim_r}} is the finite set of response classes distinguished by
+the reward alone. This is a local FTIP definition: it ignores any information
+in the response that is not returned by #{r}, and it does not identify reward
+equality with equal latent utility.}

--- a/trees/ftip-00AG.tree
+++ b/trees/ftip-00AG.tree
@@ -1,0 +1,35 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Lemma}
+\title{Refining feedback separates at least as many responses}
+\tag{ftip}
+\tag{feedback}
+\tag{identifiability}
+
+\p{Let #{\mathcal Y} be finite and let #{r_1:\mathcal Y\to\mathcal R_1} and
+#{r_2:\mathcal Y\to\mathcal R_2}. Say that #{r_2} \newvocab{refines} #{r_1}
+when}
+
+##{
+ r_2(y)=r_2(y')\quad\Longrightarrow\quad r_1(y)=r_1(y')
+ \qquad(y,y'\in\mathcal Y).
+}
+
+\p{If #{r_2} refines #{r_1}, then}
+
+##{
+ \left|\mathcal Y/{\sim_{r_2}}\right|
+ \geq
+ \left|\mathcal Y/{\sim_{r_1}}\right|.
+}
+
+\proof{
+\p{Send the #{r_2}-class of #{y} to the #{r_1}-class of #{y}. The refinement
+condition makes this map well defined. It is surjective because every
+#{r_1}-class contains some #{y}, whose #{r_2}-class maps to it. A surjection
+between finite sets has a domain at least as large as its codomain.}}
+
+\p{\strong{Status: FTIP-proved finite lemma.} It compares observational
+partitions only. It does not say that the refined reward is cheaper, more
+accurate, or better aligned with utility.}

--- a/trees/ftip-00AH.tree
+++ b/trees/ftip-00AH.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: equal sparse reward, unequal dense reward}
+\tag{ftip}
+\tag{reward}
+\tag{counterexample}
+
+\p{Take the target string #{\tau=\texttt{abc}} and two responses
+#{y=\texttt{abx}} and #{y'=\texttt{xyz}}. Both fail exact matching, while
+their edit distances and normalized edit rewards are}
+
+##{
+\begin{array}{c|c|c|c}
+ \text{response}&r_{\rm exact}&D(\,cdot\,,\tau)&r_{\rm edit}\\ \hline
+ \texttt{abx}&0&1&2/3\\
+ \texttt{xyz}&0&3&0
+\end{array}
+}
+
+\p{Thus #{y\sim_{r_{\rm exact}}y'} but
+#{y\not\sim_{r_{\rm edit}}y'}. The example witnesses a strict separation
+inside one sparse-reward class. It does not claim that every dense proxy
+refines every sparse verifier.}

--- a/trees/ftip-00AI.tree
+++ b/trees/ftip-00AI.tree
@@ -1,0 +1,32 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Three feedback resolutions on one response set}
+\tag{ftip}
+\tag{reward}
+\tag{feedback}
+
+\p{One finite response set can be observed through three different maps. The
+arrows below share a domain; they do not assert that the three codomains form a
+refinement chain.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=30mm,
+   minimum height=13mm,font=\small},
+ arr/.style={->,>=stealth,semithick}
+]
+\node[box] (y) at (-4.2,0) {finite responses\\$\mathcal Y$};
+\node[box] (s) at (0,2.0) {exact-reward classes\\binary verifier};
+\node[box] (e) at (0,0) {edit-reward classes\\target metric};
+\node[box] (p) at (0,-2.0) {process-reward classes\\judge and parser};
+\draw[arr] (y) -- (s);
+\draw[arr] (y) -- (e);
+\draw[arr] (y) -- (p);
+\end{tikzpicture}}
+
+\p{The exact reward forgets every difference among failures. Edit reward can
+retain character-level proximity, while the source process reward retains a
+declared milestone vector only after judge, override, and penalty choices. The
+partition lemma \ref{ftip-00AG} applies to a pair only after its refinement
+hypothesis has been checked.}

--- a/trees/ftip-00AJ.tree
+++ b/trees/ftip-00AJ.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Reward density is not cost-free smoothing}
+\tag{ftip}
+\tag{reward}
+\tag{cost}
+
+\p{A denser reward can distinguish more responses and supply more frequent
+update signal. It can also require information absent from a sparse verifier.
+In the controlled source, edit feedback assumes the full target and computes a
+string metric; process feedback uses a 32-billion-parameter judge, five
+problem-specific milestones, answer extraction, an enumerated near miss, and
+loop and format penalties \citet{Appendices C--D}{clay2026demystifying}.}
+
+\p{FTIP must therefore charge for specifying, computing, and validating the
+richer channel. Replacing sparse feedback by dense feedback can alter both the
+information available to training and the objective being optimized. The
+resulting comparison is an intervention on feedback resolution, not evidence
+that one fixed reward was smoothed at zero cost.}

--- a/trees/ftip-00AK.tree
+++ b/trees/ftip-00AK.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Prompt breadth and effect locality}
+\tag{ftip}
+\tag{prompt-distribution}
+\tag{distribution-shift}
+
+\p{Training on one prompt law can change behavior unevenly across evaluation
+slices. This subsection types the training law and the measured slices before
+distinguishing localized from distributed degradation.}
+
+\transclude{ftip-00AL}
+\transclude{ftip-00AM}
+\transclude{ftip-00AN}
+\transclude{ftip-00AO}
+\transclude{ftip-00AP}
+\transclude{ftip-00AQ}
+\transclude{ftip-00AR}
+\transclude{ftip-00AS}
+\transclude{ftip-00AT}

--- a/trees/ftip-00AL.tree
+++ b/trees/ftip-00AL.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Training prompt law and evaluated prompt slice}
+\tag{ftip}
+\tag{prompt-distribution}
+\tag{evaluation}
+
+\p{Let #{\mathcal X} be a task-instance set. Write
+#{\mu_{\rm tr}=\mathcal D_{\rm tr}} for the training-prompt coordinate of an
+experiment cell in \ref{ftip-009T}. A \newvocab{training prompt law} is this
+probability law on #{\mathcal X}, used to draw instances during a post-training
+protocol. Let #{\mu_{\rm ev}} be an independently declared evaluation law on
+the same set.}
+
+\p{An \newvocab{evaluated prompt slice} is a measurable set
+#{C\subseteq\mathcal X} with #{\mu_{\rm ev}(C)>0}. Its conditional evaluation
+law is}
+
+##{
+ \mu_{\rm ev}(A\mid C)
+ =\frac{\mu_{\rm ev}(A\cap C)}{\mu_{\rm ev}(C)}.
+}
+
+\p{The training and evaluation laws need not agree. A slice records where an
+effect is measured; it does not assert that prompts inside the slice are
+equally difficult or represented equally in pretraining. We specialize the
+task-law convention of \ref{ftip-001Q}.}

--- a/trees/ftip-00AM.tree
+++ b/trees/ftip-00AM.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Source-specific narrow and broad configurations}
+\tag{ftip}
+\tag{prompt-distribution}
+\tag{experiment}
+
+\p{A \newvocab{prompt configuration} is the record}
+
+##{
+ \mathsf c=(M_0,\mu_{\rm tr},m_{\rm tr},r,\mathsf A,b),
+}
+
+\p{containing the starting artifact, training prompt law, finite prompt-pool
+size, reward, update algorithm, and training budget. We call two particular
+records #{\mathsf c_{\rm nar}} and #{\mathsf c_{\rm brd}} only when a cited
+experiment names them narrow and broad.}
+
+\p{Section 4.3 and Appendix F of \citef{clay2026demystifying} instantiate
+these labels in two model-family experiments. The Qwen comparison uses 100
+DeepScaleR prompts versus 10,000 WildChat prompts. The OLMo comparison uses
+100 math-only prompts versus 10,000 prompts split evenly among mathematics,
+instruction following, and code. These are source-defined configurations,
+not a note-wide definition of breadth.}

--- a/trees/ftip-00AN.tree
+++ b/trees/ftip-00AN.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Prompt breadth is not a total order}
+\tag{ftip}
+\tag{prompt-distribution}
+\tag{causal-inference}
+
+\p{The records in \ref{ftip-00AM} change several coordinates together. The
+prompt-pool size, domain mixture, and repetition frequency differ. Across the
+paper's Qwen and OLMo studies, the starting artifact and evaluated tasks also
+differ.}
+
+\p{We therefore use ``narrow'' and ``broad'' as names for the source cells.
+They do not define a total order on prompt laws, and their comparison does not
+identify a causal effect of breadth alone. A breadth theorem would need a
+declared statistic and matched configurations that differ only in that
+statistic.}

--- a/trees/ftip-00AO.tree
+++ b/trees/ftip-00AO.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Slice-conditioned success change}
+\tag{ftip}
+\tag{evaluation}
+\tag{distribution-shift}
+
+\p{Fix an evaluated slice #{C} from \ref{ftip-00AL}, and let #{P_0} and
+#{P_1} denote the pre- and post-training protocols whose successful-support
+probabilities are defined in \ref{ftip-005U}. The
+\newvocab{slice-conditioned success change} is}
+
+##{
+ \Delta_{\rm suc}(C;P_1,P_0)
+ =\mathbb E_{X\sim\mu_{\rm ev}(\cdot\mid C)}
+  \left[p_{P_1}(X)-p_{P_0}(X)\right].
+}
+
+\p{The evaluation interface, inference budget, and success predicate are
+held fixed across the two terms. The quantity is an average change on one
+declared slice. It neither locates the change inside the model nor identifies
+which training coordinate caused it.}

--- a/trees/ftip-00AP.tree
+++ b/trees/ftip-00AP.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Localized and distributed degradation}
+\tag{ftip}
+\tag{evaluation}
+\tag{distribution-shift}
+
+\p{Fix pairwise disjoint evaluated slices #{C_1,\ldots,C_J} and a declared
+degradation threshold #{\kappa>0}. Define the set of materially degraded
+slices}
+
+##{
+ \mathcal H_\kappa(P_1,P_0)
+ =\left\{j:\Delta_{\rm suc}(C_j;P_1,P_0)\leq-\kappa\right\}.
+}
+
+\p{Degradation is \newvocab{localized} relative to this slice family and
+threshold when #{|\mathcal H_\kappa|=1}. It is \newvocab{distributed} when
+#{|\mathcal H_\kappa|\geq2}.}
+
+\p{These terms depend on the chosen partition, threshold, and evaluation
+budget. They do not turn a finite benchmark vector into a statement about all
+capabilities.}

--- a/trees/ftip-00AQ.tree
+++ b/trees/ftip-00AQ.tree
@@ -1,0 +1,37 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Narrow and broad random-reward paths}
+\tag{ftip}
+\tag{prompt-distribution}
+\tag{random-reward}
+
+\p{Section 5.3 and Appendix F of \citef{clay2026demystifying} supply two OLMo
+paths; Figure 4 reports their outcomes. Both replace the
+usual verifiable reward with a random scalar drawn from #{\operatorname{Unif}[0,1]},
+but their prompt configurations differ.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=27mm,
+ minimum height=10mm,font=\small},
+ arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}
+]
+\node[box] (n0) at (-3.6,1.25) {100 math-only\\prompts};
+\node[box] (n1) at (0,1.25) {random-reward\\post-training};
+\node[box] (n2) at (3.6,1.25) {large GSM8K loss;\\smaller other losses};
+\node[box] (b0) at (-3.6,-1.25) {10,000 mixed-domain\\prompts};
+\node[box] (b1) at (0,-1.25) {random-reward\\post-training};
+\node[box] (b2) at (3.6,-1.25) {entropy spike and\\multi-domain collapse};
+\draw[arr] (n0) -- node[lab,above]{narrow cell} (n1);
+\draw[arr] (n1) -- (n2);
+\draw[arr] (b0) -- node[lab,below]{broad cell} (b1);
+\draw[arr] (b1) -- (b2);
+\end{tikzpicture}}
+
+\p{In the narrow SFT-start path, GSM8K accuracy falls from 86 to about 32 by
+step 400, while the reported MMLU and IFEval changes are much smaller. In the
+broad path, the source reports an entropy spike near step 400 together with
+collapse on GSM8K, MMLU, and IFEval. The diagram records that interpretation;
+it does not isolate prompt breadth from pool size, mixture, or repetition.}

--- a/trees/ftip-00AR.tree
+++ b/trees/ftip-00AR.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{What the source observes about spurious reward}
+\tag{ftip}
+\tag{random-reward}
+\tag{evaluation}
+
+\p{Section 5.3 and Figures 3--4 of \citef{clay2026demystifying} report that
+the Qwen narrow configuration retains higher MATH and AMC Acc@1 than its broad
+configuration under random reward. The OLMo experiment reports the different
+evaluation patterns summarized in \ref{ftip-00AQ}.}
+
+\p{These are finite empirical observations. The random scalar reward removes
+task alignment from one feedback channel, but it does not hold all other
+training coordinates fixed. The reported entropy is a named token statistic,
+not a direct measure of capability or acquisition.}

--- a/trees/ftip-00AS.tree
+++ b/trees/ftip-00AS.tree
@@ -1,0 +1,39 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Counterexample: equal marginal reward, unequal prompt-local damage}
+\tag{ftip}
+\tag{counterexample}
+\tag{random-reward}
+
+\p{Let two evaluation slices #{C_1,C_2} have equal mass. A feedback channel
+returns an independent Bernoulli reward with mean #{1/2} under either of two
+post-training protocols. Suppose their fixed-interface success changes are}
+
+##{
+ \left(\Delta_{\rm suc}(C_1),\Delta_{\rm suc}(C_2)\right)
+ =(-1,0)
+ \quad\hbox{or}\quad
+ \left(-\tfrac12,-\tfrac12\right).
+}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=29mm,
+ minimum height=10mm,font=\small},
+ arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}
+]
+\node[box] (r) at (0,1.5) {observed reward\\mean $1/2$};
+\node[box] (a) at (-3.2,-0.9) {protocol $P_A$\\changes $(-1,0)$};
+\node[box] (b) at (3.2,-0.9) {protocol $P_B$\\changes $(-1/2,-1/2)$};
+\draw[arr] (r) -- node[lab,left]{same marginal} (a);
+\draw[arr] (r) -- node[lab,right]{same marginal} (b);
+\node[font=\scriptsize] at (-3.2,-2.0) {localized at $\kappa=1/2$};
+\node[font=\scriptsize] at (3.2,-2.0) {distributed at $\kappa=1/2$};
+\end{tikzpicture}}
+
+\p{The reward law and its mean are identical, but the slice-level evaluation
+vectors differ. Hence marginal training reward does not determine whether
+damage is localized or distributed. This is a finite counterexample, not a
+claim about the mechanism in the source experiment.}

--- a/trees/ftip-00AT.tree
+++ b/trees/ftip-00AT.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Transfer limits and next questions}
+\tag{ftip}
+\tag{research-programme}
+\tag{transfer-limit}
+
+\p{The source cells motivate tests of starting-policy coverage, feedback
+resolution, and prompt-conditioned damage. They do not establish that dense
+reward creates mathematical support, that zero sampled hits imply zero
+probability, or that random reward has one model-independent effect.}
+
+\p{The next mathematical questions require stronger intervention contracts.
+One route matches prompt laws while varying only the feedback sigma-algebra.
+Another fixes feedback and evaluation while varying one starting-policy
+coordinate. A third asks for finite confidence regions on the complete vector
+of slice-conditioned changes rather than a single aggregate score.}
+
+\p{Until such assumptions are supplied, the controlled study is an empirical
+instrument and falsification context. It is not a frontier-wide theorem about
+capability acquisition, elicitation, or the optimal allocation of
+post-training compute.}

--- a/trees/refs/clay2026demystifying.tree
+++ b/trees/refs/clay2026demystifying.tree
@@ -1,0 +1,22 @@
+% ["reinforcement learning", "post-training", "controlled coverage"]
+\title{Demystifying Reinforcement Learning Post-Training of Language Models}
+\date{2026}
+\author/literal{Donovan Clay}
+\author/literal{Saket Gollapudi}
+\author/literal{Sankar Harilal}
+\author/literal{Min Jang}
+\author/literal{Jacob Morrison}
+\author/literal{Sewoong Oh}
+\author/literal{Natasha Jaques}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2608.24949v1}
+
+\meta{bibtex}{\startverb
+@article{clay2026demystifying,
+  title = {Demystifying Reinforcement Learning Post-Training of Language Models},
+  author = {Clay, Donovan and Gollapudi, Saket and Harilal, Sankar and Jang, Min and Morrison, Jacob and Oh, Sewoong and Jaques, Natasha},
+  year = {2026},
+  url = {https://arxiv.org/abs/2608.24949v1},
+  journal = {arXiv preprint arXiv:2608.24949}
+}
+\stopverb}


### PR DESCRIPTION
## Summary

- add a 44-tree FTIP section on controlled starting-policy interventions, finite coverage measurement, feedback resolution, and prompt-local effects
- reconstruct the empirical intervention matrix of Clay et al. from arXiv:2608.24949v1 while recording source discrepancies and transfer limits
- prove only the finite iid/binomial, discovery, and reward-refinement consequences owned by the note
- add five compact worked diagrams and one pinned primary reference

## Stack

- stacked on PR #150
- landing order: #149, #150, then this PR

## Verification

- independent content and exact-source/render reviews pass on head `d7117d5c0513ea4d9dfb9c91ff361bdb58e83eea`
- `just chk` and full `CI=1 just build`
- 389/389 FTIP trees root-reachable exactly once; no missing, cyclic, duplicate, or new forward FTIP references
- `just verify-render`: 1,865 HTML/XML pairs
- targeted FTIP PDF/output/date gates and zero strict log hits
- all five SVGs and affected PDF pages visually inspected
- 147-page PDF SHA-256: `fa59d653b12a805654b078cab74a2b985bd1b8d7e44af05657d456cd2a29184f`