### PR TITLE
FTIP optimizer geometry and representation dependence

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -69,3 +69,4 @@ that combination.}
 \transclude{ftip-0075}
 \transclude{ftip-008E}
 \transclude{ftip-009M}
+\transclude{ftip-00AU}

--- a/trees/ftip-00AU.tree
+++ b/trees/ftip-00AU.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Optimizer geometry and representation dependence}
+\tag{ftip}
+\tag{optimization}
+\tag{gauge-symmetry}
+
+\p{A scalar objective does not by itself determine a training intervention.
+This section studies an exact finite-dimensional witness: one represented
+matrix can have many factor bases, the loss can be constant along that gauge
+orbit, and an update rule can nevertheless distinguish the bases.}
+
+\p{The principal source is the version-one arXiv preprint
+\citef{singh2026lossbasis}. Its algebraic results are reconstructed under their
+stated dimensions, rank conditions, state conventions, and real-arithmetic
+assumptions. Experimental observations remain source-local.}
+
+\transclude{ftip-00AV}
+\transclude{ftip-00B6}
+\transclude{ftip-00BK}
+\transclude{ftip-00BS}

--- a/trees/ftip-00AV.tree
+++ b/trees/ftip-00AV.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Factored objectives and gauge symmetry}
+\tag{ftip}
+\tag{matrix-factorization}
+\tag{gauge-symmetry}
+
+\p{We first separate a represented matrix from a choice of factors and then
+separate its full product-preserving symmetry from the orthogonal subgroup
+that preserves the Euclidean parameter metric.}
+
+\transclude{ftip-00AW}
+\transclude{ftip-00AX}
+\transclude{ftip-00AY}
+\transclude{ftip-00AZ}
+\transclude{ftip-00B0}
+\transclude{ftip-00B1}
+\transclude{ftip-00B2}
+\transclude{ftip-00B3}
+\transclude{ftip-00B4}
+\transclude{ftip-00B5}

--- a/trees/ftip-00AW.tree
+++ b/trees/ftip-00AW.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Notation}
+\title{Factored objective and represented matrix}
+\tag{ftip}
+\tag{matrix-factorization}
+
+\p{Fix integers #{d_1,d_2,k\geq1}. Let
+#{U\in\mathbb R^{d_1\times k}} and #{V\in\mathbb R^{d_2\times k}} be
+factors, let}
+
+##{
+ W(U,V)=UV^{\mathsf T}\in\mathbb R^{d_1\times d_2},
+}
+
+\p{and let #{f:\mathbb R^{d_1\times d_2}\to\mathbb R} be differentiable.
+The corresponding \newvocab{factored objective} is
+#{L(U,V)=f(W(U,V))}. The pair #{(U,V)} is a parameterization; #{W(U,V)} is
+the represented object on which #{f} depends. This is the rectangular form
+noted in Section 3 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00AX.tree
+++ b/trees/ftip-00AX.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{General linear gauge action}
+\tag{ftip}
+\tag{gauge-symmetry}
+
+\p{For #{A\in\mathrm{GL}(k)}, define the \newvocab{general linear gauge
+action} by}
+
+##{
+ \gamma_A(U,V)=(UA,VA^{-\mathsf T}).
+}
+
+\p{The inverse transpose on the second factor is essential for a general
+invertible #{A}. When #{A=Q\in\mathrm O(k)}, one has
+#{Q^{-\mathsf T}=Q}, and the action becomes #{(UQ,VQ)}.}

--- a/trees/ftip-00AY.tree
+++ b/trees/ftip-00AY.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Lemma}
+\title{The gauge action preserves the product and loss}
+\tag{ftip}
+\tag{gauge-symmetry}
+
+\p{For every #{A\in\mathrm{GL}(k)},}
+
+##{
+ W(UA,VA^{-\mathsf T})=UV^{\mathsf T}
+ \quad\hbox{and}\quad
+ L(UA,VA^{-\mathsf T})=L(U,V).
+}
+
+\proof{
+\p{Since #{(VA^{-\mathsf T})^{\mathsf T}=A^{-1}V^{\mathsf T}}, the first
+identity is #{UAA^{-1}V^{\mathsf T}=UV^{\mathsf T}}. Applying #{f} gives
+the second.}}
+
+\p{\strong{Status: source-reconstructed lemma.} This is the factored-model
+calculation in Section 3 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00AZ.tree
+++ b/trees/ftip-00AZ.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Orthogonal gauge orbit}
+\tag{ftip}
+\tag{gauge-symmetry}
+
+\p{The \newvocab{orthogonal gauge orbit} of #{(U,V)} is}
+
+##{
+ \mathcal O(U,V)=\{(UQ,VQ):Q\in\mathrm O(k)\}.
+}
+
+\p{Every pair in the orbit represents the same #{W}. This orbit is generally
+smaller than the complete fibre of the map #{(U,V)\mapsto UV^{\mathsf T}}.
+The restriction to #{\mathrm O(k)} is geometric: it preserves the Euclidean
+metric on factor space.}

--- a/trees/ftip-00B0.tree
+++ b/trees/ftip-00B0.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Lemma}
+\title{The orthogonal gauge is the maximal isometric subgroup}
+\tag{ftip}
+\tag{gauge-symmetry}
+
+\p{The action #{\gamma_A} preserves
+#{\lVert U\rVert_F^2+\lVert V\rVert_F^2} for every pair #{(U,V)} if and
+only if #{A\in\mathrm O(k)}.}
+
+\proof{
+\p{If the action is an isometry, take #{V=0} and let one row of #{U} be an
+arbitrary #{u\in\mathbb R^{1\times k}}. Then
+#{\lVert uA\rVert_2=\lVert u\rVert_2} for every #{u}, hence
+#{AA^{\mathsf T}=I}. Conversely, right multiplication by an orthogonal
+matrix preserves both Frobenius norms.}}
+
+\p{\strong{Status: source-reconstructed lemma.} See Lemma 3.2 and its proof
+in Appendix B.1 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00B1.tree
+++ b/trees/ftip-00B1.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Lemma}
+\title{Gradients transform covariantly along an orthogonal orbit}
+\tag{ftip}
+\tag{optimization}
+\tag{gauge-symmetry}
+
+\p{For #{Q\in\mathrm O(k)},}
+
+##{
+ \nabla_U L(UQ,VQ)=\nabla_U L(U,V)Q,
+ \qquad
+ \nabla_V L(UQ,VQ)=\nabla_V L(U,V)Q.
+}
+
+\proof{
+\p{Put #{G=\nabla f(W)}. Then
+#{\nabla_U L=GV} and #{\nabla_V L=G^{\mathsf T}U}. The represented matrix,
+and hence #{G}, is unchanged along the orbit. Substitution gives both
+identities.}}
+
+\p{\strong{Status: source-reconstructed lemma.} See Lemma 4.1 and its proof
+in Appendix B.2 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00B2.tree
+++ b/trees/ftip-00B2.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Optimizer state action}
+\tag{ftip}
+\tag{optimization}
+
+\p{Use the optimizer-state convention of \ref{ftip-001H}. For every
+#{Q\in\mathrm O(k)}, an \newvocab{optimizer state action} is a map
+#{\sigma_Q:\mathcal S_{\rm opt}\to\mathcal S_{\rm opt}} compatible with the
+shapes of the factor states and satisfying #{\sigma_Q(s_0)=s_0} for the
+declared initial state.}
+
+\p{For example, a momentum buffer shaped like #{U} transforms by right
+multiplication by #{Q}; a shared scalar second moment is fixed. An entrywise
+second-moment array need not admit a state action compatible with every
+orthogonal #{Q}.}

--- a/trees/ftip-00B3.tree
+++ b/trees/ftip-00B3.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Gauge-equivariant optimizer}
+\tag{ftip}
+\tag{optimization}
+\tag{gauge-symmetry}
+
+\p{Let #{\mathcal A} be a deterministic instance of the parameter-update
+rule of \ref{ftip-001I}, acting on #{(U,V,s)}. It is
+\newvocab{gauge-equivariant} when for every #{Q\in\mathrm O(k)} there is a
+state action #{\sigma_Q} such that gauge-related initial states produce}
+
+##{
+ (\widetilde U_t,\widetilde V_t,\widetilde s_t)
+ =(U_tQ,V_tQ,\sigma_Q(s_t))
+ \qquad(t\geq0).
+}
+
+\p{This reconstructs Definition 3.1 of \citef{singh2026lossbasis}. Any
+randomness, schedules, stopping rule, and mixed update blocks must also be
+coupled as required by \ref{ftip-001J}; the definition does not hide them.}

--- a/trees/ftip-00B4.tree
+++ b/trees/ftip-00B4.tree
@@ -1,0 +1,32 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{A commuting optimizer square}
+\tag{ftip}
+\tag{optimization}
+\tag{diagram}
+
+\p{One update of a gauge-equivariant optimizer makes the following square
+commute. The vertical arrows change factor basis and the horizontal arrows
+apply the same declared update.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=36mm,
+ minimum height=10mm,font=\small},
+ arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}
+]
+\node[box] (a) at (-2.8,1.35) {$(U_t,V_t,s_t)$};
+\node[box] (b) at (2.8,1.35) {$(U_{t+1},V_{t+1},s_{t+1})$};
+\node[box] (c) at (-2.8,-1.35) {$(U_tQ,V_tQ,\sigma_Qs_t)$};
+\node[box] (d) at (2.8,-1.35) {$(U_{t+1}Q,V_{t+1}Q,\sigma_Qs_{t+1})$};
+\draw[arr] (a) -- node[lab,above] {$\mathcal A$} (b);
+\draw[arr] (c) -- node[lab,below] {$\mathcal A$} (d);
+\draw[arr] (a) -- node[lab,left] {$Q$} (c);
+\draw[arr] (b) -- node[lab,right] {$Q$} (d);
+\end{tikzpicture}}
+
+\p{Commutation is stronger than equality of the scalar losses before the
+step. It states equality of the represented product trajectory after aligning
+the parameter bases.}

--- a/trees/ftip-00B5.tree
+++ b/trees/ftip-00B5.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Product symmetry is larger than the isometric gauge}
+\tag{ftip}
+\tag{gauge-symmetry}
+\tag{transfer-limit}
+
+\p{The full #{\mathrm{GL}(k)} action in \ref{ftip-00AX} preserves #{W}, but
+ordinary Euclidean gradients are covariant under the orthogonal specialization
+used in \ref{ftip-00B1}. A theorem for #{(UQ,VQ)} must therefore not be
+silently promoted to every product-preserving reparameterization.}
+
+\p{The source calls the orthogonal subgroup the gauge in its optimizer
+classification while also noting the larger function-preserving group. These
+are compatible statements only when their different geometric scopes remain
+explicit.}

--- a/trees/ftip-00B6.tree
+++ b/trees/ftip-00B6.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Equivariant and basis-sensitive update rules}
+\tag{ftip}
+\tag{optimization}
+\tag{gauge-symmetry}
+
+\p{Gradient covariance supplies a test for update rules. Linear and
+full-matrix operations can commute with a latent rotation, whereas a fixed
+nonlinear map applied separately to coordinates selects a preferred basis.}
+
+\transclude{ftip-00B7}
+\transclude{ftip-00B8}
+\transclude{ftip-00B9}
+\transclude{ftip-00BA}
+\transclude{ftip-00BB}
+\transclude{ftip-00BC}
+\transclude{ftip-00BD}
+\transclude{ftip-00BE}
+\transclude{ftip-00BF}
+\transclude{ftip-00BG}
+\transclude{ftip-00BH}
+\transclude{ftip-00BI}
+\transclude{ftip-00BJ}

--- a/trees/ftip-00B7.tree
+++ b/trees/ftip-00B7.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Memoryless right-equivariant update}
+\tag{ftip}
+\tag{optimization}
+
+\p{A \newvocab{memoryless factor-update map} is a function
+#{\Phi:\mathbb R^{n\times k}\to\mathbb R^{n\times k}} applied to a current
+gradient #{G} without a persistent optimizer state. It is
+\newvocab{right-equivariant} when}
+
+##{
+ \Phi(GQ)=\Phi(G)Q
+ \qquad(G\in\mathbb R^{n\times k},\ Q\in\mathrm O(k)).
+}
+
+\p{This local definition is the input of Theorem 4.5 in
+\citef{singh2026lossbasis}. It does not classify stateful optimizers such as
+Adam.}

--- a/trees/ftip-00B8.tree
+++ b/trees/ftip-00B8.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{proposition}
+\title{Gradient descent and momentum preserve the orthogonal gauge}
+\tag{ftip}
+\tag{optimization}
+
+\p{Gradient descent and Polyak or Nesterov momentum are gauge-equivariant
+when their factor gradients, momentum buffers, schedules, and look-ahead
+points are transformed consistently.}
+
+\proof{
+\p{By \ref{ftip-00B1}, #{G_t} becomes #{G_tQ}. Gradient descent therefore
+sends #{U_tQ} to #{(U_t-\eta_tG_t)Q}. A momentum buffer initialized at zero
+and formed by linear combinations of covariant gradients transforms as
+#{M_tQ}; a Nesterov look-ahead point is likewise the reference look-ahead
+right-multiplied by #{Q}. Induction proves the claim.}}
+
+\p{\strong{Status: source-reconstructed Proposition 4.2(1), proof Appendix
+B.3} of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00B9.tree
+++ b/trees/ftip-00B9.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{proposition}
+\title{A shared scalar second moment preserves the orthogonal gauge}
+\tag{ftip}
+\tag{optimization}
+\tag{adam}
+
+\p{Replace Adam's entrywise second-moment denominator by one scalar whose
+updates depend only on gauge-invariant quantities such as the pooled mean of
+the squared entries of both factor gradients. With a covariant first-moment
+buffer, the resulting stateful update is gauge-equivariant.}
+
+\proof{
+\p{The first moment is a linear exponential average and transforms by right
+multiplication by #{Q}. The pooled squared-entry mean is the joint squared
+Frobenius norm divided by the entry count, hence is unchanged by #{G\mapsto
+GQ}. Its bias correction and positive scalar denominator are unchanged, so
+the complete update transforms covariantly.}}
+
+\p{\strong{Status: source-reconstructed Proposition 4.2(2), proof Appendix
+B.3} of \citef{singh2026lossbasis}. The result concerns this declared
+shared-scalar variant, not stock Adam.}

--- a/trees/ftip-00BA.tree
+++ b/trees/ftip-00BA.tree
@@ -1,0 +1,38 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{proposition}
+\title{Full-matrix Muon and Shampoo preserve the orthogonal gauge}
+\tag{ftip}
+\tag{optimization}
+
+\p{Fix one factor, write #{n\in\{d_1,d_2\}} for its row dimension, and let
+#{G_t,M_t\in\mathbb R^{n\times k}} be its gradient and Muon momentum buffer.
+For #{0\leq\beta<1}, #{M_{-1}=0}, and the source's linear momentum update
+#{M_t=\beta M_{t-1}+G_t}, Muon's direction is
+#{\Delta_t=\operatorname{msign}(M_t)}. Under real arithmetic this stateful
+update and the source's damped Shampoo update are right-equivariant. The Muon
+claim includes the stated finite Newton--Schulz approximations; the Shampoo
+claim uses its complete left and right accumulators.}
+
+\proof{
+\p{By \ref{ftip-00B1}, the primed gradient is #{G'_t=G_tQ}. Starting from
+#{M'_{-1}=M_{-1}Q=0}, induction through the linear momentum update gives
+#{M'_t=M_tQ}. If #{M_t=A\Sigma B^{\mathsf T}} is a compact singular-value
+decomposition, then #{M_tQ=A\Sigma(Q^{\mathsf T}B)^{\mathsf T}}, so
+#{\operatorname{msign}(M_tQ)=\operatorname{msign}(M_t)Q}. For
+#{\epsilon_{\rm NS}>0}, the Newton--Schulz initialization
+#{X_0=M_t/(\lVert M_t\rVert_F+\epsilon_{\rm NS})} is covariant because its
+Frobenius normalization is invariant; each polynomial iterate formed from
+#{X_j} and #{X_jX_j^{\mathsf T}} preserves the same covariance. For Shampoo,
+the left accumulator is invariant while the right accumulator transforms by
+#{R_t\mapsto Q^{\mathsf T} R_t Q}. Orthogonal functional calculus conjugates
+the right matrix function, so the transformed update is the original update
+right-multiplied by #{Q}.}}
+
+\p{\strong{Status: source-reconstructed Proposition 4.2(3)--(4), proof
+Appendix B.3} of \citef{singh2026lossbasis}. Variable splitting, coordinatewise
+clipping, mixed update rules, finite precision, and different damping
+conventions lie outside this statement. The Muon part is stateful; it does not
+replace the momentum buffer by the current gradient or invoke the memoryless
+classification of \ref{ftip-00B7}.}

--- a/trees/ftip-00BB.tree
+++ b/trees/ftip-00BB.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{proposition}
+\title{Coordinatewise equivariance forces linearity}
+\tag{ftip}
+\tag{optimization}
+\tag{gauge-symmetry}
+
+\p{Let #{k\geq2} and let a memoryless update have the fixed entrywise form
+#{\Phi(G)_{ij}=\phi(G_{ij})}. If #{\Phi(GQ)=\Phi(G)Q} for every #{G} and
+#{Q\in\mathrm O(k)}, then #{\phi(x)=cx} for some #{c\in\mathbb R}.}
+
+\proof{
+\p{It suffices to use one row and rotations in the first two coordinates.
+Equivariance at zero gives #{\phi(0)=0}. Rotating #{(x,0)} through an angle
+whose cosine is #{a\in[-1,1]} gives #{\phi(ax)=a\phi(x)}. For nonzero #{x,y},
+compare each with a third number of at least their absolute magnitudes; the
+ratio #{\phi(x)/x} is constant.}}
+
+\p{\strong{Status: source-reconstructed Proposition 4.3, proof Appendix B.4}
+of \citef{singh2026lossbasis}. No continuity assumption is needed.}

--- a/trees/ftip-00BC.tree
+++ b/trees/ftip-00BC.tree
@@ -1,0 +1,17 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{Fixed nonlinear coordinatewise updates break the gauge}
+\tag{ftip}
+\tag{optimization}
+
+\p{A nonlinear fixed entrywise update applied at a zero optimizer state is
+not gauge-equivariant when #{k\geq2}. In particular, the source applies
+\ref{ftip-00BB} to the first-step maps of Adam, RMSProp, signSGD, and Lion;
+it checks Adafactor separately because its factored statistics are not an
+entrywise map.}
+
+\p{This is a first-step obstruction. It suffices to disprove equivariance of
+the full run, but it does not classify every later state or say that such an
+optimizer cannot reach a particular solution.}

--- a/trees/ftip-00BD.tree
+++ b/trees/ftip-00BD.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{First-step Adam map and gauge defect}
+\tag{ftip}
+\tag{adam}
+\tag{gauge-symmetry}
+
+\p{Fix #{\epsilon>0}. For zero-state, bias-corrected Adam define the
+entrywise first-step direction}
+
+##{
+ D_\epsilon(G)=G\mathbin{\oslash}(|G|+\epsilon)
+}
+
+\p{and, for #{Q\in\mathrm O(k)}, define its gauge-aligned defect by}
+
+##{
+ E_Q(G)=D_\epsilon(GQ)Q^{\mathsf T}-D_\epsilon(G).
+}
+
+\p{Here #{|G|}, addition, and division are entrywise. Bias correction makes
+the first direction independent of Adam's two decay coefficients under the
+declared convention \citet{Proposition 4.4}{singh2026lossbasis}.}

--- a/trees/ftip-00BE.tree
+++ b/trees/ftip-00BE.tree
@@ -1,0 +1,31 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{proposition}
+\title{Exact represented-matrix defect after one Adam step}
+\tag{ftip}
+\tag{adam}
+
+\p{Let #{G_U=\nabla_UL(U_0,V_0)}, #{G_V=\nabla_VL(U_0,V_0)},
+#{D_U=D_\epsilon(G_U)}, and #{D_V=D_\epsilon(G_V)}. Let #{W_1} be the
+product after one Adam step from #{(U_0,V_0)} and #{\widetilde W_1} the
+product after one step from #{(U_0Q,V_0Q)}. Then}
+
+##{
+\begin{aligned}
+\widetilde W_1-W_1={}&-\eta\bigl(E_Q(G_U)V_0^{\mathsf T}
+ +U_0E_Q(G_V)^{\mathsf T}\bigr)\\
+&+\eta^2\bigl(E_Q(G_U)D_V^{\mathsf T}
+ +D_UE_Q(G_V)^{\mathsf T}
+ +E_Q(G_U)E_Q(G_V)^{\mathsf T}\bigr).
+\end{aligned}
+}
+
+\proof{
+\p{Gauge-align the rotated factors back by #{Q^{\mathsf T}}. They are
+#{U_0-\eta(D_U+E_Q(G_U))} and
+#{V_0-\eta(D_V+E_Q(G_V))}. Multiply, subtract
+#{(U_0-\eta D_U)(V_0-\eta D_V)^{\mathsf T}}, and collect powers of #{\eta}.}}
+
+\p{\strong{Status: source-reconstructed Proposition 4.4, proof Appendix B.5}
+of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00BF.tree
+++ b/trees/ftip-00BF.tree
@@ -1,0 +1,38 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{A two-coordinate Adam defect witness}
+\tag{ftip}
+\tag{adam}
+\tag{diagram}
+
+\p{Take #{d_1=d_2=1}, #{k=2}, #{f(w)=w^2/2},
+#{U_0=V_0=(1,0)}, and}
+
+##{
+ Q=2^{-1/2}\begin{pmatrix}1&1\\-1&1\end{pmatrix}.
+}
+
+\p{The original and rotated products after one zero-state Adam step are}
+
+##{
+ W_1=\left(1-\frac{\eta}{1+\epsilon}\right)^2,
+ \qquad
+ \widetilde W_1=\left(1-\frac{\eta}{2^{-1/2}+\epsilon}\right)^2.
+}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=29mm,
+ minimum height=10mm,font=\small},arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}]
+\node[box] (w) at (0,1.45) {same represented value\\$W_0=1$};
+\node[box] (a) at (-3.0,-1.0) {basis $(1,0)$\\product $W_1$};
+\node[box] (b) at (3.0,-1.0) {rotated basis\\product $\widetilde W_1$};
+\draw[arr] (w) -- node[lab,left]{Adam} (a);
+\draw[arr] (w) -- node[lab,right]{Adam} (b);
+\end{tikzpicture}}
+
+\p{They differ when #{0<\eta<2^{-1/2}+\epsilon}. This is the explicit
+witness in Proposition 4.4 of \citef{singh2026lossbasis}; it is a statement
+about one factored quadratic, not about language-model performance.}

--- a/trees/ftip-00BG.tree
+++ b/trees/ftip-00BG.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{A rotated sign update fails to commute}
+\tag{ftip}
+\tag{optimization}
+
+\p{For #{G=(1,1)} and the 45-degree rotation matrix #{Q} of
+\ref{ftip-00BF}, one has #{GQ=(0,\sqrt2)}. With
+#{\operatorname{sign}(0)=0},}
+
+##{
+ \operatorname{sign}(GQ)=(0,1),
+ \qquad
+ \operatorname{sign}(G)Q=(0,\sqrt2).
+}
+
+\p{Thus even this two-coordinate update violates the commuting equation in
+\ref{ftip-00B7}. The calculation is the explicit Appendix B.4 witness of
+\citef{singh2026lossbasis}.}

--- a/trees/ftip-00BH.tree
+++ b/trees/ftip-00BH.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Full-rank memoryless equivariant rules are Gram-determined}
+\tag{ftip}
+\tag{optimization}
+
+\p{Let #{k\leq n}, and let #{\Phi} be defined on full-column-rank matrices
+#{G\in\mathbb R^{n\times k}}. Then #{\Phi(GQ)=\Phi(G)Q} for every
+#{Q\in\mathrm O(k)} if and only if there is a matrix-valued function #{H}
+of #{GG^{\mathsf T}} such that}
+
+##{
+ \Phi(G)=H(GG^{\mathsf T})G.
+}
+
+\proof{
+\p{The displayed form is immediately equivariant. Conversely, set
+#{X(G)=\Phi(G)G^+}. Then #{X(G)G=\Phi(G)} and
+#{X(GQ)=X(G)}. Two full-column-rank matrices with the same left Gram matrix
+have the same range and differ by a right orthogonal factor. Hence #{X(G)}
+depends only on #{GG^{\mathsf T}}; take #{H=X}.}}
+
+\p{\strong{Status: source-reconstructed theorem.} See Theorem 4.5 and its
+proof in Appendix B.6 of \citef{singh2026lossbasis}. It classifies the
+full-rank stratum only.}

--- a/trees/ftip-00BI.tree
+++ b/trees/ftip-00BI.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{The square invertible preconditioner representation}
+\tag{ftip}
+\tag{optimization}
+
+\p{In the specialization #{k=n} with #{G} invertible, the function in
+\ref{ftip-00BH} has the unique canonical representative}
+
+##{
+ H(P)=\Phi(P^{1/2})P^{-1/2},
+ \qquad P=GG^{\mathsf T}>0.
+}
+
+\proof{
+\p{The polar decomposition writes #{G=P^{1/2}Q}. Equivariance gives
+#{\Phi(G)=\Phi(P^{1/2})Q=H(P)G}. Evaluating at #{G=P^{1/2}} proves
+uniqueness in this square invertible case.}}
+
+\p{For rectangular #{G}, the action of #{H(P)} away from the range needed
+to multiply #{G} is not determined by #{\Phi}; the note does not promote the
+square-case uniqueness.}

--- a/trees/ftip-00BJ.tree
+++ b/trees/ftip-00BJ.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{What the structure theorem leaves unresolved at rank deficiency}
+\tag{ftip}
+\tag{optimization}
+\tag{source-discrepancy}
+
+\p{In the ambient matrix space, full-column-rank matrices form an open dense
+subset whose complement has Lebesgue measure zero. A probability-one claim
+requires the random gradient law to be absolutely continuous and not confined
+to a lower-rank set; random initialization alone does not supply that premise.}
+
+\p{\ref{ftip-00BH} therefore makes no classification claim on a
+general rank-deficient stratum. Equivariance still constrains values within
+each orthogonal orbit, and it forces #{\Phi(0)=0}, but it does not determine
+the rule there by continuity unless continuity is separately assumed. This is
+the transfer stop behind the source's generic-rank discussion.}

--- a/trees/ftip-00BK.tree
+++ b/trees/ftip-00BK.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Common-scalar flows and transfer limits}
+\tag{ftip}
+\tag{gradient-flow}
+\tag{optimization}
+
+\p{One narrow class of continuous-time preconditioners follows the
+gradient-flow path at a different speed. The clock change
+transfers path properties, but not rates, and it does not encompass a
+stateful momentum method.}
+
+\transclude{ftip-00BL}
+\transclude{ftip-00BM}
+\transclude{ftip-00BN}
+\transclude{ftip-00BO}
+\transclude{ftip-00BP}
+\transclude{ftip-00BQ}
+\transclude{ftip-00BR}

--- a/trees/ftip-00BL.tree
+++ b/trees/ftip-00BL.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Common-scalar preconditioned flow}
+\tag{ftip}
+\tag{gradient-flow}
+
+\p{Let #{\theta=(U,V)} and let #{a(t)>0} be measurable with #{1/a}
+locally integrable. A \newvocab{common-scalar preconditioned flow} is a
+locally absolutely continuous trajectory satisfying}
+
+##{
+ \dot\theta(t)=-\frac{\nabla L(\theta(t))}{a(t)}
+}
+
+\p{for almost every #{t}. The same scalar multiplies every coordinate of
+both factor gradients. For gauge-uniform conclusions, the source additionally
+requires #{a(t)} to be determined by gauge-invariant statistics of the
+trajectory up to time #{t}.}

--- a/trees/ftip-00BM.tree
+++ b/trees/ftip-00BM.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Effective optimizer clock}
+\tag{ftip}
+\tag{gradient-flow}
+
+\p{For the flow of \ref{ftip-00BL}, define the
+\newvocab{effective optimizer clock}}
+
+##{
+ \tau(t)=\int_0^t\frac{du}{a(u)},
+ \qquad
+ \tau_{\max}=\int_0^\infty\frac{du}{a(u)},
+ \qquad 0<\tau_{\max}\leq\infty.
+}
+
+\p{The clock is strictly increasing on its domain. If
+#{\tau_{\max}=\infty}, it reaches every gradient-flow time; otherwise it
+traverses only the prefix with effective time below #{\tau_{\max}}.}

--- a/trees/ftip-00BN.tree
+++ b/trees/ftip-00BN.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Theorem}
+\title{Common-scalar flow is a time-reparameterized gradient flow}
+\tag{ftip}
+\tag{gradient-flow}
+
+\p{Let #{\theta(t)} satisfy \ref{ftip-00BL}, let #{t(\tau)} be the inverse
+of the clock in \ref{ftip-00BM}, and put
+#{\widetilde\theta(\tau)=\theta(t(\tau))}. Then, for almost every #{\tau},}
+
+##{
+ \widetilde\theta'(\tau)=-\nabla L(\widetilde\theta(\tau)).
+}
+
+\proof{
+\p{The chain rule for absolutely continuous changes of variable gives
+#{dt/d\tau=a(t)} almost everywhere. Multiplying
+#{\dot\theta=-\nabla L/a(t)} by #{dt/d\tau} yields the displayed gradient
+flow.}}
+
+\p{\strong{Status: source-reconstructed theorem.} See Theorem 4.6 and its
+proof in Appendix B.9 of \citef{singh2026lossbasis}. Gauge invariance of #{a}
+is not needed for this
+single-trajectory clock identity; it makes the clock common across a gauge
+orbit.}

--- a/trees/ftip-00BO.tree
+++ b/trees/ftip-00BO.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Corollary}
+\title{Transfer of path and limit properties}
+\tag{ftip}
+\tag{gradient-flow}
+
+\p{Every property depending only on the portion of the gradient-flow path
+traversed before #{\tau_{\max}} transfers to the common-scalar flow. If
+#{\tau_{\max}=\infty} and gradient flow converges, both flows have the same
+limit point. A sufficient condition for clock divergence is an eventual
+finite upper bound on #{a(t)}.}
+
+\p{For shallow factorization, the source cites
+\citef{gunasekar2017implicit}. For deep factorization, it cites
+\citef{arora2019implicit}. For greedy low-rank dynamics, it cites
+\citef{li2021greedy}.}
+
+\p{Those conclusions transfer only when both this clock theorem and every
+hypothesis of the original result hold. This corollary supplies no missing
+matrix-sensing assumption.}

--- a/trees/ftip-00BP.tree
+++ b/trees/ftip-00BP.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Rates and hitting times do not survive time reparameterization}
+\tag{ftip}
+\tag{gradient-flow}
+\tag{transfer-limit}
+
+\p{Two flows can traverse the same curve with arbitrarily different physical
+clocks. A convergence rate, finite-step budget, or hitting time stated in
+#{t} therefore does not transfer through \ref{ftip-00BN} without quantitative
+bounds on #{a} and its integral. If #{\tau_{\max}<\infty}, even the tail and
+limit of the gradient-flow path are not reached.}

--- a/trees/ftip-00BQ.tree
+++ b/trees/ftip-00BQ.tree
@@ -1,0 +1,17 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Scalar-Adam is outside the common-scalar flow theorem}
+\tag{ftip}
+\tag{adam}
+\tag{transfer-limit}
+
+\p{The shared-scalar Adam variant in \ref{ftip-00B9} retains a first-moment
+exponential moving average. It is stateful and is not the memoryless flow in
+\ref{ftip-00BL}. Remark 4.7 of \citef{singh2026lossbasis} treats its agreement
+with gradient flow as empirical rather than as a consequence of Theorem 4.6.}
+
+\p{The same stop applies more strongly to discrete Adam, PPO, RLVR update
+loops, clipping, weight decay, and mixed optimizers. Gauge equivariance and
+time reparameterization are separate properties.}

--- a/trees/ftip-00BR.tree
+++ b/trees/ftip-00BR.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{Equivariance neither guarantees nor precludes recovery}
+\tag{ftip}
+\tag{optimization}
+\tag{diagram}
+
+\p{The source records controls on both sides of the proposed implication.
+Its ScaledGD-inspired control is equivariant but equalizes the spectral
+schedule and does not recover the planted low-rank target at the declared
+budget. A long-anneal sign update is non-equivariant but eventually reaches a
+low-recovery-error regime.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=31mm,
+ minimum height=11mm,font=\small}]
+\node[font=\scriptsize] at (-2.3,1.65) {equivariant};
+\node[font=\scriptsize] at (2.3,1.65) {non-equivariant};
+\node[box] at (-2.3,0) {ScaledGD control\\no recovery at budget};
+\node[box] at (2.3,0) {long-anneal sign\\recovery observed};
+\node[font=\scriptsize,align=center] at (0,-1.65)
+ {spectral schedule and budget remain separate coordinates};
+\end{tikzpicture}}
+
+\p{\strong{Status: source-observed controls, Remark 4.7 and Appendix D.10}
+of \citef{singh2026lossbasis}. The source reports no tuned reproducibility
+baseline for the ScaledGD control. The diagram is not a convergence theorem.}

--- a/trees/ftip-00BS.tree
+++ b/trees/ftip-00BS.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Consequences for FTIP intervention contracts}
+\tag{ftip}
+\tag{optimization}
+\tag{intervention}
+
+\p{The algebra now returns to the FTIP protocol question. A training
+intervention must specify enough update geometry to determine how equivalent
+parameterizations evolve; the scalar loss and represented starting object do
+not always suffice.}
+
+\transclude{ftip-00BT}
+\transclude{ftip-00BU}
+\transclude{ftip-00BV}
+\transclude{ftip-00BW}
+\transclude{ftip-00BX}
+\transclude{ftip-00BY}
+\transclude{ftip-00BZ}
+\transclude{ftip-00C0}
+\transclude{ftip-00C1}

--- a/trees/ftip-00BT.tree
+++ b/trees/ftip-00BT.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Objective-equivalent parameterizations}
+\tag{ftip}
+\tag{optimization}
+
+\p{Two factor pairs #{(U,V)} and #{(\widetilde U,\widetilde V)} are
+\newvocab{objective-equivalent} for #{L=f\circ W} when}
+
+##{
+ W(U,V)=W(\widetilde U,\widetilde V).
+}
+
+\p{They then have the same scalar loss for every objective depending only on
+that represented matrix. Orthogonal gauge-related pairs are
+objective-equivalent by \ref{ftip-00AY}; objective equivalence need not imply
+membership in the same orthogonal orbit.}

--- a/trees/ftip-00BU.tree
+++ b/trees/ftip-00BU.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Definition}
+\title{Parameterization-stable training intervention}
+\tag{ftip}
+\tag{optimization}
+\tag{intervention}
+
+\p{Fix a factorized objective, an update algorithm, hyperparameter schedule,
+randomness coupling, stopping rule, and initial optimizer state. The resulting
+training intervention is \newvocab{parameterization-stable on an orthogonal
+orbit} when every two gauge-related initial states have identical represented
+trajectories:}
+
+##{
+ \widetilde U_t\widetilde V_t^{\mathsf T}=U_tV_t^{\mathsf T}
+ \qquad\hbox{at every compared step }t.
+}
+
+\p{This is a local stability property of a fully declared intervention. It
+does not say that arbitrary objective-equivalent pairs outside the orbit must
+agree.}

--- a/trees/ftip-00BV.tree
+++ b/trees/ftip-00BV.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{proposition}
+\title{Gauge equivariance gives parameterization stability}
+\tag{ftip}
+\tag{optimization}
+
+\p{Every gauge-equivariant optimizer is parameterization-stable on each
+orthogonal orbit, provided the remaining protocol coordinates are coupled as
+in \ref{ftip-00BU}.}
+
+\proof{
+\p{\ref{ftip-00B3} gives
+#{(\widetilde U_t,\widetilde V_t)=(U_tQ,V_tQ)}. Hence}
+##{
+ \widetilde U_t\widetilde V_t^{\mathsf T}
+ =U_tQQ^{\mathsf T}V_t^{\mathsf T}=U_tV_t^{\mathsf T}.
+}
+}
+
+\p{\strong{Status: FTIP-proved proposition.} It is a sufficient condition
+on a declared orbit, not a claim that equivariance is necessary for every
+possible equality of represented trajectories.}

--- a/trees/ftip-00BW.tree
+++ b/trees/ftip-00BW.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{proposition}
+\title{A first-step defect falsifies a loss-only protocol specification}
+\tag{ftip}
+\tag{optimization}
+\tag{falsifier}
+
+\p{Suppose two orthogonally gauge-related initializations have equal
+represented object and scalar objective, but a declared update produces
+different represented objects after one step. Then the training intervention
+is not determined by the represented initialization and scalar objective
+alone.}
+
+\proof{
+\p{If those two objects determined the intervention, equal inputs would give
+the same represented next state. The witnessed inequality contradicts that
+factorization.}}
+
+\p{\strong{Status: FTIP-proved finite falsifier.} Proposition
+\ref{ftip-00BE} and \ref{ftip-00BF} instantiate its premise for one
+factored quadratic and zero-state Adam. It proves underspecification, not a
+capability difference.}

--- a/trees/ftip-00BX.tree
+++ b/trees/ftip-00BX.tree
@@ -1,0 +1,36 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{The orthogonal gauge of an attention head}
+\tag{ftip}
+\tag{attention}
+\tag{diagram}
+
+\p{Use the suite convention of \ref{ftip-000P}:
+#{W^Q,W^K\in\mathbb R^{d\times d_h}} and
+#{Q_h=XW^Q}, #{K_h=XW^K}. Attention logits depend on these weights through}
+
+##{
+ Q_hK_h^{\mathsf T}=XW^Q(W^K)^{\mathsf T}X^{\mathsf T}.
+}
+
+\p{For #{A\in\mathrm O(d_h)}, the right action
+#{(W^Q,W^K)\mapsto(W^QA,W^KA)} preserves the middle product.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=29mm,
+ minimum height=10mm,font=\small},arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}]
+\node[box] (f) at (-3.3,0) {head factors\\$(W^Q,W^K)$};
+\node[box] (g) at (0,1.35) {rotate head basis\\$(W^QA,W^KA)$};
+\node[box] (p) at (3.3,0) {invariant product\\$W^Q(W^K)^\mathsf T$};
+\draw[arr] (f) -- node[lab,above left] {$A$} (g);
+\draw[arr] (f) -- node[lab,below] {multiply} (p);
+\draw[arr] (g) -- node[lab,above right] {multiply} (p);
+\end{tikzpicture}}
+
+\p{Section 6 of \citef{singh2026lossbasis} uses column-vector weights and
+the invariant #{W_Q^{\mathsf T}W_K}; transposition gives the suite formula
+above. Copying the source action without this translation would be
+dimensionally wrong.}

--- a/trees/ftip-00BY.tree
+++ b/trees/ftip-00BY.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{What the attention-twin experiment observes}
+\tag{ftip}
+\tag{attention}
+\tag{experiment}
+
+\p{Section 6 and Table 3 of \citef{singh2026lossbasis} compare two
+function-equivalent initializations of a two-layer, four-head transformer on
+modular addition. The reported relative logit distance after one Adam step is
+#{3.6\times10^{-3}}, versus #{2.9\times10^{-7}} for a same-basis noise twin;
+the final per-head invariant distance is reported as 56 percent.}
+
+\p{\strong{Status: source-observed experiment.} The exact first-step defect
+has an algebraic explanation, but later drift, scale robustness, and downstream
+behavior are empirical. The tested small transformers, precision, optimizer
+allocation, seeds, and task do not establish a frontier-wide law.}

--- a/trees/ftip-00BZ.tree
+++ b/trees/ftip-00BZ.tree
@@ -1,0 +1,31 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Example}
+\title{One loss quotient and two optimizer trajectories}
+\tag{ftip}
+\tag{optimization}
+\tag{diagram}
+
+\p{A loss-only description collapses a gauge orbit to one represented
+starting point. A basis-sensitive optimizer can split that quotient back into
+different represented trajectories.}
+
+\tikzfig{\begin{tikzpicture}[
+ box/.style={draw,rounded corners,align=center,text width=25mm,
+ minimum height=10mm,font=\small},arr/.style={->,>=stealth,semithick},
+ lab/.style={font=\scriptsize,fill=white,inner sep=1pt}]
+\node[box] (u) at (-4.0,1.25) {$(U_0,V_0)$};
+\node[box] (q) at (-4.0,-1.25) {$(U_0Q,V_0Q)$};
+\node[box] (w) at (0,0) {same $W_0$\\same scalar loss};
+\node[box] (a) at (4.0,1.25) {represented path\\$W_1,W_2,\ldots$};
+\node[box] (b) at (4.0,-1.25) {represented path\\$\widetilde W_1,\widetilde W_2,\ldots$};
+\draw[arr] (u) -- (w); \draw[arr] (q) -- (w);
+\draw[arr] (w) -- node[lab,pos=.5,sloped,above]{basis-sensitive} (a);
+\draw[arr] (w) -- node[lab,pos=.5,sloped,below]{same rule} (b);
+\end{tikzpicture}}
+
+\p{The right-hand split is possible only because the centre box omits the
+factor basis and optimizer geometry. An FTIP admissible protocol in
+\ref{ftip-005J} must retain those intervention coordinates when they affect
+the executable result.}

--- a/trees/ftip-00C0.tree
+++ b/trees/ftip-00C0.tree
@@ -1,0 +1,33 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Source status and reconstruction discrepancies}
+\tag{ftip}
+\tag{source-discrepancy}
+\tag{transfer-limit}
+
+\p{The source is the single-author arXiv preprint
+\citelink{https://arxiv.org/abs/2608.05136v1}, submitted 5 August 2026. This
+reconstruction uses version one's Sections 3--4 and 6, Appendices B.1--B.6
+and B.9, and the limitations in Section 11. The linked code and raw run
+records were not audited here.}
+
+\p{Four precision repairs are material. First, the full product symmetry acts
+on the factors by}
+
+##{
+ (U,V)\longmapsto(UA,VA^{-\mathsf T}).
+}
+
+\p{It does not use #{(UA,VA)}. Second, the attention action is transposed into
+the suite's row-vector convention.}
+
+\p{The general rectangular preconditioner representation is not assigned the
+square-case uniqueness. The source's generic full-rank observation is not
+turned into a probability-one statement without a law for the gradient.}
+
+\p{Four scope repairs are equally material. The coordinatewise theorem is a
+zero-state, memoryless obstruction. The clock theorem is continuous-time and
+excludes scalar-Adam's momentum. Experimental optimizer and attention results
+remain source-observed. Equivariance is not identified with low-rank recovery.}

--- a/trees/ftip-00C1.tree
+++ b/trees/ftip-00C1.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\taxon{Remark}
+\title{Transfer limits and next dynamic-compute questions}
+\tag{ftip}
+\tag{research-programme}
+\tag{transfer-limit}
+
+\p{The factored-model results prove that update geometry can be a genuine
+intervention coordinate even when objective and represented initialization
+are fixed. They do not prove transformer or RLVR convergence, practical
+optimizer superiority, a scaling law, or any change in reliable capability.
+Different represented trajectories are not by themselves an acquisition
+witness of \ref{ftip-005X}.}
+
+\p{The memoryless theorem does not describe Adam's full state, and the
+continuous-flow result does not supply discrete rates or finite-step bounds.
+The source also notes that fixed-rank LoRA changes the learned-rank mechanism;
+no LoRA transfer is made here.}
+
+\p{The next route should type dynamic training compute rather than extend
+these conclusions by analogy: active research state, persistent harness state,
+retained history, evaluation configuration, descendant and retry costs, and
+the distinction between one realized chain and an archive-best envelope.}

--- a/trees/refs/arora2019implicit.tree
+++ b/trees/refs/arora2019implicit.tree
@@ -1,0 +1,19 @@
+% ["optimization", "deep matrix factorization", "implicit regularization"]
+\title{Implicit regularization in deep matrix factorization}
+\date{2019}
+\author/literal{Sanjeev Arora}
+\author/literal{Nadav Cohen}
+\author/literal{Wei Hu}
+\author/literal{Yuping Luo}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/1905.13655v1}
+
+\meta{bibtex}{\startverb
+@inproceedings{arora2019implicit,
+  title = {Implicit Regularization in Deep Matrix Factorization},
+  author = {Arora, Sanjeev and Cohen, Nadav and Hu, Wei and Luo, Yuping},
+  booktitle = {Advances in Neural Information Processing Systems},
+  year = {2019},
+  url = {https://arxiv.org/abs/1905.13655v1}
+}
+\stopverb}

--- a/trees/refs/gunasekar2017implicit.tree
+++ b/trees/refs/gunasekar2017implicit.tree
@@ -1,0 +1,20 @@
+% ["optimization", "matrix factorization", "implicit regularization"]
+\title{Implicit regularization in matrix factorization}
+\date{2017}
+\author/literal{Suriya Gunasekar}
+\author/literal{Blake Woodworth}
+\author/literal{Srinadh Bhojanapalli}
+\author/literal{Behnam Neyshabur}
+\author/literal{Nathan Srebro}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/1705.09280v1}
+
+\meta{bibtex}{\startverb
+@inproceedings{gunasekar2017implicit,
+  title = {Implicit Regularization in Matrix Factorization},
+  author = {Gunasekar, Suriya and Woodworth, Blake and Bhojanapalli, Srinadh and Neyshabur, Behnam and Srebro, Nathan},
+  booktitle = {Advances in Neural Information Processing Systems},
+  year = {2017},
+  url = {https://arxiv.org/abs/1705.09280v1}
+}
+\stopverb}

--- a/trees/refs/li2021greedy.tree
+++ b/trees/refs/li2021greedy.tree
@@ -1,0 +1,18 @@
+% ["optimization", "matrix factorization", "low-rank learning"]
+\title{Towards resolving the implicit bias of gradient descent for matrix factorization: Greedy low-rank learning}
+\date{2021}
+\author/literal{Zhiyuan Li}
+\author/literal{Yuping Luo}
+\author/literal{Kaifeng Lyu}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2012.09839v1}
+
+\meta{bibtex}{\startverb
+@inproceedings{li2021greedy,
+  title = {Towards Resolving the Implicit Bias of Gradient Descent for Matrix Factorization: Greedy Low-Rank Learning},
+  author = {Li, Zhiyuan and Luo, Yuping and Lyu, Kaifeng},
+  booktitle = {International Conference on Learning Representations},
+  year = {2021},
+  url = {https://arxiv.org/abs/2012.09839v1}
+}
+\stopverb}

--- a/trees/refs/singh2026lossbasis.tree
+++ b/trees/refs/singh2026lossbasis.tree
@@ -1,0 +1,16 @@
+% ["optimization", "gauge symmetry", "implicit bias"]
+\title{The loss does not see the basis, but Adam does}
+\date{2026}
+\author/literal{Devender Singh}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2608.05136v1}
+
+\meta{bibtex}{\startverb
+@article{singh2026lossbasis,
+  title = {The Loss Does Not See the Basis, but Adam Does},
+  author = {Singh, Devender},
+  year = {2026},
+  url = {https://arxiv.org/abs/2608.05136v1},
+  journal = {arXiv preprint arXiv:2608.05136}
+}
+\stopverb}


### PR DESCRIPTION
## Summary

- add exactly 44 FTIP trees, ftip-00AU through ftip-00C1, bringing the suite to 433 root-reachable entries
- reconstruct the GL(k) gauge action, orthogonal invariance boundary, optimizer classification, Adam counterexample, square Gram reconstruction, scalar flows, clock equivalence, and attention translation from Singh et al. arXiv:2608.05136v1
- keep empirical optimizer and attention findings source-observed; do not transfer generic full-rank statements to probability-one claims, coordinatewise conclusions beyond zero-state memoryless updates, or equivariance to low-rank recovery
- add five compact worked diagrams and four version-pinned references

## Source status

The principal source is arXiv:2608.05136v1. Exact section/appendix locators and reconstruction discrepancies are recorded in the note. Linked code and raw run records were not audited. Gunasekar et al. v1, Arora et al. v1, and Li et al. v1 are contextual references, not imported theorem statements.

## Verification

- just chk
- git diff --check
- graph audit: 433/433 root-reachable exactly once; no missing edges or cycles
- new-range audit: 44 contiguous IDs; no forward FTIP references
- CI=1 just build with the repository-required nightly Rust toolchain
- targeted lize.sh ftip-0001: 162 A4 pages; no undefined references/citations, LaTeX errors, fatal errors, or overfull boxes
- visual inspection of all five diagram pages, including the final quotient diagram
- independent exact-head content, source-fidelity, PDF, and browser-native render reviews

Rendered PDF SHA-256: de433d93d2b766eba9b0077a845fb8bfe76b3a91b67392462a77649e15fb187e