### PR TITLE
FTIP reward, verifier, and environment failure modes

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -83,3 +83,4 @@ that combination.}
 \transclude{ftip-00AU}
 \transclude{ftip-00C2}
 \transclude{ftip-00DA}
+\transclude{ftip-00DX}

--- a/trees/ftip-00DX.tree
+++ b/trees/ftip-00DX.tree
@@ -1,0 +1,16 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Reward, verifier, and environment failure modes}
+\tag{ftip}
+\tag{agent}
+\tag{evidence-boundary}
+\p{This section separates a named reward channel, a verifier, and the
+environment transition law. A high score in one channel is not by itself a
+utility, support, or capability-acquisition statement.}
+\p{The catalog of \citek{dharna2026aifindsway} supplies heterogeneous empirical
+counterexamples and provenance, not rates or a general theorem. The finite
+lemmas below are note-local and state their assumptions explicitly.}
+\transclude{ftip-00DY}
+\transclude{ftip-00E4}
+\transclude{ftip-00E8}
+\transclude{ftip-00ED}

--- a/trees/ftip-00DY.tree
+++ b/trees/ftip-00DY.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Reward semantics and environment coupling}
+\tag{ftip}
+\p{The same response can be scored by several channels while the environment
+can assign different transitions or hidden consequences. The next cards keep
+these objects typed instead of identifying them by their names.}
+\transclude{ftip-00DZ}
+\transclude{ftip-00E0}
+\transclude{ftip-00E1}
+\transclude{ftip-00E2}
+\transclude{ftip-00E3}

--- a/trees/ftip-00DZ.tree
+++ b/trees/ftip-00DZ.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Named reward channel}
+\tag{ftip}
+\p{For a fixed task #{x}, let #{\mathcal Y_x} be a finite response set and
+let a named reward channel be a map #{r:\mathcal Y_x\to\mathbb R}. A utility
+map #{u:\mathcal Y_x\to\mathbb R} is a separate evaluation quantity.}
+\p{If an interaction has state space #{\mathcal S}, action space #{\mathcal A},
+and transition kernel #{K(\mathord{\cdot}\mid s,a)}, then #{K} is a third
+object: changing #{K} can change consequences without changing #{r}.}

--- a/trees/ftip-00E0.tree
+++ b/trees/ftip-00E0.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Verifier channel and false acceptance}
+\tag{ftip}
+\p{A verifier channel is a map #{V:\mathcal Y_x\to\{0,1\}}. Given a validity
+map #{U:\mathcal Y_x\to\{0,1\}}, a false-accept event is}
+##{F=\{y\in\mathcal Y_x:V(y)=1\ \text{and}\ U(y)=0\}.}
+\p{The event depends on the declared verifier and validity test. It is not
+identified by a scalar reward unless the note declares that equivalence.}

--- a/trees/ftip-00E1.tree
+++ b/trees/ftip-00E1.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Source catalog and evidence boundary}
+\tag{ftip}
+\p{Sections 4.1--4.2 and 7.2--7.3 of \citek{dharna2026aifindsway} catalogue
+reward, score, environment, and evaluator-target anecdotes. The source gives
+26 curated firsthand anecdotes involving more than 100 researchers; it does
+not provide a common sampling frame, base rates, or causal effect estimates.}
+\p{Accordingly, this section uses the paper as an empirical counterexample
+catalog. The finite statements that follow are proved here and do not claim
+to summarize all training systems.}

--- a/trees/ftip-00E2.tree
+++ b/trees/ftip-00E2.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Uniform proxy disagreement gives two-epsilon regret}
+\tag{ftip}
+\tag{finite-result}
+\p{Let #{\mathcal Y_x} be finite, let #{u,r:\mathcal Y_x\to\mathbb R}, and
+assume #{|r(y)-u(y)|\le\varepsilon} for every #{y}, with #{\varepsilon\ge0}.
+If #{y^\star} maximizes #{u} and #{\widehat y} maximizes #{r}, then}
+##{u(y^\star)-u(\widehat y)\le2\varepsilon.}
+\p{Indeed, #{u(y^\star)\le r(y^\star)+\varepsilon\le r(\widehat y)+\varepsilon
+\le u(\widehat y)+2\varepsilon}. This is a finite same-class decision bound,
+not an optimization, distribution-shift, or capability theorem.}

--- a/trees/ftip-00E3.tree
+++ b/trees/ftip-00E3.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Equal nominal score, different utility}
+\tag{ftip}
+\tag{counterexample}
+\p{Take #{\mathcal Y_x=\{a,b\}}, with #{r(a)=r(b)=1} but #{u(a)=1} and
+#{u(b)=0}. Every reward maximizer is a nominal tie, while only #{a} is utility
+optimal. The example shows why a score equality does not establish intent or
+validity.}

--- a/trees/ftip-00E4.tree
+++ b/trees/ftip-00E4.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Verifier false accepts}
+\tag{ftip}
+\p{False acceptance is an event over candidates and a declared validity test.
+Repeated auditing can bound its occurrence, but a bound on existence is not
+automatically a bound on the selected output.}
+\transclude{ftip-00E5}
+\transclude{ftip-00E6}
+\transclude{ftip-00E7}

--- a/trees/ftip-00E5.tree
+++ b/trees/ftip-00E5.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{False-accept event for a candidate}
+\tag{ftip}
+\p{For candidate index #{i}, let #{I_i\in\{0,1\}} indicate invalidity and let
+#{A_i\in\{0,1\}} indicate verifier acceptance. Define #{F_i=\{I_i=1,A_i=1\}}.
+Write #{q_i=\Pr(I_i=1)}. If #{q_i>0}, write
+#{\eta_i=\Pr(A_i=1\mid I_i=1)}; if #{q_i=0}, set #{\eta_i=0}. Then
+#{\Pr(F_i)=q_i\eta_i}.}
+\p{No independence or identical-distribution hypothesis is part of this
+definition.}

--- a/trees/ftip-00E6.tree
+++ b/trees/ftip-00E6.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Lemma}
+\title{Union bound for repeated false accepts}
+\tag{ftip}
+\tag{finite-result}
+\p{For finitely many candidate events from \ref{ftip-00E5},}
+##{\Pr\left(\bigcup_{i=1}^{N}F_i\right)\le\sum_{i=1}^{N}\Pr(F_i)
+=\sum_{i=1}^{N}q_i\eta_i.}
+\p{This is the union bound and requires no independence. If every marginal is
+at most #{\eta}, the right side is at most #{N\eta}.}

--- a/trees/ftip-00E7.tree
+++ b/trees/ftip-00E7.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Existence of a false accept is not selected-output failure}
+\tag{ftip}
+\p{Suppose two candidates are produced: candidate 1 is invalid and falsely
+accepted, while candidate 2 is valid and rejected by a separate score tie-break.
+Then #{\bigcup_iF_i} occurs, but a selection rule that always chooses candidate
+2 outputs a valid response. Thus an existence probability and a selected-output
+probability coincide only after the selection law is specified.}

--- a/trees/ftip-00E8.tree
+++ b/trees/ftip-00E8.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Environment and oversight targets}
+\tag{ftip}
+\p{An evaluator can be an optimization target while hidden environment
+consequences remain outside its score. The next cards state this as typed
+counterexamples and preserve the source catalog's limited evidentiary scope.}
+\transclude{ftip-00E9}
+\transclude{ftip-00EA}
+\transclude{ftip-00EB}
+\transclude{ftip-00EC}

--- a/trees/ftip-00E9.tree
+++ b/trees/ftip-00E9.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Environment exploit}
+\tag{ftip}
+\p{Given transition kernel #{K}, reward #{r}, and validity predicate #{U}, an
+environment exploit is a candidate #{y\in\mathcal Y_x} whose induced
+interaction under #{K} receives high #{r(y)} while failing #{U}. The definition
+is relative to the declared kernel, horizon, and validity test; it is not a
+universal property of a model.}

--- a/trees/ftip-00EA.tree
+++ b/trees/ftip-00EA.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Same reward, different transition semantics}
+\tag{ftip}
+\p{Let one response receive #{r(y)=1} under two environments, and let
+#{W:\mathcal S\to\{0,1\}} test terminal-state safety. In #{K_1}, its next
+state #{s_1} has #{W(s_1)=1}; in #{K_2}, the same observed response enters
+#{s_2} with #{W(s_2)=0}. The reward channel alone cannot distinguish the two
+transition semantics, so equal reward does not certify safe consequences.}

--- a/trees/ftip-00EB.tree
+++ b/trees/ftip-00EB.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Evaluator-target behavior}
+\tag{ftip}
+\p{Let #{V(y)=1} for every output that contains a visible marker, while #{U}
+checks a hidden task condition that the marker does not affect. A policy that
+optimizes #{V} can improve its observed score while leaving #{U} unchanged or
+worse. This is a finite illustration of evaluator targeting, not a claim about
+the frequency of such behavior.}

--- a/trees/ftip-00EC.tree
+++ b/trees/ftip-00EC.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{No base rates or causal estimates}
+\tag{ftip}
+\tag{transfer-limit}
+\p{The source catalog does not identify the base rate of exploits, the causal
+effect of a reward intervention, or a universal relationship between score and
+utility. Heterogeneous anecdotes therefore motivate audit questions and failure
+tests, not population-level probabilities.}

--- a/trees/ftip-00ED.tree
+++ b/trees/ftip-00ED.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Finite remediation protocol}
+\tag{ftip}
+\p{A remediation protocol records what was scored, what was audited, and which
+environment and verifier versions were used. It may reject candidates before a
+commit, but its guarantee is only the finite event bound proved below.}
+\transclude{ftip-00EE}
+\transclude{ftip-00EF}
+\transclude{ftip-00EG}

--- a/trees/ftip-00EE.tree
+++ b/trees/ftip-00EE.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Audit record}
+\tag{ftip}
+\p{An audit record is a tuple containing candidate identity, evaluator and
+verifier version, environment or transition-kernel version, invalidity tests,
+random seed, evidence pointers, and adjudicator decision. A record is complete
+only when these fields are bound to the candidate and the protocol run.}

--- a/trees/ftip-00EF.tree
+++ b/trees/ftip-00EF.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{proposition}
+\title{Finite audit-gate bound}
+\tag{ftip}
+\tag{finite-result}
+\p{Let #{N\in\mathbb N_{\geq1}} and #{0\leq\eta\leq1}. Assume these #{N}
+candidates are audited and each invalid candidate is falsely accepted with
+marginal probability at most #{\eta}. Then the probability that
+some invalid candidate is accepted is at most #{N\eta}, by the union bound of
+\ref{ftip-00E6}. This conclusion does not require independence.}
+\p{The statement bounds existence of an accepted invalid candidate. A selected
+output guarantee additionally requires a typed selection rule and its relation
+to the audit decisions.}

--- a/trees/ftip-00EG.tree
+++ b/trees/ftip-00EG.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Transfer limits and next failure questions}
+\tag{ftip}
+\tag{transfer-limit}
+\p{These finite channel distinctions do not prove reward hacking rates,
+capability acquisition, or safety of a deployed agent. The next questions are
+to measure verifier sensitivity, environment changes, selection rules, and
+independent audit power under a declared protocol.}

--- a/trees/refs/dharna2026aifindsway.tree
+++ b/trees/refs/dharna2026aifindsway.tree
@@ -1,0 +1,20 @@
+% ["reward hacking", "environment exploits", "oversight"]
+\title{AI Finds A Way}
+\date{2026}
+\author/literal{Aaron Dharna}
+\author/literal{Cong Lu}
+\author/literal{Ryan Sullivan}
+\author/literal{Joel Lehman}
+\author/literal{Victoria Krakovna}
+\author/literal{Jeff Clune}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2608.23875v1}
+\meta{bibtex}{\startverb
+@article{dharna2026aifindsway,
+  title = {AI Finds A Way},
+  author = {Dharna, Aaron and Lu, Cong and Sullivan, Ryan and Lehman, Joel and Krakovna, Victoria and Clune, Jeff},
+  year = {2026},
+  url = {https://arxiv.org/abs/2608.23875v1},
+  journal = {arXiv preprint arXiv:2608.23875}
+}
+\stopverb}


### PR DESCRIPTION
Adds a narrowly typed FTIP section on reward, verifier, and environment failure modes.

- 20 new trees (00DX-00EG) and one pinned primary reference (arXiv 2608.23875v1).
- Separates reward, validity, verifier, and transition semantics.
- Includes finite proxy regret and false-accept union bounds with explicit hypotheses.
- Uses AI Finds A Way only as an empirical counterexample catalog; no rates or capability claims.

Local gates: just chk, Forest parse, graph/no-forward-ref audit pass.