### PR TITLE
FTIP recursive harnesses and archive envelopes

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -84,3 +84,4 @@ that combination.}
 \transclude{ftip-00C2}
 \transclude{ftip-00DA}
 \transclude{ftip-00DX}
+\transclude{ftip-00EH}

--- a/trees/ftip-00EH.tree
+++ b/trees/ftip-00EH.tree
@@ -1,0 +1,15 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Recursive harnesses and archive envelopes}
+\tag{ftip}
+\tag{agent}
+\tag{recursive-harness}
+\p{This section types recursive harnesses as fixed-driver transformations of
+traces, code, and task descriptions. Sections 2.2--2.4 of
+\citek{kim2026metanrecursive} supply the fixed meta-operation, conditioning,
+stopping, and archive context; Sections 3.1--3.4 are empirical architecture
+comparisons. The finite consequences below are proved locally.}
+\transclude{ftip-00EI}
+\transclude{ftip-00EP}
+\transclude{ftip-00EU}
+\transclude{ftip-00F0}

--- a/trees/ftip-00EI.tree
+++ b/trees/ftip-00EI.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Fixed drivers and recursive layers}
+\p{The first cluster separates a fixed meta-operation from the mutable layer
+artifacts it emits, then records the resulting wrapper composition.}
+\transclude{ftip-00EJ}
+\transclude{ftip-00EK}
+\transclude{ftip-00EL}
+\transclude{ftip-00EM}
+\transclude{ftip-00EN}
+\transclude{ftip-00EO}

--- a/trees/ftip-00EJ.tree
+++ b/trees/ftip-00EJ.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Recursive layer state}
+\tag{ftip}
+\p{Let #{S_1} be a base solver and, for #{d\geq2}, let #{C_d} be a layer
+artifact and #{M_d} a wrapper. The depth-#{d} solver is
+#{S_d=M_d(C_d,S_{d-1})}. The layer state is #{\Lambda_d=(C_d,S_d)}.}
+\p{A layer is a harness transformation when it changes #{C_d} or the wrapper
+context while leaving the executable base weights in #{S_1} fixed.}

--- a/trees/ftip-00EK.tree
+++ b/trees/ftip-00EK.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Fixed meta-operation}
+\tag{ftip}
+\p{A \newvocab{fixed meta-operation} is a single map #{\Omega} whose code and
+prompt template are held fixed across depths. For task set #{\mathcal T}, traces
+#{\boldsymbol\tau_{d-1}}, code stack #{[C_2,\ldots,C_{d-1}]}, and depth #{d},}
+##{\Omega(\boldsymbol\tau_{d-1},[C_2,\ldots,C_{d-1}],\mathcal T,d)=C_d.}
+\p{Only the input to #{\Omega} changes with depth; this is a declared protocol
+condition, not a claim that every implementation obeys it.}

--- a/trees/ftip-00EL.tree
+++ b/trees/ftip-00EL.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Trace-and-code input}
+\tag{ftip}
+\p{For each task #{t_i}, a trace #{\tau_i^{(d)}} is a finite record containing
+the produced artifact, execution outcome, score, and declared evaluator
+feedback. The depth-#{d} input to #{\Omega} is the pair
+#{(\boldsymbol\tau_{d-1},[C_2,\ldots,C_{d-1}])}; a flat refiner that sees only
+#{\boldsymbol\tau} has a strictly smaller declared input when the code stack is
+not recoverable from the traces.}

--- a/trees/ftip-00EM.tree
+++ b/trees/ftip-00EM.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Nested wrapper composition}
+\tag{ftip}
+\tag{finite-result}
+\p{If every wrapper leaves its inner solver and earlier libraries unchanged,
+then induction on #{d} gives}
+##{S_d=M_d\circ M_{d-1}\circ\cdots\circ M_2\circ S_1.}
+\p{Proof. The case #{d=2} is the definition. Substituting the induction
+hypothesis into #{S_d=M_d(C_d,S_{d-1})} gives the displayed composition.}

--- a/trees/ftip-00EN.tree
+++ b/trees/ftip-00EN.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Finite trace growth under recursive wrapping}
+\tag{ftip}
+\tag{finite-result}
+\p{Suppose each wrapper emits one finite trace record per task and there are
+#{N} tasks and depths #{2,\ldots,d}. The audit log contains at most #{N(d-1)}
+depth-tagged records, in addition to the base records. This is a counting fact;
+it says nothing about trace quality or score improvement.}
+\p{Proof. There are #{d-1} wrapped depths and #{N} records at each depth, so
+the product counts all records.}

--- a/trees/ftip-00EO.tree
+++ b/trees/ftip-00EO.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Code explains a regression that traces alone cannot}
+\tag{ftip}
+\p{Two runs can share the same failing score and stderr trace while one layer
+adds an over-prescriptive directive and another adds a helper. Recording the
+code artifact alongside the trace permits a later layer to roll back the
+directive without discarding the helper. This is an audit example, not a
+guarantee that a recursive driver finds the rollback.}

--- a/trees/ftip-00EP.tree
+++ b/trees/ftip-00EP.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Archives and stopping rules}
+\p{The second cluster separates a finite archive of candidate chains from the
+single chain selected for execution, and makes stopping explicit.}
+\transclude{ftip-00EQ}
+\transclude{ftip-00ER}
+\transclude{ftip-00ES}
+\transclude{ftip-00ET}

--- a/trees/ftip-00EQ.tree
+++ b/trees/ftip-00EQ.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Finite recursive archive}
+\tag{ftip}
+\p{An archive at depth bound #{D} is a finite set #{\mathcal A_D} of recorded
+chains. Each chain has the form}
+##{a=(C_2,\ldots,C_{d_a}),\qquad 1\leq d_a\leq D.}
+\p{Each chain stores its evaluation record and resource cost. Archive
+membership is a protocol state, not a learned weight update.}

--- a/trees/ftip-00ER.tree
+++ b/trees/ftip-00ER.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Archive score envelope}
+\tag{ftip}
+\p{For finite task set #{\mathcal T}, define the evaluated mean score of chain
+#{a} by}
+##{J(a)=N^{-1}\sum_{i=1}^N s_i(a).}
+\p{When #{\mathcal A_D} is nonempty, its \newvocab{archive envelope} is}
+##{J_D^{\max}=\max_{a\in\mathcal A_D}J(a).}
+\p{The envelope is an evaluation summary; it need not identify one deployable
+chain if scores were obtained under different configurations.}

--- a/trees/ftip-00ES.tree
+++ b/trees/ftip-00ES.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Lemma}
+\title{Archive envelope dominates its incumbent}
+\tag{ftip}
+\tag{finite-result}
+\p{If #{a_0\in\mathcal A_D}, then #{J_D^{\max}\geq J(a_0)}.}
+\p{Proof. The maximum of a finite nonempty set is at least each member, in
+particular #{a_0}. No claim about an unseen task follows.}

--- a/trees/ftip-00ET.tree
+++ b/trees/ftip-00ET.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Finite archive selection bound}
+\tag{ftip}
+\tag{finite-result}
+\p{Let #{a^\star} maximize #{J} over a finite nonempty archive and let #{\hat a}
+be an approximate selector with #{J(\hat a)\geq J(a^\star)-\delta}. Then}
+##{0\leq J(a^\star)-J(\hat a)\leq\delta.}
+\p{This is a finite selection statement under the same evaluation law; it is
+not an optimizer-convergence or generalization theorem.}

--- a/trees/ftip-00EU.tree
+++ b/trees/ftip-00EU.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Conditioning, interference, and finite protocol records}
+\p{The remaining clusters type conditional strategy/tactic composition and the
+costed records needed to audit a recursive run.}
+\transclude{ftip-00EV}
+\transclude{ftip-00EW}
+\transclude{ftip-00EX}
+\transclude{ftip-00EY}
+\transclude{ftip-00EZ}

--- a/trees/ftip-00EV.tree
+++ b/trees/ftip-00EV.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Strategy and tactic configuration}
+\tag{ftip}
+\p{At depth #{d}, let #{\mathcal K_d} be a finite set of tactic behaviors and
+let a strategy select a conditional tactic in #{\mathcal K_d}. A realized
+configuration is #{(k_2,\ldots,k_n)}. The notation records expressible choices,
+not the number of choices an implementation actually discovers.}

--- a/trees/ftip-00EW.tree
+++ b/trees/ftip-00EW.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Lemma}
+\title{Conditional configuration upper bound}
+\tag{ftip}
+\tag{finite-result}
+\p{If layer #{d} has #{k_d} possible tactics and all combinations are allowed,
+the number of configurations is at most #{\prod_{d=2}^n k_d}. An unconditioned
+flat choice with the same layerwise menus has at most #{\sum_{d=2}^n k_d}
+listed choices.}
+\p{Proof. The first count is the cardinality of a Cartesian product; the second
+is the cardinality of a disjoint menu union. These are upper bounds only.}

--- a/trees/ftip-00EX.tree
+++ b/trees/ftip-00EX.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Product versus sum is not a measured gain}
+\tag{ftip}
+\p{With three menus of size three, the product bound is #{27} and the sum bound
+is #{9}. A protocol that never emits most combinations can realize far fewer
+than #{27}; the arithmetic does not establish a benchmark improvement.}

--- a/trees/ftip-00EY.tree
+++ b/trees/ftip-00EY.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Layer interference and rollback}
+\tag{ftip}
+\p{Let a helper improve one task while a later directive lowers its score.
+The archive can retain the earlier helper chain and a later layer can remove
+the directive. The example separates a compositional possibility from a proof
+that any driver detects or repairs interference.}

--- a/trees/ftip-00EZ.tree
+++ b/trees/ftip-00EZ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Recursion is not a quality guarantee}
+\tag{ftip}
+\p{The product bound, richer trace input, and archive envelope can all hold
+while scores regress, overfit, or depend on the evaluator. The source reports
+empirical ablations and layer roles in Sections 3.1--3.4; those observations do
+not become FTIP theorems or capability claims here.}

--- a/trees/ftip-00F0.tree
+++ b/trees/ftip-00F0.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Stopping, admission, and transfer limits}
+\transclude{ftip-00F1}
+\transclude{ftip-00F2}
+\transclude{ftip-00F3}
+\transclude{ftip-00F4}
+\transclude{ftip-00F5}
+\transclude{ftip-00F6}
+\transclude{ftip-00F7}
+\transclude{ftip-00F8}

--- a/trees/ftip-00F1.tree
+++ b/trees/ftip-00F1.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Recursive run record}
+\tag{ftip}
+\p{A recursive run record is #{R=(\mathcal T,\Omega,S_1,\mathcal A_D,\sigma)},
+where #{\sigma} lists depth, seed, evaluator version, emitted code hashes,
+scores, and resource costs. A record is replayable only relative to these
+declared inputs and versions.}

--- a/trees/ftip-00F2.tree
+++ b/trees/ftip-00F2.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Convergence stopping rule}
+\tag{ftip}
+\p{Fix tolerance #{\epsilon>0}, score range #{R>0}, patience #{P\geq1}, and
+maximum depth #{D}. A linear recursive run stops when no emitted layer improves
+the mean score by more than #{\epsilon R} for #{P} consecutive layers, or when
+the driver emits empty code, or when depth #{D} is reached.}

--- a/trees/ftip-00F3.tree
+++ b/trees/ftip-00F3.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Lemma}
+\title{Finite stopping bound}
+\tag{ftip}
+\tag{finite-result}
+\p{Under the rule in \ref{ftip-00F2}, a run that reaches its depth cap emits at
+most #{D-1} wrapped layers. If it stops earlier, it emits no more than this
+many. This bound is combinatorial and does not imply convergence of scores.}

--- a/trees/ftip-00F4.tree
+++ b/trees/ftip-00F4.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Budget-preserving layer admission}
+\tag{ftip}
+\tag{finite-result}
+\p{Let a candidate layer cost #{c\geq0}, remaining budget be #{b\geq0}, and
+admission require #{c\leq b}. After admission, set #{b'=b-c}; then #{b'\geq0}
+and the total admitted cost is at most the initial budget.}
+\p{Proof. Subtracting a nonnegative cost no larger than #{b} preserves
+nonnegativity; induction over admissions gives the total bound.}

--- a/trees/ftip-00F5.tree
+++ b/trees/ftip-00F5.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Rollback preserves the base solver}
+\tag{ftip}
+\p{If a later layer is rejected by its admission or evaluation gate, removing
+that layer returns to #{S_{d-1}}. This is a harness rollback, not a reversal of
+weight training and not evidence that the rejected layer was unsafe.}

--- a/trees/ftip-00F6.tree
+++ b/trees/ftip-00F6.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{What the recursive source reports}
+\tag{ftip}
+\p{The source reports two backbones, eight benchmark families, convergence
+stopping, and archive ablations in Sections 3.1--3.4 of
+\citek{kim2026metanrecursive}; its fixed-driver, conditioning, stopping, and
+archive setup is described in Sections 2.2--2.4. These are empirical
+comparisons under its task, model, and budget choices; they are not universal
+depth, stability, or capability theorems.}

--- a/trees/ftip-00F7.tree
+++ b/trees/ftip-00F7.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Transfer limits for recursive harnesses}
+\tag{ftip}
+\p{The finite statements assume a fixed task set, evaluator, versions, and
+declared budget. They do not transfer to weight learning, RLVR optimization,
+unbounded self-modification, or capability acquisition without new hypotheses.}

--- a/trees/ftip-00F8.tree
+++ b/trees/ftip-00F8.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Archive-best is not one deployable policy}
+\tag{ftip}
+\p{Two chains can attain their best scores on disjoint task subsets. The
+archive envelope records the larger mean after selecting per-chain evaluations,
+but a deployment that must choose one chain cannot inherit both subsets. A
+common-task, common-seed evaluation is required for a deployable comparison.}

--- a/trees/refs/kim2026metanrecursive.tree
+++ b/trees/refs/kim2026metanrecursive.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\title{Meta-n: Recursive Self-Improvement through Emergent Depth}
+\date{2026}
+\author/literal{Zae Myung Kim}
+\author/literal{Young-Jun Lee}
+\author/literal{Seungyeon Jwa}
+\author/literal{Dongyeop Kang}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2608.24735v1}
+\meta{bibtex}{\startverb
+@article{kim2026metanrecursive,
+  title = {Meta-n: Recursive Self-Improvement through Emergent Depth},
+  author = {Kim, Zae Myung and Lee, Young-Jun and Jwa, Seungyeon and Kang, Dongyeop},
+  year = {2026},
+  url = {https://arxiv.org/abs/2608.24735v1},
+  journal = {arXiv preprint arXiv:2608.24735}
+}
+\stopverb}


### PR DESCRIPTION
Adds the next narrowly scoped FTIP note on recursive harnesses and archive envelopes.

- 28 new trees, 00EH–00F8; one root transclusion; one pinned Meta-n reference
- local finite results for nested composition, archive envelopes, stopping, admission, and transfer limits
- Meta-n source claims remain empirical and are cited to Sections 2.2–2.4 and 3.1–3.4
- no universal depth, stability, quality, or capability claim

Local gates: just chk, Forester, full CI=1 build, verify-render, targeted lize, strict PDF scan, and graph/reachability/no-forward-ref checks pass.