### PR TITLE
FTIP evaluation transport and matched protocols

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -85,3 +85,4 @@ that combination.}
 \transclude{ftip-00DA}
 \transclude{ftip-00DX}
 \transclude{ftip-00EH}
+\transclude{ftip-00F9}

--- a/trees/ftip-00F9.tree
+++ b/trees/ftip-00F9.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Evaluation transport and matched protocols}
+\tag{ftip}
+\tag{evaluation}
+\p{This section compares post-training artifacts only through declared
+evaluation laws, inference protocols, utilities, seeds, and budgets. It proves
+finite transport statements locally and treats long-horizon research-state
+records as empirical evidence, not as theorems.}
+\transclude{ftip-00FA}
+\transclude{ftip-00G2}
+\transclude{ftip-00G8}
+\transclude{ftip-00GE}
+\transclude{ftip-00GK}

--- a/trees/ftip-00FA.tree
+++ b/trees/ftip-00FA.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Evaluation laws and couplings}
+\tag{ftip}
+\tag{evaluation}
+\transclude{ftip-00FB}
+\transclude{ftip-00FC}
+\transclude{ftip-00FD}
+\transclude{ftip-00FE}
+\transclude{ftip-00FF}
+\transclude{ftip-00G0}
+\transclude{ftip-00G1}

--- a/trees/ftip-00FB.tree
+++ b/trees/ftip-00FB.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Convention}
+\title{A named evaluation experiment}
+\tag{ftip}
+\p{A named evaluation experiment records the artifact, task law, inference
+protocol, evaluator, seed kernel, budget, and sampling unit. Two reported
+scores are comparable only after these coordinates and their intended target
+have been stated.}

--- a/trees/ftip-00FC.tree
+++ b/trees/ftip-00FC.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Evaluation law}
+\tag{ftip}
+\p{For a fixed evaluation interface from \ref{ftip-005D}, an evaluation law
+is a probability measure #{\mathsf Q} on the finite outcome space
+#{\mathcal Z=\mathcal X_{\mathsf T_{\rm ev}}\times\mathcal O_{\mathsf T_{\rm ev}}}
+with random pair #{(X,O)\sim\mathsf Q}. Its score for artifact #{M} is a
+bounded measurable map #{s_M:\mathcal Z\to[0,1]}. Write
+#{J_{\mathsf Q}(M)=\mathbb E_{\mathsf Q}[s_M(X,O)]}.}

--- a/trees/ftip-00FD.tree
+++ b/trees/ftip-00FD.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Matched evaluation pair}
+\tag{ftip}
+\p{A matched evaluation pair is #{(\mathsf Q,\mathsf I,b,\Lambda)} and
+#{(\mathsf Q',\mathsf I',b',\Lambda')} together with a coupling
+#{(Z,Z')} whose marginals are the two laws. The pair is \strong{matched on
+the declared coordinates} when the task, utility, evaluator version, and
+sampling unit are shared; any changed coordinate is named.}

--- a/trees/ftip-00FE.tree
+++ b/trees/ftip-00FE.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Paired finite score estimator}
+\tag{ftip}
+\p{For iid coupled draws #{(Z_j,Z'_j)_{j=1}^m}, define
+#{\widehat\Delta_m=m^{-1}\sum_{j=1}^m(s_M(Z_j)-s_{M'}(Z'_j))}. The pairing is
+part of the estimator specification; it does not silently identify the two
+evaluation laws.}

--- a/trees/ftip-00FF.tree
+++ b/trees/ftip-00FF.tree
@@ -1,0 +1,15 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Unbiasedness of the paired score estimator}
+\tag{ftip}
+\p{Under the iid coupling in \ref{ftip-00FE},
+#{\mathbb E[\widehat\Delta_m]=J_{\mathsf Q}(M)-J_{\mathsf Q'}(M')}.}
+\proof{\p{Linearity of expectation gives the displayed identity.}
+##{
+\mathbb E[\widehat\Delta_m]
+=m^{-1}\sum_j\left(\mathbb E[s_M(Z_j)]-
+\mathbb E[s_{M'}(Z'_j)]\right).
+}
+\p{The coupling fixes the joint sampling but does not change either marginal,
+so the two terms are the stated expectations.}}

--- a/trees/ftip-00G0.tree
+++ b/trees/ftip-00G0.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Common seeds can reduce paired variance}
+\tag{ftip}
+\p{If #{s_M(Z)=s_{M'}(Z')} almost surely under a common-seed coupling,
+then #{\widehat\Delta_m=0} for every sample even when independent sampling
+would have nonzero variance. This is a variance statement, not evidence that
+the two artifacts have equal behavior on a different law.}

--- a/trees/ftip-00G1.tree
+++ b/trees/ftip-00G1.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{A coupling does not merge estimands}
+\tag{ftip}
+\p{\ref{ftip-00FF} is FTIP-proved. A shared seed can make a paired
+comparison precise while the changed task law, evaluator, or inference budget
+still changes the estimand. No causal effect follows without a declared
+intervention and matched coordinates.}

--- a/trees/ftip-00G2.tree
+++ b/trees/ftip-00G2.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Utility transport}
+\tag{ftip}
+\tag{evaluation}
+\transclude{ftip-00G3}
+\transclude{ftip-00G4}
+\transclude{ftip-00G5}
+\transclude{ftip-00G6}
+\transclude{ftip-00G7}

--- a/trees/ftip-00G3.tree
+++ b/trees/ftip-00G3.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Bounded utility perturbation}
+\tag{ftip}
+\p{On a common finite outcome law #{\mathsf Q}, let each artifact #{M}
+have score maps #{s_M,t_M:\mathcal Z\to[0,1]}. They have perturbation
+radius #{\varepsilon=\sup_{M,\,z\in\operatorname{supp}(\mathsf Q)}
+|s_M(z)-t_M(z)|} when #{0\leq\varepsilon\leq1}; write
+#{J_s(M)=\mathbb E_{\mathsf Q}[s_M]} and
+#{J_t(M)=\mathbb E_{\mathsf Q}[t_M]}.}

--- a/trees/ftip-00G4.tree
+++ b/trees/ftip-00G4.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Direct utility transport bound}
+\tag{ftip}
+\p{Under \ref{ftip-00G3}, every artifact #{M} satisfies
+#{|J_s(M)-J_t(M)|\leq\varepsilon}.}
+\proof{\p{Pointwise bounds give #{-\varepsilon\leq s_M(z)-t_M(z)\leq
+\varepsilon}. Taking expectations preserves both inequalities.}}

--- a/trees/ftip-00G5.tree
+++ b/trees/ftip-00G5.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Corollary}
+\title{Transporting an artifact comparison}
+\tag{ftip}
+\p{If two artifacts #{M_1,M_0} are scored by both #{s} and #{t} under the
+same law and #{\lVert s-t\rVert_{\infty,\mathsf Q}\leq\varepsilon}, then
+the gain difference obeys #{|(J_s(M_1)-J_s(M_0))-(J_t(M_1)-J_t(M_0))|
+\leq2\varepsilon}. This is a finite utility perturbation bound, not a
+training or distribution-shift theorem.}

--- a/trees/ftip-00G6.tree
+++ b/trees/ftip-00G6.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Equal aggregate score can hide a slice reversal}
+\tag{ftip}
+\p{On equally likely outcomes #{a,b}, take score vectors
+#{(s_{M_1}(a),s_{M_1}(b))=(1,0)} and
+#{(s_{M_0}(a),s_{M_0}(b))=(0,1)}; a second score map swaps coordinates.
+Both artifacts have aggregate score #{1/2} under both maps, but their
+per-outcome ordering reverses. Aggregate transport alone does not identify
+localized behavior.}

--- a/trees/ftip-00G7.tree
+++ b/trees/ftip-00G7.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Common domains are a transport hypothesis}
+\tag{ftip}
+\p{The bound in \ref{ftip-00G4} requires the same finite outcome support.
+Changing prompts, parsers, evaluators, or inference budgets is a new law and
+must be recorded rather than hidden inside a score perturbation.}

--- a/trees/ftip-00G8.tree
+++ b/trees/ftip-00G8.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Prompt and research-state transport}
+\tag{ftip}
+\tag{state}
+\transclude{ftip-00G9}
+\transclude{ftip-00GA}
+\transclude{ftip-00GB}
+\transclude{ftip-00GC}
+\transclude{ftip-00GD}

--- a/trees/ftip-00G9.tree
+++ b/trees/ftip-00G9.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Research-state observable}
+\tag{ftip}
+\p{For a finite record space #{\mathcal R}, an observable is a map
+#{h:\mathcal R\to\mathcal H}. A summary-only evaluator sees #{h(r)} and
+not the underlying record #{r}; the omitted coordinates are part of the
+declared transport boundary.}

--- a/trees/ftip-00GA.tree
+++ b/trees/ftip-00GA.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Compaction kernel}
+\tag{ftip}
+\p{A compaction kernel is a randomized map #{K(dh\mid r)} from records in
+#{\mathcal R} to summaries in #{\mathcal H}. A deterministic summary is the
+special case #{K(dh\mid r)=\delta_{h(r)}}.}

--- a/trees/ftip-00GB.tree
+++ b/trees/ftip-00GB.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Summary-only indistinguishability}
+\tag{ftip}
+\p{Let #{r,r'\in\mathcal R} induce the same summary law under the kernel in
+\ref{ftip-00GA}. Any randomized decision rule that receives only that summary
+has the same output law in the two worlds.}
+\proof{\p{The output law is the pushforward of the common summary law through
+the same decision kernel. Pushforwards of equal finite measures are equal.}}

--- a/trees/ftip-00GC.tree
+++ b/trees/ftip-00GC.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{An omitted feasibility constraint}
+\tag{ftip}
+\p{Two research records can share every summary score while one contains a
+withdrawn lemma and the other contains a feasible proof plan. A summary-only
+selector therefore chooses identically, although the correct next action
+differs. This is a finite witness to information loss, not a claim about a
+particular model.}

--- a/trees/ftip-00GD.tree
+++ b/trees/ftip-00GD.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Long-horizon records are empirical transport evidence}
+\tag{ftip}
+\p{The case study in \citek{li2026longhorizon}, Sections 4--7, reports
+file-based memory, human steering, and research-state failures under one
+system and task. It motivates explicit observables and omitted constraints;
+it does not supply the finite theorem in \ref{ftip-00GB} or a general model
+capability law.}

--- a/trees/ftip-00GE.tree
+++ b/trees/ftip-00GE.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Evaluation cells and budget accounting}
+\tag{ftip}
+\tag{evaluation}
+\transclude{ftip-00GF}
+\transclude{ftip-00GG}
+\transclude{ftip-00GH}
+\transclude{ftip-00GI}
+\transclude{ftip-00GJ}

--- a/trees/ftip-00GF.tree
+++ b/trees/ftip-00GF.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Evaluation cell}
+\tag{ftip}
+\p{An evaluation cell is #{C=(M,\mathsf Q,\mathsf I,b,\Lambda,v)}, where
+#{M} is an artifact, #{\mathsf Q} a task law, #{\mathsf I} an inference
+protocol, #{b} a budget, #{\Lambda} a seed kernel, and #{v} an evaluator
+version. A cell comparison may differ in named coordinates only.}

--- a/trees/ftip-00GG.tree
+++ b/trees/ftip-00GG.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Lemma}
+\title{Additive evaluation cost}
+\tag{ftip}
+\p{For a finite evaluation plan with disjoint stages of costs
+#{c_1,\ldots,c_k\in\mathbb R_{\geq0}}, total cost is #{c=\sum_{i=1}^k c_i}.
+Appending a stage increases cost by its declared amount and cannot preserve a
+budget #{B} unless the remaining slack covers it.}
+\proof{\p{The statement is the associativity and monotonicity of finite sums.}}

--- a/trees/ftip-00GH.tree
+++ b/trees/ftip-00GH.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Budget-preserving matched comparison}
+\tag{ftip}
+\p{Let two evaluation plans use the same declared stages except for a
+substitution whose cost is at most the replaced stage cost. If their common
+prefix cost is #{c_0} and both suffix costs fit #{B-c_0}, then both cells in
+\ref{ftip-00GF} are admissible under budget #{B}.}
+\proof{\p{Apply \ref{ftip-00GG} to the common prefix and each suffix. The
+assumed inequalities give total cost at most #{B} in each plan.}}

--- a/trees/ftip-00GI.tree
+++ b/trees/ftip-00GI.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Cost-balanced evaluation cells}
+\tag{ftip}
+\p{A paired run can spend #{B=100} units as 40 units of inference, 20 of
+evaluator calls, and 40 of audit. Replacing 10 inference units by 10 audit
+units preserves the budget, but changes the cell and must not be described as
+the same inference protocol.}

--- a/trees/ftip-00GJ.tree
+++ b/trees/ftip-00GJ.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Execution and evaluator confounds}
+\tag{ftip}
+\p{A score change can arise from the artifact, prompt law, inference budget,
+parser, evaluator version, or execution failure. A matched-cell report names
+these coordinates before interpreting a paired gain.}

--- a/trees/ftip-00GK.tree
+++ b/trees/ftip-00GK.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Transfer boundaries and reversals}
+\tag{ftip}
+\transclude{ftip-00GL}
+\transclude{ftip-00GM}
+\transclude{ftip-00GN}
+\transclude{ftip-00GO}
+\transclude{ftip-00GP}
+\transclude{ftip-00GQ}

--- a/trees/ftip-00GL.tree
+++ b/trees/ftip-00GL.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Train and evaluation laws can reverse a ranking}
+\tag{ftip}
+\p{Let #{\mathsf Q_{\rm tr}} put masses #{.9,.1} on #{a,b}, and let
+#{\mathsf Q_{\rm ev}} swap them. Artifacts #{M_1,M_0} with score vectors
+#{(s_{M_1}(a),s_{M_1}(b))=(1,0)} and
+#{(s_{M_0}(a),s_{M_0}(b))=(0,1)} rank oppositely under the two laws. A
+training score is not an evaluation transport certificate.}

--- a/trees/ftip-00GM.tree
+++ b/trees/ftip-00GM.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Total-variation transport bound}
+\tag{ftip}
+\p{For any score #{s:\mathcal Z\to[0,1]} and finite laws #{\mathsf Q,\mathsf Q'},
+#{|\mathbb E_{\mathsf Q}s-\mathbb E_{\mathsf Q'}s|\leq
+\lVert\mathsf Q-\mathsf Q'\rVert_{\rm TV}}, where
+#{\lVert\mathsf Q-\mathsf Q'\rVert_{\rm TV}:=\frac12\sum_{z\in\mathcal Z}
+|\mathsf Q(z)-\mathsf Q'(z)|}.}
+\proof{\p{Expand the finite expectation difference and use
+#{|s(z)|\leq1}. The positive and negative parts are bounded by the total
+variation mass, giving the displayed inequality.}}

--- a/trees/ftip-00GN.tree
+++ b/trees/ftip-00GN.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{A sharp two-point transport bound}
+\tag{ftip}
+\p{On #{\mathcal Z=\{a,b\}}, let #{s(a)=1,s(b)=0}, and let
+#{\mathsf Q(a)=1}, #{\mathsf Q'(a)=1-\eta}, and
+#{\mathsf Q'(b)=\eta}. The score difference and total
+variation distance are both #{\eta}.}

--- a/trees/ftip-00GO.tree
+++ b/trees/ftip-00GO.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{What transport does not identify}
+\tag{ftip}
+\p{The bounds above transport a declared score across a declared law. They do
+not identify why an artifact changed, establish support expansion, prove
+generalization, or order different evaluators whose outcome spaces differ.}

--- a/trees/ftip-00GP.tree
+++ b/trees/ftip-00GP.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{A minimal evaluation trace}
+\tag{ftip}
+\p{A reproducible record is #{(M,\mathsf Q,\mathsf I,b,\Lambda,v,m,
+\widehat\Delta_m,c)}, listing the cells, sample count, paired estimate, and
+cost. Replaying this tuple reproduces the estimator target only when the
+recorded laws and versions remain available.}

--- a/trees/ftip-00GQ.tree
+++ b/trees/ftip-00GQ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Route to a reliability protocol}
+\tag{ftip}
+\p{The next reliability lane should turn these cell, cost, and trace fields
+into execution gates, contamination checks, grader calibration, and audit
+before commit. It should remain a methodology protocol rather than a new
+capability theorem.}


### PR DESCRIPTION
Adds the evaluation-transport lane after the landed recursive-harness work.

Scope: finite evaluation laws and couplings, paired estimators, bounded utility/TV transport, research-state compaction limits, matched evaluation cells and budget accounting, and explicit transfer/reversal boundaries. Long-horizon research records remain empirical context only.

Validation: just chk, just forest, full CI=1 just build, verify-render, targeted PDF/lize, strict FTIP log scan, and affected-page visual review.

Base: 7df08e8c8268891de049a2d73609714ae1ecaaad
New trees: 00F9-00GQ (33 trees); total 582.