### PR TITLE
FTIP reliability protocol and failure taxonomy

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -86,3 +86,4 @@ that combination.}
 \transclude{ftip-00DX}
 \transclude{ftip-00EH}
 \transclude{ftip-00F9}
+\transclude{ftip-00GR}

--- a/trees/ftip-00GR.tree
+++ b/trees/ftip-00GR.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Reliability protocol and failure taxonomy}
+\tag{ftip}
+\tag{evaluation}
+\p{This section turns the existing evaluation-cell, durable-state, replay, and
+audit objects into a checkable operating protocol. It records methodology
+guidance as methodology, proves only finite bookkeeping consequences, and
+classifies failures without converting benchmark movement into capability.}
+\transclude{ftip-00GS}
+\transclude{ftip-00H1}
+\transclude{ftip-00HA}
+\transclude{ftip-00HK}
+\transclude{ftip-00HT}

--- a/trees/ftip-00GS.tree
+++ b/trees/ftip-00GS.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Measurement and contamination controls}
+\tag{ftip}
+\tag{evaluation}
+\transclude{ftip-00GT}
+\transclude{ftip-00GU}
+\transclude{ftip-00GV}
+\transclude{ftip-00GW}
+\transclude{ftip-00GX}
+\transclude{ftip-00GY}
+\transclude{ftip-00GZ}
+\transclude{ftip-00H0}

--- a/trees/ftip-00GT.tree
+++ b/trees/ftip-00GT.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Convention}
+\title{A reliability claim has an evidence contract}
+\tag{ftip}
+\p{A reliability claim is admitted only with a named estimand, task and
+evaluation laws, artifact revision, inference protocol, evaluator version,
+sample rule, and failure policy. Missing coordinates are unknown rather than
+implicitly held fixed.}

--- a/trees/ftip-00GU.tree
+++ b/trees/ftip-00GU.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Contamination record}
+\tag{ftip}
+\p{For a candidate evaluation item #{z}, a contamination record is}
+##{c(z)=(source,split,exposure,overlap,decision)}
+\p{The fields identify source provenance, split membership, prior agent
+exposure, overlap evidence, and the admission decision; an absent field is an
+explicit unknown.}

--- a/trees/ftip-00GV.tree
+++ b/trees/ftip-00GV.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A contamination predicate}
+\tag{ftip}
+\p{Given a contamination record #{c(z)}, write #{\operatorname{cont}(z)=1}
+when its declared overlap or exposure rule rejects #{z}, and write
+#{\operatorname{cont}(z)=0} when the rule clears it. The predicate belongs to
+the protocol, not to a model’s score.}

--- a/trees/ftip-00GW.tree
+++ b/trees/ftip-00GW.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{An uncontaminated evaluation slice}
+\tag{ftip}
+\p{For an evaluation law #{\mathsf Q}, an admitted slice is
+#{\mathcal Z_0=\{z:\operatorname{cont}(z)=0\}}. Its reported score is
+conditioned on the declared slice law; removing contaminated items does not
+preserve the original estimand unless the law is unchanged by construction.}

--- a/trees/ftip-00GX.tree
+++ b/trees/ftip-00GX.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A paired comparison design}
+\tag{ftip}
+\p{A paired design fixes one evaluation law, one item order, and one sampling
+kernel for two artifacts, then records the paired difference from
+\ref{ftip-00FE}. Any item-level exclusion is applied before seeing the paired
+outcomes or is declared as an adaptive rule.}

--- a/trees/ftip-00GY.tree
+++ b/trees/ftip-00GY.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Lemma}
+\title{Pairing preserves the declared marginal target}
+\tag{ftip}
+\p{Under a fixed nonadaptive slice and the iid coupling of
+\ref{ftip-00FE}, the paired estimator remains unbiased for the two marginal
+scores in \ref{ftip-00FF}.}
+\proof{\p{Condition on the fixed slice. The coupling has the stated marginals,
+so the proof of \ref{ftip-00FF} applies without changing either expectation.}}

--- a/trees/ftip-00GZ.tree
+++ b/trees/ftip-00GZ.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{A contamination decision can change the estimand}
+\tag{ftip}
+\p{If one paired run scores all ten items but a second run removes two items
+after inspecting outputs, the two means answer different questions. A report
+must expose the removal rule and the resulting slice law.}

--- a/trees/ftip-00H0.tree
+++ b/trees/ftip-00H0.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Methodology boundary for measurement}
+\tag{ftip}
+\p{The measurement and paired-comparison guidance in
+\citek{jarmak2026reliable}, Part I, is a methodology source. It motivates
+contamination ledgers and matched comparisons; it supplies no universal
+contamination detector or statistical guarantee.}

--- a/trees/ftip-00H1.tree
+++ b/trees/ftip-00H1.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Grader calibration}
+\tag{ftip}
+\tag{evaluation}
+\transclude{ftip-00H2}
+\transclude{ftip-00H3}
+\transclude{ftip-00H4}
+\transclude{ftip-00H5}
+\transclude{ftip-00H6}
+\transclude{ftip-00H7}
+\transclude{ftip-00H8}
+\transclude{ftip-00H9}

--- a/trees/ftip-00H2.tree
+++ b/trees/ftip-00H2.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A typed grading rubric}
+\tag{ftip}
+\p{A grading rubric is #{R=(\mathcal Z,\mathcal L,g,v)}: outcome space,
+finite label set, scoring map #{g:\mathcal Z\to\mathcal L}, and evaluator
+version #{v}. The rubric declares which labels count as success and which
+observations are abstentions.}

--- a/trees/ftip-00H3.tree
+++ b/trees/ftip-00H3.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A grader response law}
+\tag{ftip}
+\p{For rubric #{R}, a grader response law is a kernel
+#{K(\ell\mid z)} on #{\mathcal L} given outcome #{z}. A deterministic grader
+is the point-mass case; stochastic or model-based graders must retain their
+version and sampling coordinates.}

--- a/trees/ftip-00H4.tree
+++ b/trees/ftip-00H4.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A calibration set}
+\tag{ftip}
+\p{A calibration set is a finite set #{\mathcal C\subseteq\mathcal Z} with
+an adjudicated label #{y^star(z)} for each #{z\in\mathcal C}. The adjudication
+source, disagreement policy, and release version are part of the set’s
+provenance.}

--- a/trees/ftip-00H5.tree
+++ b/trees/ftip-00H5.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Calibration agreement}
+\tag{ftip}
+\p{For grader kernel #{K} and calibration set #{\mathcal C}, the agreement
+rate is #{A(K,\mathcal C)=|\mathcal C|^{-1}\sum_{z\in\mathcal C}
+K(y^star(z)\mid z)}. It is a calibration-set statistic, not a population
+accuracy claim.}

--- a/trees/ftip-00H6.tree
+++ b/trees/ftip-00H6.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Lemma}
+\title{Agreement threshold admission}
+\tag{ftip}
+\p{If #{|\mathcal C|=n\geq1} and #{A(K,\mathcal C)\geq1-\eta}, then the
+empirical disagreement mass #{1-A(K,\mathcal C)} is at most #{\eta}.}
+\proof{\p{Rearrange the defining finite average in \ref{ftip-00H5}. No
+generalization beyond #{\mathcal C} is implied.}}

--- a/trees/ftip-00H7.tree
+++ b/trees/ftip-00H7.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{High aggregate agreement can hide a subgroup failure}
+\tag{ftip}
+\p{A grader that agrees on 99 of 100 easy cases but fails on the one safety
+case has agreement .99 and still fails the declared safety criterion. A
+calibration report therefore stratifies by failure-relevant labels.}

--- a/trees/ftip-00H8.tree
+++ b/trees/ftip-00H8.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A grader release gate}
+\tag{ftip}
+\p{A grader release gate accepts #{K} only when its calibration version,
+agreement thresholds, abstention handling, and stratified failure checks are
+recorded. A failed gate blocks interpretation of downstream score changes.}

--- a/trees/ftip-00H9.tree
+++ b/trees/ftip-00H9.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Methodology boundary for grading}
+\tag{ftip}
+\p{Part II of \citek{jarmak2026reliable} organizes grading and reviewer
+calibration practices. The finite agreement quantities above are note-local;
+the source does not establish a universal threshold or blinded-human
+reliability theorem.}

--- a/trees/ftip-00HA.tree
+++ b/trees/ftip-00HA.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Execution gates and durable state}
+\tag{ftip}
+\tag{state}
+\transclude{ftip-00HB}
+\transclude{ftip-00HC}
+\transclude{ftip-00HD}
+\transclude{ftip-00HE}
+\transclude{ftip-00HF}
+\transclude{ftip-00HG}
+\transclude{ftip-00HH}
+\transclude{ftip-00HI}
+\transclude{ftip-00HJ}

--- a/trees/ftip-00HB.tree
+++ b/trees/ftip-00HB.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{An execution gate}
+\tag{ftip}
+\p{An execution gate is a predicate #{g_i(e_i)} over a recorded stage result
+#{e_i}. It names its owner, required inputs, pass/fail/unknown outputs, and
+the artifact versions to which the result applies.}

--- a/trees/ftip-00HC.tree
+++ b/trees/ftip-00HC.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{An ordered gate chain}
+\tag{ftip}
+\p{An ordered gate chain is #{(g_1,\ldots,g_k)} with stage outputs
+#{e_1,\ldots,e_k}; gate #{g_i} may execute only after its declared
+prerequisites and records a monotone status in #{\{pass,fail,unknown\}}.}

--- a/trees/ftip-00HD.tree
+++ b/trees/ftip-00HD.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{A failed gate blocks a release conjunction}
+\tag{ftip}
+\p{For a finite chain, define release status as
+#{G=\bigwedge_{i=1}^k g_i(e_i)}. If any gate is false, then #{G} is false.}
+\proof{\p{This is the defining conjunction of finitely many Boolean gate
+predicates. It says nothing about whether a later gate would have passed.}}

--- a/trees/ftip-00HE.tree
+++ b/trees/ftip-00HE.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A durable execution record}
+\tag{ftip}
+\p{A durable execution record is}
+##{d=(run,revision,environment,inputs,events,artifacts,checks)}
+\p{It is append-only, versioned, and sufficient to locate each gate input and
+output without relying on worker-local memory.}

--- a/trees/ftip-00HF.tree
+++ b/trees/ftip-00HF.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A replay contract}
+\tag{ftip}
+\p{A replay contract for #{d} fixes the executable revision, environment
+image, input artifact hashes, seed law, and event order. A replay is faithful
+only when those coordinates are available and the resulting events satisfy
+the recorded schema.}

--- a/trees/ftip-00HG.tree
+++ b/trees/ftip-00HG.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Deterministic replay reproduces a recorded trace}
+\tag{ftip}
+\p{If the execution map is deterministic in the coordinates fixed by
+\ref{ftip-00HF}, replaying the same inputs, revision, environment, and seed
+produces the same event trace.}
+\proof{\p{Induct over the finite event sequence. Equal initial coordinates
+give equal first events; determinism and equal prefixes give the next event.}}

--- a/trees/ftip-00HH.tree
+++ b/trees/ftip-00HH.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Replayability is not correctness}
+\tag{ftip}
+\p{A reproducible run can deterministically reproduce a wrong patch or a
+misconfigured evaluator. Replay establishes trace identity under its contract;
+it does not establish that the trace met the intended utility or safety goal.}

--- a/trees/ftip-00HI.tree
+++ b/trees/ftip-00HI.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A state-integrity digest}
+\tag{ftip}
+\p{For durable record #{d}, let #{H(d)} be a cryptographic digest of its
+canonical serialized fields. A replay request fails closed when the supplied
+record digest or any referenced input hash differs from the declared value.}

--- a/trees/ftip-00HJ.tree
+++ b/trees/ftip-00HJ.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Methodology boundary for execution}
+\tag{ftip}
+\p{Part III of \citek{jarmak2026reliable} motivates containment, durable
+execution, and recovery records. The replay theorem and digest gate are
+note-local finite consequences, not claims that replay ensures correctness.}

--- a/trees/ftip-00HK.tree
+++ b/trees/ftip-00HK.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Audit before commit and failure taxonomy}
+\tag{ftip}
+\tag{evaluation}
+\transclude{ftip-00HL}
+\transclude{ftip-00HM}
+\transclude{ftip-00HN}
+\transclude{ftip-00HO}
+\transclude{ftip-00HP}
+\transclude{ftip-00HQ}
+\transclude{ftip-00HR}
+\transclude{ftip-00HS}

--- a/trees/ftip-00HL.tree
+++ b/trees/ftip-00HL.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{An audit-before-commit record}
+\tag{ftip}
+\p{An audit-before-commit record is #{a=(d,scope,checks,reviewer,decision)}.
+It binds the durable execution record #{d} to the audited scope, check list,
+review identity, and a decision in #{\{commit,hold,reject\}}.}

--- a/trees/ftip-00HM.tree
+++ b/trees/ftip-00HM.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Audit-before-commit safety gate}
+\tag{ftip}
+\p{A commit decision is admissible only if every required check in an
+\ref{ftip-00HL} record is pass, the audited digest equals the proposed record
+digest, and the decision is #{commit}.}
+\proof{\p{Admissibility is defined as the conjunction of these three recorded
+conditions; failure of any conjunct yields hold or reject.}}

--- a/trees/ftip-00HN.tree
+++ b/trees/ftip-00HN.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{An independent audit scope}
+\tag{ftip}
+\p{An audit is independent for scope #{S} when its inputs are frozen before
+review, its reviewer or checker is distinct from the proposing action, and
+its decision cannot rewrite #{S} without a new record. Independence is a
+protocol condition, not a claim of infallibility.}

--- a/trees/ftip-00HO.tree
+++ b/trees/ftip-00HO.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{A latent failure caught before commit}
+\tag{ftip}
+\p{A run may pass unit tests while an independent audit finds that the
+evaluator version in #{d} differs from the declared version. The audit holds
+the commit and records the mismatch; replay alone would not have caught it.}

--- a/trees/ftip-00HP.tree
+++ b/trees/ftip-00HP.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A reliability failure taxonomy}
+\tag{ftip}
+\p{Classify a failed run by its earliest violated contract: measurement
+failure (M), grading failure (G), execution/state failure (E), audit failure
+(A), or transfer failure (T). A single run may receive secondary labels, but
+the primary label is the earliest failed gate in recorded order.}

--- a/trees/ftip-00HQ.tree
+++ b/trees/ftip-00HQ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Lemma}
+\title{Earliest-failure labels are unique}
+\tag{ftip}
+\p{For a finite ordered gate chain with at least one failed gate, the earliest
+failed index is unique and therefore determines one primary taxonomy label.}
+\proof{\p{Every nonempty finite subset of ordered indices has a unique least
+element.}}

--- a/trees/ftip-00HR.tree
+++ b/trees/ftip-00HR.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A remediation record}
+\tag{ftip}
+\p{A remediation record maps a primary label from
+\ref{ftip-00HP} to an owner, corrective action, re-test scope, and closure
+condition. Closure requires a new durable record and cannot mutate the failed
+record in place.}

--- a/trees/ftip-00HS.tree
+++ b/trees/ftip-00HS.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Methodology boundary for audit}
+\tag{ftip}
+\p{Parts III and V of \citek{jarmak2026reliable} motivate durable execution,
+review, and accountability practices. The taxonomy and conjunction gates here
+are local operational specifications; they do not establish that an audit is
+complete or that a committed artifact is correct.}

--- a/trees/ftip-00HT.tree
+++ b/trees/ftip-00HT.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Limits and protocol handoff}
+\tag{ftip}
+\transclude{ftip-00HU}
+\transclude{ftip-00HV}
+\transclude{ftip-00HW}
+\transclude{ftip-00HX}
+\transclude{ftip-00HY}
+\transclude{ftip-00HZ}
+\transclude{ftip-00I0}

--- a/trees/ftip-00HU.tree
+++ b/trees/ftip-00HU.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{A protocol is not a causal estimator}
+\tag{ftip}
+\p{The gates above make evidence auditable. They do not identify the causal
+effect of an intervention when task law, artifact, grader, budget, or harness
+state changes together. Those coordinates remain the matched-cell boundary in
+\ref{ftip-00GF}.}

--- a/trees/ftip-00HV.tree
+++ b/trees/ftip-00HV.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Counterexample: a perfect replay can repeat a contaminated result}
+\tag{ftip}
+\p{Let a deterministic run train and evaluate on one leaked item. Its digest,
+event trace, and replay are all identical across reruns, yet the measurement
+is contaminated under \ref{ftip-00GV}. Replayability and contamination control
+are independent obligations.}

--- a/trees/ftip-00HW.tree
+++ b/trees/ftip-00HW.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Counterexample: a calibrated grader can still face a changed domain}
+\tag{ftip}
+\p{A grader can meet its threshold on #{\mathcal C} in
+\ref{ftip-00H6} while every deployment item lies outside that calibration
+domain and receives an unvalidated label. Agreement on #{\mathcal C} alone does
+not transport to a new law.}

--- a/trees/ftip-00HX.tree
+++ b/trees/ftip-00HX.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Budgeted audit admission}
+\tag{ftip}
+\p{If an audit plan has finite nonnegative stage costs and its declared sum is
+at most budget #{B}, then the plan is budget-admissible; adding any positive
+stage beyond the remaining slack makes it inadmissible.}
+\proof{\p{Apply additive cost monotonicity from \ref{ftip-00GG}.}}

--- a/trees/ftip-00HY.tree
+++ b/trees/ftip-00HY.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{A cost-balanced audit plan}
+\tag{ftip}
+\p{With budget #{B=100}, a plan may allocate 50 units to execution, 30 to
+grading calibration, and 20 to audit. A proposed 10-unit extra audit must be
+funded by reducing another stage or the admission gate fails.}

--- a/trees/ftip-00HZ.tree
+++ b/trees/ftip-00HZ.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{What this protocol can establish}
+\tag{ftip}
+\p{A passing protocol establishes that declared evidence contracts, hashes,
+checks, and budgets were satisfied for the recorded run. It does not establish
+capability acquisition, broad generalization, or absence of unobserved faults.}

--- a/trees/ftip-00I0.tree
+++ b/trees/ftip-00I0.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Handoff to the theorem ledger}
+\tag{ftip}
+\p{The next lane should freeze the machine-checkable signatures of the finite
+results already marked FTIP-proved, together with domains, source boundaries,
+counterexamples, and transfer limits. Lean implementation remains outside
+this protocol note.}

--- a/trees/refs/jarmak2026reliable.tree
+++ b/trees/refs/jarmak2026reliable.tree
@@ -1,0 +1,15 @@
+% ["reliability", "coding agents", "evaluation methodology"]
+\title{Engineering Reliable Coding Agents: Evaluating and Operating the System Around the Model}
+\date{2026}
+\author/literal{Stephanie Jarmak}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2608.13867v1}
+\meta{bibtex}{\startverb
+@article{jarmak2026reliable,
+  title = {Engineering Reliable Coding Agents: Evaluating and Operating the System Around the Model},
+  author = {Jarmak, Stephanie},
+  year = {2026},
+  url = {https://arxiv.org/abs/2608.13867v1},
+  journal = {arXiv preprint arXiv:2608.13867}
+}
+\stopverb}


### PR DESCRIPTION
Adds a checkable reliability protocol over the landed evaluation-transport and harness-state machinery.

Scope: contamination records and paired measurement, grader calibration, execution gates and durable replay, audit-before-commit, failure taxonomy, budgeted remediation, and explicit methodology/transfer limits. arXiv 2608.13867 is used as methodology only; finite conjunction, replay, and bookkeeping statements are note-local.

Validation: just chk, just forest, full pinned CI build, verify-render, targeted PDF/lize, strict FTIP log scan, and affected-page visual review.

Base: 68121cc46f8e759c0d8aa42584aaf68a047833c2
New trees: 00GR-00I0 (46 trees); suite total: 628.