### PR TITLE
FTIP public theorem ledger and Lean handoff

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -87,3 +87,4 @@ that combination.}
 \transclude{ftip-00EH}
 \transclude{ftip-00F9}
 \transclude{ftip-00GR}
+\transclude{ftip-00I1}

--- a/trees/ftip-00I1.tree
+++ b/trees/ftip-00I1.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Public theorem ledger and Lean handoff}
+\tag{ftip}
+\tag{ledger}
+
+\p{This section freezes the checkable finite statements currently ready for formalization. Each entry records its status, domains, hypotheses, conclusion, and dependency references. Lean implementation is explicitly out of scope.}
+\transclude{ftip-00I2}
+\transclude{ftip-00ID}
+\transclude{ftip-00IN}
+\transclude{ftip-00IV}

--- a/trees/ftip-00I2.tree
+++ b/trees/ftip-00I2.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Assumptions and domains}
+\tag{ftip}
+\tag{ledger}
+
+\p{The ledger starts by making every carrier, law, index set, and finiteness hypothesis explicit. A statement is not ledger-ready when a reader must infer a domain from a source paper.}
+\transclude{ftip-00I3}
+\transclude{ftip-00I4}
+\transclude{ftip-00I5}
+\transclude{ftip-00I6}
+\transclude{ftip-00I7}
+\transclude{ftip-00I8}
+\transclude{ftip-00I9}
+\transclude{ftip-00IA}
+\transclude{ftip-00IB}
+\transclude{ftip-00IC}
+\transclude{ftip-00IJ}
+\transclude{ftip-00IK}
+\transclude{ftip-00IL}
+\transclude{ftip-00IM}

--- a/trees/ftip-00I3.tree
+++ b/trees/ftip-00I3.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Convention}
+\title{Status labels for ledger entries}
+\tag{ftip}
+\tag{ledger}
+
+\p{A ledger card is marked \strong{FTIP-PROVED} for a proof in this note, \strong{SOURCE RECONSTRUCTION} for a faithful restatement of a paper result, \strong{FINITE COUNTEREXAMPLE} for a constructed obstruction, or \strong{OPEN} when no proof is claimed.}

--- a/trees/ftip-00I4.tree
+++ b/trees/ftip-00I4.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Ledger statement record}
+\tag{ftip}
+\tag{ledger}
+
+\p{A statement record has fields for id, status, domain, hypotheses, conclusion, dependencies, and limits. These finite fields document a claim; they are not a new object used by earlier cards.}

--- a/trees/ftip-00I5.tree
+++ b/trees/ftip-00I5.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Typed domain record}
+\tag{ftip}
+\tag{ledger}
+
+\p{A domain record names each carrier #{X_1,\ldots,X_n}, its equality and order conventions, and any finiteness or positivity assumptions. Every bound in a ledger conclusion quantifies over this record.}

--- a/trees/ftip-00I6.tree
+++ b/trees/ftip-00I6.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Source and local ownership}
+\tag{ftip}
+\tag{ledger}
+
+\p{A source locator licenses only the claim it states. Elementary finite proofs in this section are local FTIP results even when a source motivated them; source reconstructions retain their original hypotheses and do not become stronger by appearing in the ledger.}

--- a/trees/ftip-00I7.tree
+++ b/trees/ftip-00I7.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: independent discovery}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} Under the independent events and probabilities declared in \ref{ftip-0077}, the finite discovery identity in \ref{ftip-0078} is a ledger-ready theorem: #{B\in\mathbb N}, #{\Pr(D_B)=1-\prod_{i=1}^{B}(1-p_i)}.}

--- a/trees/ftip-00I8.tree
+++ b/trees/ftip-00I8.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: discovery budget}
+\tag{ftip}
+\tag{ledger}
+
+\p{This is FTIP-proved. Under #{0<p<1}, #{0<\delta<1}, and an integer budget #{B\geq1}, the failure constraint is equivalent to the following bound.}
+
+##{B\geq\left\lceil\frac{\log\delta}{\log(1-p)}\right\rceil.}
+
+\p{The result is proved in \ref{ftip-0079}.}

--- a/trees/ftip-00I9.tree
+++ b/trees/ftip-00I9.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: finite support tilt}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} Under the finite-carrier and positive-temperature hypotheses of \ref{ftip-007C}, normalized exponential tilting preserves the base law's positive support.}

--- a/trees/ftip-00IA.tree
+++ b/trees/ftip-00IA.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: uniform proxy regret}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} For a finite common feasible set and a common regularizer, the uniform proxy error hypothesis in \ref{ftip-007G} yields the two-epsilon objective regret bound proved in \ref{ftip-007H}; the conclusion concerns the regularized objective named there.}

--- a/trees/ftip-00IB.tree
+++ b/trees/ftip-00IB.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: utility transport}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} If the evaluation laws and finite response space satisfy the total-variation hypotheses of \ref{ftip-00GM}, then the expectation difference is bounded by the stated sup-norm times total variation.}

--- a/trees/ftip-00IC.tree
+++ b/trees/ftip-00IC.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: feedback refinement}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} For finite response set #{\mathcal Y} and deterministic rewards, a reward channel that refines the equality partition of another channel separates at least as many response classes, as proved in \ref{ftip-00AG}.}

--- a/trees/ftip-00ID.tree
+++ b/trees/ftip-00ID.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Counterexamples and transfer limits}
+\tag{ftip}
+\tag{ledger}
+
+\p{A theorem signature also records what it does not establish. The following cards freeze finite obstructions and keep empirical or source-specific claims from being silently generalized.}
+\transclude{ftip-00IE}
+\transclude{ftip-00IF}
+\transclude{ftip-00IG}
+\transclude{ftip-00IH}
+\transclude{ftip-00II}

--- a/trees/ftip-00IE.tree
+++ b/trees/ftip-00IE.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Counterexample certificate}
+\tag{ftip}
+\tag{ledger}
+
+\p{A counterexample certificate records its finite domain, parameters, law, claim, and failed conclusion. Every value is displayed for direct substitution; it is not evidence for a universal theorem.}

--- a/trees/ftip-00IF.tree
+++ b/trees/ftip-00IF.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Transfer-limit field}
+\tag{ftip}
+\tag{ledger}
+
+\p{The limits field must name changed carriers, policies, feedback, budgets, or evaluation laws. In particular, finite zero hits do not imply zero support, empirical benchmark movement does not imply acquisition, and a source reconstruction does not transfer to an approximate optimizer without a separate argument.}

--- a/trees/ftip-00IG.tree
+++ b/trees/ftip-00IG.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Finite discovery boundary certificate}
+\tag{ftip}
+\tag{ledger}
+
+\p{The two-task certificates in \ref{ftip-007E} and \ref{ftip-00A3} witness that equal one-shot averages or zero observed hits can coexist with different coverage or nonzero latent rates. They are ledgered as finite counterexamples, not as estimates outside their declared iid model.}

--- a/trees/ftip-00IH.tree
+++ b/trees/ftip-00IH.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Finite proxy boundary certificate}
+\tag{ftip}
+\tag{ledger}
+
+\p{The two-point construction in \ref{ftip-007J} is a complete certificate: its training-law average error is small while evaluation selection reverses. The missing hypothesis is a uniform bound on the evaluated feasible set, not an informal promise of similar distributions.}

--- a/trees/ftip-00II.tree
+++ b/trees/ftip-00II.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Source reconstruction boundary certificate}
+\tag{ftip}
+\tag{ledger}
+
+\p{The DGG cards \ref{ftip-007Z}--\ref{ftip-0081} and the NExt cards \ref{ftip-0086}--\ref{ftip-008B} remain source reconstructions or empirical observations. Their exact locators and transfer limits are ledger metadata; no universal collapse, capability, or speed theorem is admitted here.}

--- a/trees/ftip-00IJ.tree
+++ b/trees/ftip-00IJ.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: deterministic replay}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} If the execution map is deterministic in all coordinates fixed by \ref{ftip-00HF}, then equal input, revision, environment, and seed records produce equal finite traces, as proved in \ref{ftip-00HG}.}

--- a/trees/ftip-00IK.tree
+++ b/trees/ftip-00IK.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: summary indistinguishability}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} For the finite transcript and world kernels declared in \ref{ftip-008C}--\ref{ftip-008D}, observationally equivalent worlds induce the same output law for any common randomized post-training kernel, as proved in \ref{ftip-007S}.}

--- a/trees/ftip-00IL.tree
+++ b/trees/ftip-00IL.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: audit gate}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} Under the typed audit record of \ref{ftip-00HL}, a commit is admissible exactly when all required checks pass, the digest matches, and the recorded decision is #{commit}, as proved in \ref{ftip-00HM}.}

--- a/trees/ftip-00IM.tree
+++ b/trees/ftip-00IM.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger signature: budget admission}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} A finite audit plan with nonnegative stage costs is admissible exactly when its declared additive cost is within budget; adding a positive stage beyond slack is inadmissible, by \ref{ftip-00HX}.}

--- a/trees/ftip-00IN.tree
+++ b/trees/ftip-00IN.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Canonical notation and dependency order}
+\tag{ftip}
+\tag{ledger}
+
+\p{The canonical notation below prevents aliases from drifting between sections. Existing definitions remain authoritative; these cards only record the names and the order in which a formalizer should import them.}
+\transclude{ftip-00IO}
+\transclude{ftip-00IP}
+\transclude{ftip-00IQ}
+\transclude{ftip-00IR}
+\transclude{ftip-00IS}
+\transclude{ftip-00IT}
+\transclude{ftip-00IU}

--- a/trees/ftip-00IO.tree
+++ b/trees/ftip-00IO.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Convention}
+\title{Canonical carriers and laws}
+\tag{ftip}
+\tag{ledger}
+
+\p{Use #{\mathcal X} for prompts, #{\mathcal Y} for finite responses, #{\Omega} for sample space, #{\mathsf P} for a declared protocol, and #{\mu} for a prompt law. A probability law is written #{\Pr} only after its sample space is named.}

--- a/trees/ftip-00IP.tree
+++ b/trees/ftip-00IP.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Convention}
+\title{Canonical policy notation}
+\tag{ftip}
+\tag{ledger}
+
+\p{Use #{\pi} for a policy, #{\pi_{\rm base}} for a reference policy, and #{\pi_\theta} for a parameterized policy. A policy is always typed as a kernel from the declared prompt carrier to the declared response carrier.}

--- a/trees/ftip-00IQ.tree
+++ b/trees/ftip-00IQ.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Convention}
+\title{Canonical reward notation}
+\tag{ftip}
+\tag{ledger}
+
+\p{Use #{r:\mathcal X\times\mathcal Y\to\mathbb R} for a deterministic reward and #{u} for an evaluation utility. Proxy, verifier, and process rewards retain their local subscripts; no bare symbol silently changes meaning.}

--- a/trees/ftip-00IR.tree
+++ b/trees/ftip-00IR.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Convention}
+\title{Canonical evaluation notation}
+\tag{ftip}
+\tag{ledger}
+
+\p{Use #{M} for a model artifact, #{\mathsf E} for an evaluation protocol, and #{J_{\mathsf E}(M)} for its declared score. A comparison must state the invariant evaluation law before subtracting two scores.}

--- a/trees/ftip-00IS.tree
+++ b/trees/ftip-00IS.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Convention}
+\title{Canonical trace and state notation}
+\tag{ftip}
+\tag{ledger}
+
+\p{Use #{z_{0:n}} for a finite trace, #{s_t} for a harness state, #{\ell} for a lineage, and #{c} for an execution cost. Event logs and summaries are distinct carriers even when one is computed from the other.}

--- a/trees/ftip-00IT.tree
+++ b/trees/ftip-00IT.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Alias and collision policy}
+\tag{ftip}
+\tag{ledger}
+
+\p{When an older card uses a local alias, the ledger records the alias and its owner rather than redefining it. The graph order is the formal dependency order; prose similarity never creates an implicit edge.}

--- a/trees/ftip-00IU.tree
+++ b/trees/ftip-00IU.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger dependency acyclicity}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} If every ledger card references only an earlier card in the canonical order and each referenced carrier is introduced before use, the induced dependency graph is acyclic.}

--- a/trees/ftip-00IV.tree
+++ b/trees/ftip-00IV.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Machine-checkable statement signatures}
+\tag{ftip}
+\tag{ledger}
+
+\p{The signature format is intentionally close to a Lean theorem header while remaining Forest prose. It records universes, carriers, hypotheses, conclusion, and status; proofs and source locators remain separate fields.}
+\transclude{ftip-00IW}
+\transclude{ftip-00IX}
+\transclude{ftip-00IY}
+\transclude{ftip-00IZ}
+\transclude{ftip-00J0}
+\transclude{ftip-00J1}
+\transclude{ftip-00J2}
+\transclude{ftip-00J3}
+\transclude{ftip-00J4}
+\transclude{ftip-00J5}
+\transclude{ftip-00J6}
+\transclude{ftip-00J7}
+\transclude{ftip-00J8}

--- a/trees/ftip-00IW.tree
+++ b/trees/ftip-00IW.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Formal signature schema}
+\tag{ftip}
+\tag{ledger}
+
+\p{A machine-checkable signature is #{\mathsf S=(\mathsf{vars},\mathsf{types},\mathsf{hyp},\mathsf{stmt},\mathsf{status},\mathsf{refs})}. Every free variable in #{\mathsf{stmt}} occurs in #{\mathsf{vars}} with a type, and every ref points backward.}

--- a/trees/ftip-00IX.tree
+++ b/trees/ftip-00IX.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Signature instance: discovery}
+\tag{ftip}
+\tag{ledger}
+
+\p{An instance is #{B:\mathbb N,\ p_i:[0,1],\ E_i:\mathsf{Prop}} with independence as a hypothesis and conclusion #{\Pr(D_B)=1-\prod_{i=1}^{B}(1-p_i)}. Its status is FTIP-PROVED and its proof owner is \ref{ftip-0078}.}

--- a/trees/ftip-00IY.tree
+++ b/trees/ftip-00IY.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Signature instance: replay}
+\tag{ftip}
+\tag{ledger}
+
+\p{An instance is a deterministic execution kernel with typed inputs #{(x,\rho,e,\sigma)} and finite output trace #{z_{0:n}}. Its conclusion is equality of traces under equal inputs; its proof owner is \ref{ftip-00HG}.}

--- a/trees/ftip-00IZ.tree
+++ b/trees/ftip-00IZ.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Signature instance: audit}
+\tag{ftip}
+\tag{ledger}
+
+\p{An instance quantifies over a finite audit record #{a}, digest #{d}, and decision #{q}. Its admissibility conclusion is the conjunction in \ref{ftip-00HM}; no unstated verifier or probabilistic assumption is added.}

--- a/trees/ftip-00J0.tree
+++ b/trees/ftip-00J0.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Translation boundary to Lean}
+\tag{ftip}
+\tag{ledger}
+
+\p{A later Lean file may translate each signature into declarations and theorem statements. This note does not choose imports, automation, quotient constructions, or a probability library, and therefore does not claim kernel-checked formalization.}

--- a/trees/ftip-00J1.tree
+++ b/trees/ftip-00J1.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Finite composition of ledger results}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} If two ledger theorems have disjoint conclusions and the conclusion of the first is an explicit hypothesis of the second, their conjunction is a valid finite composition under the union of their hypotheses.}

--- a/trees/ftip-00J2.tree
+++ b/trees/ftip-00J2.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Deterministic composition of replay and audit}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} A deterministic replay theorem and the audit gate compose only when the replay trace is included in the audited record and the digest covers that trace. Otherwise the composition is not licensed.}

--- a/trees/ftip-00J3.tree
+++ b/trees/ftip-00J3.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Untyped-signature failure}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FINITE COUNTEREXAMPLE.} A statement that quantifies over a policy but omits its response carrier admits two incompatible interpretations and cannot be entered in the machine-checkable ledger. Adding #{\pi:\mathcal X\to\Delta(\mathcal Y)} repairs the signature.}

--- a/trees/ftip-00J4.tree
+++ b/trees/ftip-00J4.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Excluded source and empirical claims}
+\tag{ftip}
+\tag{ledger}
+
+\p{Claims about optimizer convergence, universal capability, NExt speedups, or DGG safety remain excluded unless a future card supplies their missing assumptions and proof. The ledger is a boundary, not a promise that every useful observation is formalizable now.}

--- a/trees/ftip-00J5.tree
+++ b/trees/ftip-00J5.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Ledger release criterion}
+\tag{ftip}
+\tag{ledger}
+
+\p{\strong{FTIP-PROVED.} A card is release-ready exactly when its status, typed domain, hypotheses, conclusion, backward dependencies, and transfer limits are all nonempty. This is a documentation predicate, not a theorem about the underlying model.}

--- a/trees/ftip-00J6.tree
+++ b/trees/ftip-00J6.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Corollary}
+\title{Ready-set closure}
+\tag{ftip}
+\tag{ledger}
+
+\p{The finite cards listed in \ref{ftip-00I7}--\ref{ftip-00IM}, \ref{ftip-00IU}, and \ref{ftip-00J1}--\ref{ftip-00J2} satisfy the release criterion of \ref{ftip-00J5} after their prerequisite cards are imported.}

--- a/trees/ftip-00J7.tree
+++ b/trees/ftip-00J7.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Lean handoff remains out of scope}
+\tag{ftip}
+\tag{ledger}
+
+\p{The handoff freezes statements and notation only. A future repository must recheck every proof, source reconstruction, and probability convention independently; no code or theorem-prover artifact is implied by this section.}

--- a/trees/ftip-00J8.tree
+++ b/trees/ftip-00J8.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Closing ledger boundary}
+\tag{ftip}
+\tag{ledger}
+
+\p{The storyline therefore ends this arc with a small formalization-ready core, explicit obstructions, and named open routes. Capability remains conditional behavior under a declared intervention and evaluation law, not a scalar latent property.}


### PR DESCRIPTION
Adds the public theorem ledger and Lean handoff as 44 new FTIP trees (00I1–00J8), preserving the no-forward-reference graph and canonical notation.

Scope: assumptions/domains; source reconstruction vs FTIP-proved results; finite counterexamples and transfer limits; machine-checkable signatures; composition/release criteria. Lean implementation remains out of scope.

Base: e440a0cbc4023eeb0a12d7b180c678015039608c
Local gates: just chk, just forest, full LIZE build, verify-render, targeted lize, strict log scan.
Rendered artifact: 213 A4 pages, SHA-256 4016ca663edeb1a5190be84a6ff5d386790c5cdf3ff057bcf530b706a153e542.