### PR TITLE
docs(ftip): add structural chapter hierarchy

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -58,33 +58,9 @@ clipping, and reward design.}
 remark identifies the contributing literature and the questions created by
 that combination.}
 
-\transclude{ftip-0002}
-\transclude{ftip-0009}
-\transclude{ftip-000K}
-\transclude{ftip-0014}
-\transclude{ftip-001M}
-\transclude{ftip-001W}
-\transclude{ftip-006P}
-\transclude{ftip-0029}
-\transclude{ftip-002J}
-\transclude{ftip-002W}
-\transclude{ftip-006S}
-\transclude{ftip-0039}
-\transclude{ftip-003L}
-\transclude{ftip-003V}
-\transclude{ftip-0042}
-\transclude{ftip-004O}
-\transclude{ftip-004Y}
-\transclude{ftip-005C}
-\transclude{ftip-005T}
-\transclude{ftip-0075}
-\transclude{ftip-008E}
-\transclude{ftip-009M}
-\transclude{ftip-00AU}
-\transclude{ftip-00C2}
-\transclude{ftip-00DA}
-\transclude{ftip-00DX}
-\transclude{ftip-00EH}
-\transclude{ftip-00F9}
-\transclude{ftip-00GR}
-\transclude{ftip-00I1}
+\transclude{ftip-00J9}
+\transclude{ftip-00JA}
+\transclude{ftip-00JB}
+\transclude{ftip-00JC}
+\transclude{ftip-00JD}
+\transclude{ftip-00JE}

--- a/trees/ftip-00J9.tree
+++ b/trees/ftip-00J9.tree
@@ -1,0 +1,17 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Foundations and interfaces}
+\tag{ftip}
+\tag{chapter}
+
+\p{This chapter groups the black-box model, task, environment, and
+evaluation interfaces that the later chapters reuse. The section roots below
+retain their existing definitions and internal transclusion structure.}
+
+\transclude{ftip-0002}
+\transclude{ftip-0009}
+\transclude{ftip-000K}
+\transclude{ftip-0014}
+\transclude{ftip-001M}
+\transclude{ftip-001W}

--- a/trees/ftip-00JA.tree
+++ b/trees/ftip-00JA.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Post-training, alignment, and feedback}
+\tag{ftip}
+\tag{chapter}
+
+\p{This chapter groups the post-training, alignment, preference, feedback,
+and agentic-update sections. Each section remains an independent addressed
+subtree; this wrapper adds organization without changing its mathematics.}
+
+\transclude{ftip-006P}
+\transclude{ftip-0029}
+\transclude{ftip-002J}
+\transclude{ftip-002W}
+\transclude{ftip-006S}
+\transclude{ftip-0039}
+\transclude{ftip-003L}
+\transclude{ftip-003V}
+\transclude{ftip-0042}
+\transclude{ftip-004O}
+\transclude{ftip-004Y}

--- a/trees/ftip-00JB.tree
+++ b/trees/ftip-00JB.tree
@@ -1,0 +1,16 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Evaluation, evidence, and finite limits}
+\tag{ftip}
+\tag{chapter}
+
+\p{This chapter groups the evaluation, evidence, finite-consequence, and
+obstruction sections. The wrappers are organizational: all statement cards
+remain owned by their existing section roots.}
+
+\transclude{ftip-005C}
+\transclude{ftip-005T}
+\transclude{ftip-0075}
+\transclude{ftip-008E}
+\transclude{ftip-009M}

--- a/trees/ftip-00JC.tree
+++ b/trees/ftip-00JC.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Optimization, computation, and architecture}
+\tag{ftip}
+\tag{chapter}
+
+\p{This optional refinement chapter groups optimization geometry,
+computation, retained context, and architecture-indexed questions. Readers
+using only the black-box formulation may omit this chapter.}
+
+\transclude{ftip-00AU}
+\transclude{ftip-00DA}

--- a/trees/ftip-00JD.tree
+++ b/trees/ftip-00JD.tree
@@ -1,0 +1,16 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Harness state, failure modes, and reliability}
+\tag{ftip}
+\tag{chapter}
+
+\p{This chapter groups persistent harness state, reward and environment
+failures, recursive harnesses, evaluation transport, and reliability
+protocols. These sections retain their existing operational interfaces.}
+
+\transclude{ftip-00C2}
+\transclude{ftip-00DX}
+\transclude{ftip-00EH}
+\transclude{ftip-00F9}
+\transclude{ftip-00GR}

--- a/trees/ftip-00JE.tree
+++ b/trees/ftip-00JE.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Theorem ledger and formalization}
+\tag{ftip}
+\tag{chapter}
+
+\p{This chapter contains the public theorem ledger and its formalization
+handoff. The ledger records assumptions, domains, status, dependencies, and
+transfer limits; Lean implementation remains outside the note suite.}
+
+\transclude{ftip-00I1}


### PR DESCRIPTION
Adds six structural chapter wrapper trees and rewires the FTIP root through them. Existing section/card trees and mathematical content are unchanged; each prior section remains reachable exactly once under one chapter.

Gates run locally: just chk and git diff --check. Full build, PDF hierarchy, and adversarial review are pending.