### PR TITLE
docs(ftip): add architecture-indexed ceilings and matched compute

### DIFF
--- a/trees/ftip-00JC.tree
+++ b/trees/ftip-00JC.tree
@@ -11,3 +11,4 @@ using only the black-box formulation may omit this chapter.}
 
 \transclude{ftip-00AU}
 \transclude{ftip-00DA}
+\transclude{ftip-00JF}

--- a/trees/ftip-00JF.tree
+++ b/trees/ftip-00JF.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+
+\title{Architecture-indexed ceilings and matched compute}
+\tag{ftip}
+\tag{architecture}
+\tag{optional-refinement}
+
+\p{This optional section refines the black-box capability framework only when
+the question names an architecture, optimizer, or systems implementation.
+The generic model remains a black box when these fields are unnecessary.}
+
+\p{Architecture comparisons below are conditional on a declared task family,
+evaluation law, intervention class, and scalar cost. Toy bounds are finite
+FTIP mathematics and do not transfer to production models without the stated
+interface and measurement gates.}
+
+\transclude{ftip-00JG}
+\transclude{ftip-00JN}
+\transclude{ftip-00JU}
+\transclude{ftip-00K2}
+\transclude{ftip-00K9}

--- a/trees/ftip-00JG.tree
+++ b/trees/ftip-00JG.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Black-box bridge and typed architecture records}
+\tag{ftip}
+\tag{architecture}
+\p{These cards add architecture fields without changing the existing black-box
+object. Each field is optional until a conclusion refers to it.}
+\transclude{ftip-00JH}
+\transclude{ftip-00JI}
+\transclude{ftip-00JJ}
+\transclude{ftip-00JK}
+\transclude{ftip-00JL}
+\transclude{ftip-00JM}

--- a/trees/ftip-00JH.tree
+++ b/trees/ftip-00JH.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Optional architecture refinement}
+\tag{ftip}
+\p{Let #{M} denote an existing black-box model intervention. An architecture
+refinement is a record #{A=(\mathcal X,\mathcal Y,\operatorname{Map}_A)} whose
+map realizes the same declared input and output interface. Forgetting #{A}
+returns #{M}; no architecture claim is made when the field is omitted.}

--- a/trees/ftip-00JI.tree
+++ b/trees/ftip-00JI.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Optimizer and systems records}
+\tag{ftip}
+\p{When needed, extend the record by #{O} for optimizer and state-update
+rules, and #{S} for kernels, precision, memory, cache, and scheduling. The
+triplet #{(A,O,S)} is descriptive; it is not a scalar intelligence score.}

--- a/trees/ftip-00JJ.tree
+++ b/trees/ftip-00JJ.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Architecture-indexed evaluation functional}
+\tag{ftip}
+\p{Fix an evaluation protocol #{J} and an architecture #{A}. Define
+#{V_A(C)} as the supremum of #{J(\operatorname{PostTrain}(A,\eta))} over
+allowed interventions #{\eta}.}
+
+\p{Restrict the supremum to interventions whose measured scalar cost is at
+most #{C}.}
+
+\p{The allowed class and evaluation law are part of the definition, so #{V_A}
+is not a universal intelligence function.}

--- a/trees/ftip-00JK.tree
+++ b/trees/ftip-00JK.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Black-box projection and gradual complexity}
+\tag{ftip}
+\p{A theorem that does not mention #{A}, #{O}, or #{S} remains a black-box
+statement. Add a field only when a conclusion changes under that field. This
+projection prevents architecture-aware notation from contaminating generic
+formalization.}

--- a/trees/ftip-00JL.tree
+++ b/trees/ftip-00JL.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Three ceiling layers}
+\tag{ftip}
+\p{For fixed task and evaluation laws, distinguish the representational
+ceiling of #{A}, the optimizer-reachable ceiling of #{(A,O)}, and the
+systems-feasible frontier of #{(A,O,S,C)}. Each layer is conditional on the
+objects named; none implies that the next layer attains it.}

--- a/trees/ftip-00JM.tree
+++ b/trees/ftip-00JM.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Architecture effects are comparative estimands}
+\tag{ftip}
+\p{A difference between two architectures is meaningful only after the task,
+data, post-training, inference, evaluation, and cost records identify which
+coordinates are held fixed and which are allowed to vary.}

--- a/trees/ftip-00JN.tree
+++ b/trees/ftip-00JN.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Ceilings, frontiers, and saturation}
+\tag{ftip}
+\tag{cost}
+\transclude{ftip-00JO}
+\transclude{ftip-00JP}
+\transclude{ftip-00JQ}
+\transclude{ftip-00JR}
+\transclude{ftip-00JS}
+\transclude{ftip-00JT}

--- a/trees/ftip-00JO.tree
+++ b/trees/ftip-00JO.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Fixed-recipe and tuned frontiers}
+\tag{ftip}
+\p{The fixed-recipe frontier evaluates one common #{\eta}. The equal-tuning
+frontier permits architecture-specific choices from a predeclared trial set
+with the same tuning data and budget. The restricted envelope permits a
+predeclared class of interventions under #{C}. These are distinct estimands.}

--- a/trees/ftip-00JP.tree
+++ b/trees/ftip-00JP.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Iso-quality cost ratio}
+\tag{ftip}
+\p{For a declared quality #{q}, define #{C_A(q)=\inf\{C:V_A(C)\ge q\}} when
+the set is nonempty. The iso-quality ratio is #{\rho_{A/B}(q)=C_A(q)/C_B(q)}
+when both costs are finite. It compares efficiency, not a universal ceiling.}

--- a/trees/ftip-00JQ.tree
+++ b/trees/ftip-00JQ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Operational cost vector and scalarization}
+\tag{ftip}
+\p{Record training FLOPs, inference FLOPs, wall time, memory, energy, and
+hardware separately as #{\mathbf c}. A scalar cost #{C=w\cdot\mathbf c} is a
+declared study choice with nonnegative units #{w}; changing #{w} changes the
+frontier and must not be hidden as architecture quality.}

--- a/trees/ftip-00JR.tree
+++ b/trees/ftip-00JR.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Finite-window representational obstruction}
+\tag{ftip}
+\tag{finite-counterexample}
+\p{Consider a causal system whose state after each prefix has at most #{K}
+distinct values, and a task with #{K+1} prefixes requiring pairwise distinct
+continuation labels. By the pigeonhole principle two prefixes share a state,
+so at least one continuation label is wrong. This is an FTIP-proved toy
+obstruction only; it does not bound a production Transformer or KDA without a
+proved reduction to this state model.}

--- a/trees/ftip-00JS.tree
+++ b/trees/ftip-00JS.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{A conditional saturation certificate}
+\tag{ftip}
+\tag{saturation}
+\p{Let #{V_A} be nondecreasing and bounded above by #{U}. If a declared
+target #{q<U} is reached at cost #{C_q}, then every cost above #{C_q} is within
+#{U-q} of the target upper bound. This elementary certificate is conditional
+on the bound #{U}; it does not assert that real intelligence saturates.}

--- a/trees/ftip-00JT.tree
+++ b/trees/ftip-00JT.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Equal scalar cost does not identify architecture}
+\tag{ftip}
+\tag{finite-counterexample}
+\p{Two systems can have the same scalar #{C} while differing in memory,
+latency, and training allocation. A cost-weight change can reverse their
+ordering without changing either system. Thus a one-factor comparison needs a
+fixed scalarization and a reported cost vector; no architecture effect follows
+from equal #{C} alone.}

--- a/trees/ftip-00JU.tree
+++ b/trees/ftip-00JU.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Matched-compute comparison protocol}
+\tag{ftip}
+\tag{protocol}
+\transclude{ftip-00JV}
+\transclude{ftip-00JW}
+\transclude{ftip-00JX}
+\transclude{ftip-00JY}
+\transclude{ftip-00JZ}
+\transclude{ftip-00K0}
+\transclude{ftip-00K1}

--- a/trees/ftip-00JV.tree
+++ b/trees/ftip-00JV.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Common-recipe comparison arm}
+\tag{ftip}
+\p{A common-recipe arm fixes training data, optimizer family, schedule,
+post-training feedback, inference budget, and evaluation draws, then swaps
+only the architecture record. Deviations are recorded rather than silently
+called architecture effects.}

--- a/trees/ftip-00JW.tree
+++ b/trees/ftip-00JW.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Equal-tuning-budget comparison arm}
+\tag{ftip}
+\p{Each architecture receives the same tuning-data volume, trial count,
+selection rule, and tuning cost. The resulting frontier measures practical
+efficiency under equal optimization effort, not best possible training.}

--- a/trees/ftip-00JX.tree
+++ b/trees/ftip-00JX.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Restricted-envelope comparison arm}
+\tag{ftip}
+\p{Declare an allowed intervention class #{\mathcal E_A} for each architecture
+and compare the suprema over #{\mathcal E_A} under the same cost cap. The
+classes must expose exclusions, search budgets, seeds, and stopping rules.}

--- a/trees/ftip-00JY.tree
+++ b/trees/ftip-00JY.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Production comparison evidence record}
+\tag{ftip}
+\p{A production record contains architecture/checkpoint identity, parameter
+count, data and post-training recipe, optimizer, precision, hardware, cache
+policy, training and inference cost vectors, task suite, and independent
+evaluation seed. A missing field makes an architecture attribution unknown.}

--- a/trees/ftip-00JZ.tree
+++ b/trees/ftip-00JZ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Systems optimizations are measured interventions}
+\tag{ftip}
+\p{FlashAttention, KV-cache layouts, quantization, batching, and kernels can
+change feasible cost. If they approximate, truncate, or alter precision of the
+mathematical computation, the record must mark that as a systems intervention
+rather than as a pure architecture comparison.}

--- a/trees/ftip-00K0.tree
+++ b/trees/ftip-00K0.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Matched-protocol difference is an estimand}
+\tag{ftip}
+\p{Given #{n\geq1} evaluation draws, let #{\widehat V_A(C)} be the sample
+mean of the declared score #{J} for architecture #{A} at cost cap #{C}. Under
+a fixed evaluation law and common-recipe arm, the finite difference
+#{\widehat V_A(C)-\widehat V_B(C)} is a well-defined empirical estimand.}
+
+\p{It does not identify a causal architecture effect when data, tuning, or
+systems coordinates differ. The conclusion follows directly from the
+declared record.}

--- a/trees/ftip-00K1.tree
+++ b/trees/ftip-00K1.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Mandatory production-instantiation gate}
+\tag{ftip}
+\p{A toy theorem may enter a production comparison only with an explicit map
+from its state, interface, and cost assumptions to measured model records. If
+that map is absent, retain the toy result as a finite obstruction and report
+the production conclusion as unknown.}

--- a/trees/ftip-00K2.tree
+++ b/trees/ftip-00K2.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Kimi Delta Attention versus Transformer}
+\tag{ftip}
+\tag{production-example}
+\transclude{ftip-00K3}
+\transclude{ftip-00K4}
+\transclude{ftip-00K5}
+\transclude{ftip-00K6}
+\transclude{ftip-00K7}
+\transclude{ftip-00K8}

--- a/trees/ftip-00K3.tree
+++ b/trees/ftip-00K3.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{KDA production instantiation record}
+\tag{ftip}
+\p{For a Kimi Delta Attention (KDA) versus full-attention baseline study,
+record the exact Kimi Linear checkpoint, layer mix, context length, hardware,
+kernel, precision, batch, and decoding workload. The paper describes KDA as a
+fine-grained gated delta-rule module in a hybrid architecture; those are
+source observations from \citef{kimi2025linear}, not universal theorems.}
+
+\p{If the baseline is called a Transformer, record whether it is the paper's
+MLA baseline or another full-attention implementation; the label alone does
+not identify a common architecture or cost.}

--- a/trees/ftip-00K4.tree
+++ b/trees/ftip-00K4.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{KDA and Transformer matched-cost worksheet}
+\tag{ftip}
+\tag{production-example}
+\p{A valid worksheet pairs the same task prompts, post-training data and
+feedback, optimizer family, evaluation protocol, and quality target. It then
+reports parameter count, training FLOPs, inference FLOPs, wall time, memory,
+KV-cache bytes, and context length for each architecture. A reported speed or
+quality difference is conditional on this worksheet.}

--- a/trees/ftip-00K5.tree
+++ b/trees/ftip-00K5.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{What the Kimi Linear paper establishes}
+\tag{ftip}
+\p{Kimi Linear reports a hybrid KDA/MLA model and fair-comparison experiments
+in Sections 3--5, with setup in Section 5.4 and efficiency comparisons in
+Sections 5.5--5.6 of \citef{kimi2025linear}. These include long-context
+efficiency.}
+
+\p{The reported throughput and quality are empirical under its training recipe
+and hardware; they are lower bounds on demonstrated performance, not an
+architecture-independent ceiling.}

--- a/trees/ftip-00K6.tree
+++ b/trees/ftip-00K6.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Parameter matching is not cost matching}
+\tag{ftip}
+\p{Two models with equal parameter count can have different attention FLOPs,
+KV-cache memory, kernel utilization, and attainable context. Conversely,
+equal wall time can hide different hardware and precision. Therefore a
+parameter-matched result cannot by itself identify a compute frontier.}

--- a/trees/ftip-00K7.tree
+++ b/trees/ftip-00K7.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{KDA transfer limits}
+\tag{ftip}
+\p{The KDA example does not prove that every linear-attention model beats every
+Transformer, that cache savings imply equal quality, or that a measured
+throughput gain is a capability gain. Any such statement requires a new matched
+study with the evidence record of \ref{ftip-00JY}.}

--- a/trees/ftip-00K8.tree
+++ b/trees/ftip-00K8.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Production comparison decision rule}
+\tag{ftip}
+\p{Call architecture A more cost-efficient than B at quality #{q} only when
+both #{C_A(q)} and #{C_B(q)} are observed under the same declared protocol,
+the confidence procedure and stopping rule are fixed, and all cost-vector
+coordinates needed by the claim are present. Otherwise the comparison is
+descriptive or unknown.}

--- a/trees/ftip-00K9.tree
+++ b/trees/ftip-00K9.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Interface boundaries for alternative architectures}
+\tag{ftip}
+\tag{comparability}
+\transclude{ftip-00KA}
+\transclude{ftip-00KB}
+\transclude{ftip-00KC}
+\transclude{ftip-00KD}
+\transclude{ftip-00KE}
+\transclude{ftip-00KF}

--- a/trees/ftip-00KA.tree
+++ b/trees/ftip-00KA.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{JEPA comparability interface}
+\tag{ftip}
+\p{A JEPA-like architecture is comparable to an autoregressive model only
+after fixing the predictor, target representation, decoder or downstream
+interface, training objective, inference procedure, and evaluation law. A
+parameter-count match alone is not a typed comparison.}

--- a/trees/ftip-00KB.tree
+++ b/trees/ftip-00KB.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Representation and task interface are separate}
+\tag{ftip}
+\p{A latent predictor can be excellent under one decoder and unusable under
+another. The evaluation record must therefore include the interface that maps
+the representation to the declared task output.}

--- a/trees/ftip-00KC.tree
+++ b/trees/ftip-00KC.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Interface-preserving black-box reduction}
+\tag{ftip}
+\p{If two architecture records induce the same conditional output law on a
+fixed task and evaluation interface, every black-box evaluation functional
+#{J} gives the same value. This is an immediate pushforward identity and is a
+local bridge, not a claim that distinct architectures are generally
+equivalent.}

--- a/trees/ftip-00KD.tree
+++ b/trees/ftip-00KD.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Equal benchmark score can hide different ceilings}
+\tag{ftip}
+\p{Two architectures may tie on a finite benchmark while differing on an
+unmeasured task slice or longer context. Thus a single score cannot establish
+equal representational ceilings; the task family and evaluation coverage must
+be declared.}

--- a/trees/ftip-00KE.tree
+++ b/trees/ftip-00KE.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Architecture claims and black-box formalization}
+\tag{ftip}
+\p{The generic theorem ledger may quantify over an opaque model and ignore
+this chapter. Architecture-aware lemmas are optional refinements whose fields
+can be erased by the black-box projection in \ref{ftip-00JK}.}

--- a/trees/ftip-00KF.tree
+++ b/trees/ftip-00KF.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Open production questions}
+\tag{ftip}
+\p{The next empirical study should compare KDA, full attention, and any JEPA
+candidate with public checkpoints or reproducible training, fixed evaluation
+seeds, and the full cost worksheet. Until then, architecture-specific ceilings
+remain estimands and hypotheses rather than established constants.}

--- a/trees/refs/kimi2025linear.tree
+++ b/trees/refs/kimi2025linear.tree
@@ -1,0 +1,15 @@
+% ["forest"]
+\title{Kimi Linear: An Expressive, Efficient Attention Architecture}
+\date{2025}
+\author/literal{Kimi Team}
+\taxon{Reference}
+
+\meta{external}{https://arxiv.org/abs/2510.26692v2}
+\meta{bibtex}{\startverb
+@article{kimi2025linear,
+ title = {Kimi Linear: An Expressive, Efficient Attention Architecture},
+ author = {{Kimi Team}},
+ year = {2025},
+ journal = {arXiv preprint arXiv:2510.26692v2}
+}
+\stopverb}


### PR DESCRIPTION
Optional architecture-aware refinement on the black-box FTIP foundation. Adds typed architecture/optimizer/systems records, conditional ceiling/frontier estimands, matched-cost protocols, Kimi Delta Attention vs Transformer production worksheet, and JEPA comparability boundaries. Toy results are explicitly local and non-transferable.

Base: cf7f1ce7fa6ac0dec8ab972855c14d2e23f216ae
New trees: 37 (00JF–00KF); total 715 FTIP trees; one pinned Kimi Linear reference.

Validation: just chk, just forest, graph/reachability/no-forward-ref checks passed. Full build/render and adversarial review follow.