### PR TITLE
Simplify storyline structure and architecture terminology

### DIFF
--- a/trees/ftip-00I2.tree
+++ b/trees/ftip-00I2.tree
@@ -5,7 +5,6 @@
 \tag{ledger}
 
 \p{The ledger starts by making every carrier, law, index set, and finiteness hypothesis explicit. A statement is not ledger-ready when a reader must infer a domain from a source paper.}
-\transclude{ftip-00I3}
 \transclude{ftip-00I4}
 \transclude{ftip-00I5}
 \transclude{ftip-00I6}

--- a/trees/ftip-00I3.tree
+++ b/trees/ftip-00I3.tree
@@ -1,8 +1,0 @@
-\import{macros}
-\meta{agent-authored}{true}
-\taxon{Convention}
-\title{Status labels for ledger entries}
-\tag{ftip}
-\tag{ledger}
-
-\p{A ledger card is marked \strong{FTIP-PROVED} for a proof in this note, \strong{SOURCE RECONSTRUCTION} for a faithful restatement of a paper result, \strong{FINITE COUNTEREXAMPLE} for a constructed obstruction, or \strong{OPEN} when no proof is claimed.}

--- a/trees/ftip-00J9.tree
+++ b/trees/ftip-00J9.tree
@@ -5,7 +5,7 @@
 \tag{ftip}
 \tag{chapter}
 
-\p{This chapter groups the black-box model, task, environment, and
+\p{This chapter groups the model, task, environment, and
 evaluation interfaces that the later chapters reuse. The section roots below
 retain their existing definitions and internal transclusion structure.}
 

--- a/trees/ftip-00JC.tree
+++ b/trees/ftip-00JC.tree
@@ -1,14 +1,16 @@
 \import{macros}
 \meta{agent-authored}{true}
 
-\title{Optimization, computation, and architecture}
+\title{Architecture-conditioned potential and computation}
 \tag{ftip}
 \tag{chapter}
 
-\p{This optional refinement chapter groups optimization geometry,
-computation, retained context, and architecture-indexed questions. Readers
-using only the black-box formulation may omit this chapter.}
+\p{This optional refinement chapter groups architecture-indexed potential,
+optimization geometry, computation, and retained context. Readers whose
+question does not name an architecture may omit this chapter. The reference
+autoregressive Transformer formulation in \ref{ftip-000K} is the comparison
+baseline; the sections below add only the fields needed by a stated claim.}
 
+\transclude{ftip-00JF}
 \transclude{ftip-00AU}
 \transclude{ftip-00DA}
-\transclude{ftip-00JF}

--- a/trees/ftip-00JF.tree
+++ b/trees/ftip-00JF.tree
@@ -6,14 +6,15 @@
 \tag{architecture}
 \tag{optional-refinement}
 
-\p{This optional section refines the black-box capability framework only when
-the question names an architecture, optimizer, or systems implementation.
-The generic model remains a black box when these fields are unnecessary.}
+\p{This optional section refines the architecture-neutral capability framework
+only when the question names an architecture, optimizer, or systems
+implementation. The general model/interface formulation remains available
+when these fields are unnecessary.}
 
 \p{Architecture comparisons below are conditional on a declared task family,
 evaluation law, intervention class, and scalar cost. Toy bounds are finite
-FTIP mathematics and do not transfer to production models without the stated
-interface and measurement gates.}
+results under their displayed assumptions and do not transfer to production
+models without the stated interface and measurement gates.}
 
 \transclude{ftip-00JG}
 \transclude{ftip-00JN}

--- a/trees/ftip-00JG.tree
+++ b/trees/ftip-00JG.tree
@@ -1,10 +1,11 @@
 \import{macros}
 \meta{agent-authored}{true}
-\title{Black-box bridge and typed architecture records}
+\title{Architecture bridge and typed records}
 \tag{ftip}
 \tag{architecture}
-\p{These cards add architecture fields without changing the existing black-box
-object. Each field is optional until a conclusion refers to it.}
+\p{These cards add architecture fields without changing the existing
+model/interface object. Each field is optional until a conclusion refers to
+it.}
 \transclude{ftip-00JH}
 \transclude{ftip-00JI}
 \transclude{ftip-00JJ}

--- a/trees/ftip-00JH.tree
+++ b/trees/ftip-00JH.tree
@@ -3,7 +3,7 @@
 \taxon{Definition}
 \title{Optional architecture refinement}
 \tag{ftip}
-\p{Let #{M} denote an existing black-box model intervention. An architecture
+\p{Let #{M} denote an existing model intervention. An architecture
 refinement is a record #{A=(\mathcal X,\mathcal Y,\operatorname{Map}_A)} whose
 map realizes the same declared input and output interface. Forgetting #{A}
 returns #{M}; no architecture claim is made when the field is omitted.}

--- a/trees/ftip-00JK.tree
+++ b/trees/ftip-00JK.tree
@@ -1,9 +1,9 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Remark}
-\title{Black-box projection and gradual complexity}
+\title{Architecture-neutral projection and gradual complexity}
 \tag{ftip}
-\p{A theorem that does not mention #{A}, #{O}, or #{S} remains a black-box
-statement. Add a field only when a conclusion changes under that field. This
-projection prevents architecture-aware notation from contaminating generic
-formalization.}
+\p{A theorem that does not mention #{A}, #{O}, or #{S} remains an
+architecture-neutral statement. Add a field only when a conclusion changes
+under that field. This projection prevents architecture-aware notation from
+contaminating generic formalization.}

--- a/trees/ftip-00KC.tree
+++ b/trees/ftip-00KC.tree
@@ -1,10 +1,9 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Theorem}
-\title{Interface-preserving black-box reduction}
+\title{Interface-preserving architecture reduction}
 \tag{ftip}
 \p{If two architecture records induce the same conditional output law on a
-fixed task and evaluation interface, every black-box evaluation functional
-#{J} gives the same value. This is an immediate pushforward identity and is a
-local bridge, not a claim that distinct architectures are generally
-equivalent.}
+fixed task and evaluation interface, every evaluation functional #{J} gives
+the same value. This is an immediate pushforward identity and is a local
+bridge, not a claim that distinct architectures are generally equivalent.}

--- a/trees/ftip-00KE.tree
+++ b/trees/ftip-00KE.tree
@@ -1,8 +1,9 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Remark}
-\title{Architecture claims and black-box formalization}
+\title{Architecture claims and neutral formalization}
 \tag{ftip}
-\p{The generic theorem ledger may quantify over an opaque model and ignore
-this chapter. Architecture-aware lemmas are optional refinements whose fields
-can be erased by the black-box projection in \ref{ftip-00JK}.}
+\p{The generic theorem ledger may quantify over a model/interface map and
+ignore this chapter. Architecture-aware lemmas are optional refinements whose
+extra fields can be erased by the architecture-neutral projection in
+\ref{ftip-00JK}.}


### PR DESCRIPTION
## Scope

- preserve the existing six chapter wrappers;
- make the architecture-conditioned chapter the first element of its refinement wrapper;
- establish the reference autoregressive Transformer (decoder-only) as the comparison baseline;
- remove informal black-box terminology from the architecture bridge;
- delete `ftip-00I3` and its sole transclusion, without renumbering other nodes.

## Gates

- `just chk` PASS
- `CI=1 just build` PASS
- `just verify-render` PASS (2202 XML/HTML pairs)
- reachable graph: 714 files, 714 reachable exactly once; no cycles or missing refs
- `00I3` absent and untranscluded
- commit: `b6342e7412b73507f5fe37d6502350593788d309`

This is the first layer of the bounded stack. No mined theorem content is added here.
