### PR TITLE
Architecture-conditioned potential and matched compute

### DIFF
--- a/trees/ftip-00JF.tree
+++ b/trees/ftip-00JF.tree
@@ -17,6 +17,7 @@ results under their displayed assumptions and do not transfer to production
 models without the stated interface and measurement gates.}
 
 \transclude{ftip-00JG}
+\transclude{ftip-00KG}
 \transclude{ftip-00JN}
 \transclude{ftip-00JU}
 \transclude{ftip-00K2}

--- a/trees/ftip-00KG.tree
+++ b/trees/ftip-00KG.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Depth reuse and latent recurrence}
+\tag{ftip}
+\tag{architecture}
+\p{This bounded subsection treats repeated depth, latent feedback, and
+recirculation as explicit computation interventions. It keeps the reference
+autoregressive Transformer fixed and records any extra passes, state, or
+prefill work in the cost vector.}
+\transclude{ftip-00KH}
+\transclude{ftip-00KI}
+\transclude{ftip-00KJ}
+\transclude{ftip-00KK}
+\transclude{ftip-00KL}
+\transclude{ftip-00KM}
+\transclude{ftip-00KN}
+\transclude{ftip-00KO}
+\transclude{ftip-00KP}
+\transclude{ftip-00KQ}
+\transclude{ftip-00KR}
+\transclude{ftip-00KS}
+\transclude{ftip-00KT}

--- a/trees/ftip-00KH.tree
+++ b/trees/ftip-00KH.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Computation-axis record}
+\tag{ftip}
+\p{For an architecture record #{A}, distinguish token steps, feed-forward
+depth passes, recurrent passes, and latent-state updates. Let #{d(A,r)} be
+the declared number of depth passes in run #{r}; it is a computation coordinate,
+not a synonym for parameter count or reasoning quality.}

--- a/trees/ftip-00KI.tree
+++ b/trees/ftip-00KI.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Looped Transformers as a source result}
+\tag{ftip}
+\p{Giannou et al. show that a fixed shallow Transformer placed in a loop can
+execute programmed iterative computations, including conditional branches and
+in-context algorithms, in \citef{giannou2023looped}. This is a source result
+under its program, state, and precision assumptions; it is not a universal
+claim about language-model capability.}

--- a/trees/ftip-00KJ.tree
+++ b/trees/ftip-00KJ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Parameter sharing and width tradeoffs}
+\tag{ftip}
+\p{Xue et al. report that depth sharing can reduce trainable parameters while
+limiting modeling capacity, and study width and mixture-of-experts remedies in
+\citef{xue2021wider}. The comparison is empirical and task-specific; it does
+not identify a depth-independent ceiling.}

--- a/trees/ftip-00KK.tree
+++ b/trees/ftip-00KK.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Virtual logical depth and scaling}
+\tag{ftip}
+\p{Zhu et al. vary virtual logical depth by reusing weights and report
+reasoning gains at nearly fixed parameter count in \citef{zhu2025virtualdepth}.
+Their results motivate a depth coordinate in a scaling study, while leaving
+knowledge capacity, optimization, and transfer dependent on the declared
+training and evaluation protocol.}

--- a/trees/ftip-00KL.tree
+++ b/trees/ftip-00KL.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Recirculation as an inference intervention}
+\tag{ftip}
+\p{Mozer et al. introduce inference-time recirculation that feeds latent
+states back through an off-the-shelf model and report task improvements in
+\citef{mozer2026recirculation}. The added serial prefill and adaptive tuning
+belong in the systems and inference records; the observation is not a proof of
+a new representational ceiling.}

--- a/trees/ftip-00KM.tree
+++ b/trees/ftip-00KM.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Latent feedback with a preserved Transformer interface}
+\tag{ftip}
+\p{Wang et al. widen the feedback channel between decoding steps with latent
+feedback while retaining a Transformer and language-modeling interface in
+\citef{wang2026fullbandwidth}. Any reported token or accuracy savings are
+conditional on the scheduled multi-pass training and measured decoding cost.}

--- a/trees/ftip-00KN.tree
+++ b/trees/ftip-00KN.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Latent prediction as a training intervention}
+\tag{ftip}
+\p{Teoh et al. add next-latent prediction to next-token training and report
+compact predictive states without changing the Transformer interface in
+\citef{teoh2025nextlatent}. This belongs to the training intervention record,
+not to an architecture-only comparison.}

--- a/trees/ftip-00KO.tree
+++ b/trees/ftip-00KO.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Equal parameters do not fix effective depth}
+\tag{ftip}
+\p{Two runs can share parameter count while using different numbers of
+recurrent or latent-feedback passes. A matched study must therefore report
+the computation-axis record and cannot infer an architecture ceiling from
+parameters alone.}

--- a/trees/ftip-00KP.tree
+++ b/trees/ftip-00KP.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Depth-reuse production record}
+\tag{ftip}
+\p{For a depth-reuse comparison, record shared weights, pass count, stopping
+rule, recurrent state, training objective, token and pass FLOPs, prefill and
+decode latency, memory, and evaluation seeds. A pass-count change is an
+intervention even when the parameter tensor is unchanged.}

--- a/trees/ftip-00KQ.tree
+++ b/trees/ftip-00KQ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Fixed-recipe depth comparison}
+\tag{ftip}
+\p{In a fixed-recipe arm, hold data, optimizer, feedback, stopping rule, and
+evaluation law fixed while varying only the declared depth-reuse intervention.
+The resulting difference is an estimand for that recipe, not a best-achievable
+comparison.}

--- a/trees/ftip-00KR.tree
+++ b/trees/ftip-00KR.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Scaling surfaces rather than a single law}
+\tag{ftip}
+\p{A depth-reuse study may fit a surface over parameters, tokens, passes, and
+cost. The fit is an empirical summary over its measured range; it does not
+establish an asymptotic law or a universal saturation point.}

--- a/trees/ftip-00KS.tree
+++ b/trees/ftip-00KS.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Architecture and training are separable records}
+\tag{ftip}
+\p{Weight sharing, latent objectives, and recirculation can alter optimization
+without changing the declared external interface. The comparison must retain
+architecture, training intervention, and systems coordinates separately.}

--- a/trees/ftip-00KT.tree
+++ b/trees/ftip-00KT.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Depth-reuse transfer limits}
+\tag{ftip}
+\p{The cited looped, virtual-depth, latent-feedback, and recirculation results
+do not show that more passes always improve capability, that parameter sharing
+dominates added parameters, or that inference-time gains transfer to training
+or to another task family. Each transfer requires a matched production record.}

--- a/trees/refs/giannou2023looped.tree
+++ b/trees/refs/giannou2023looped.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\title{Looped Transformers as Programmable Computers}
+\date{2023}
+\author/literal{Angeliki Giannou}
+\author/literal{Shashank Rajput}
+\author/literal{Jy-yong Sohn}
+\author/literal{Kangwook Lee}
+\author/literal{Jason D. Lee}
+\author/literal{Dimitris Papailiopoulos}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2301.13196}
+\meta{bibtex}{\startverb
+@article{giannou2023looped,
+  title = {Looped Transformers as Programmable Computers},
+  author = {Giannou, Angeliki and Rajput, Shashank and Sohn, Jy-yong and Lee, Kangwook and Lee, Jason D. and Papailiopoulos, Dimitris},
+  year = {2023},
+  url = {https://arxiv.org/abs/2301.13196},
+  journal = {arXiv preprint arXiv:2301.13196}
+}
+\stopverb}
+% ["forest"]

--- a/trees/refs/mozer2026recirculation.tree
+++ b/trees/refs/mozer2026recirculation.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\title{Recirculation}
+\date{2026}
+\author/literal{Michael C. Mozer}
+\author/literal{Shoaib Ahmed Siddiqui}
+\author/literal{Danny Sawyer}
+\author/literal{Sunny Sanyal}
+\author/literal{Rosanne Liu}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2608.17981v2}
+\meta{bibtex}{\startverb
+@article{mozer2026recirculation,
+  title = {Recirculation},
+  author = {Mozer, Michael C. and Siddiqui, Shoaib Ahmed and Sawyer, Danny and Sanyal, Sunny and Liu, Rosanne},
+  year = {2026},
+  url = {https://arxiv.org/abs/2608.17981v2},
+  journal = {arXiv preprint arXiv:2608.17981v2}
+}
+\stopverb}
+% ["forest"]

--- a/trees/refs/teoh2025nextlatent.tree
+++ b/trees/refs/teoh2025nextlatent.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\title{Next-Latent Prediction Transformers Learn Compact World Models}
+\date{2025}
+\author/literal{Jayden Teoh}
+\author/literal{Manan Tomar}
+\author/literal{Kwangjun Ahn}
+\author/literal{Edward S. Hu}
+\author/literal{Tim Pearce}
+\author/literal{Pratyusha Sharma}
+\author/literal{Akshay Krishnamurthy}
+\author/literal{Riashat Islam}
+\author/literal{Alex Lamb}
+\author/literal{John Langford}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2511.05963v4}
+\meta{bibtex}{\startverb
+@article{teoh2025nextlatent,
+  title = {Next-Latent Prediction Transformers Learn Compact World Models},
+  author = {Teoh, Jayden and Tomar, Manan and Ahn, Kwangjun and Hu, Edward S. and Pearce, Tim and Sharma, Pratyusha and Krishnamurthy, Akshay and Islam, Riashat and Lamb, Alex and Langford, John},
+  year = {2025},
+  url = {https://arxiv.org/abs/2511.05963v4},
+  journal = {arXiv preprint arXiv:2511.05963v4}
+}
+\stopverb}
+% ["forest"]

--- a/trees/refs/wang2026fullbandwidth.tree
+++ b/trees/refs/wang2026fullbandwidth.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\title{Full-bandwidth transformer}
+\date{2026}
+\author/literal{Xi Wang}
+\author/literal{Ziyang Cai}
+\author/literal{Zheng Zhan}
+\author/literal{Harry Dong}
+\author/literal{Ying Fan}
+\author/literal{Gustavo de Rosa}
+\author/literal{Tim Pearce}
+\author/literal{John Langford}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2608.08888}
+\meta{bibtex}{\startverb
+@article{wang2026fullbandwidth,
+  title = {Full-bandwidth transformer},
+  author = {Wang, Xi and Cai, Ziyang and Zhan, Zheng and Dong, Harry and Fan, Ying and de Rosa, Gustavo and Pearce, Tim and Langford, John},
+  year = {2026},
+  url = {https://arxiv.org/abs/2608.08888},
+  journal = {arXiv preprint arXiv:2608.08888}
+}
+\stopverb}
+% ["forest"]

--- a/trees/refs/xue2021wider.tree
+++ b/trees/refs/xue2021wider.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\title{Go Wider Instead of Deeper}
+\date{2021}
+\author/literal{Fuzhao Xue}
+\author/literal{Ziji Shi}
+\author/literal{Futao Wei}
+\author/literal{Yuxuan Lou}
+\author/literal{Yong Liu}
+\author/literal{Yang You}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2107.11817}
+\meta{bibtex}{\startverb
+@article{xue2021wider,
+  title = {Go Wider Instead of Deeper},
+  author = {Xue, Fuzhao and Shi, Ziji and Wei, Futao and Lou, Yuxuan and Liu, Yong and You, Yang},
+  year = {2021},
+  url = {https://arxiv.org/abs/2107.11817},
+  journal = {arXiv preprint arXiv:2107.11817}
+}
+\stopverb}
+% ["forest"]

--- a/trees/refs/zhu2025virtualdepth.tree
+++ b/trees/refs/zhu2025virtualdepth.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\title{Beyond Parameters: Exploring Virtual Logic Depth for Scaling Laws}
+\date{2025}
+\author/literal{Ruike Zhu}
+\author/literal{Hanwen Zhang}
+\author/literal{Kevin Li}
+\author/literal{Tianyu Shi}
+\author/literal{Yiqun Duan}
+\author/literal{Chi Wang}
+\author/literal{Tianyi Zhou}
+\author/literal{Arindam Banerjee}
+\author/literal{Zengyi Qin}
+\taxon{Reference}
+\meta{external}{https://arxiv.org/abs/2506.18233}
+\meta{bibtex}{\startverb
+@article{zhu2025virtualdepth,
+  title = {Beyond Parameters: Exploring Virtual Logic Depth for Scaling Laws},
+  author = {Zhu, Ruike and Zhang, Hanwen and Li, Kevin and Shi, Tianyu and Duan, Yiqun and Wang, Chi and Zhou, Tianyi and Banerjee, Arindam and Qin, Zengyi},
+  year = {2025},
+  url = {https://arxiv.org/abs/2506.18233},
+  journal = {arXiv preprint arXiv:2506.18233}
+}
+\stopverb}
+% ["forest"]


### PR DESCRIPTION
## Scope

- add a bounded depth-reuse and latent-recurrence subsection inside the existing architecture-conditioned chapter;
- distinguish token steps, depth passes, recurrent passes, and latent-state updates from parameter count;
- reconstruct source observations for looped Transformers, parameter sharing, virtual logical depth, recirculation, latent feedback, and next-latent prediction;
- add a production record for pass count, state, stopping rule, FLOPs, latency, memory, and evaluation seeds;
- retain the Kimi Delta Attention versus reference Transformer worksheet and require matched protocol fields;
- state explicit limits on transferring toy or source results to production systems.

## Sources

- [Looped Transformers as Programmable Computers](https://arxiv.org/abs/2301.13196)
- [Go Wider Instead of Deeper](https://arxiv.org/abs/2107.11817)
- [Beyond Parameters: Exploring Virtual Logic Depth for Scaling Laws](https://arxiv.org/abs/2506.18233)
- [Recirculation](https://arxiv.org/abs/2608.17981v2)
- [Full-bandwidth transformer](https://arxiv.org/abs/2608.08888)
- [Next-Latent Prediction Transformers Learn Compact World Models](https://arxiv.org/abs/2511.05963v4)

## Gates

- `just chk` PASS
- `CI=1 just build` PASS
- `just verify-render` PASS (2222 XML/HTML pairs)
- reachable graph: 728 files, 728 reachable exactly once; no cycles or missing refs
- targeted rendered PDF: 225 A4 pages, SHA-256 `c2e8779d8e4e95e4956e610c9d6e31c027ae6e6e9fb5afd3e8fb971c44cb6607`
- commit: `641a9015c4ff90d639f260fe6b01839613f93b27`

All comparisons remain conditional estimands; no universal scaling or saturation law is claimed.
