### PR TITLE
Add measured KDA and Transformer comparison

### DIFF
--- a/trees/ftip-00JF.tree
+++ b/trees/ftip-00JF.tree
@@ -13,8 +13,8 @@ when these fields are unnecessary.}
 
 \p{Architecture comparisons below are conditional on a declared task family,
 evaluation law, intervention class, and scalar cost. Toy bounds are finite
-results under their displayed assumptions and do not transfer to production
-models without the stated interface and measurement gates.}
+results under their displayed assumptions and do not transfer to concrete
+model instances without the stated interface and measurement gates.}
 
 \transclude{ftip-00JG}
 \transclude{ftip-00KG}

--- a/trees/ftip-00JF.tree
+++ b/trees/ftip-00JF.tree
@@ -22,3 +22,4 @@ models without the stated interface and measurement gates.}
 \transclude{ftip-00JU}
 \transclude{ftip-00K2}
 \transclude{ftip-00K9}
+\transclude{ftip-00KU}

--- a/trees/ftip-00JR.tree
+++ b/trees/ftip-00JR.tree
@@ -8,5 +8,5 @@
 distinct values, and a task with #{K+1} prefixes requiring pairwise distinct
 continuation labels. By the pigeonhole principle two prefixes share a state,
 so at least one continuation label is wrong. This is an FTIP-proved toy
-obstruction only; it does not bound a production Transformer or KDA without a
+obstruction only; it does not bound a concrete Transformer or KDA instance without a
 proved reduction to this state model.}

--- a/trees/ftip-00JY.tree
+++ b/trees/ftip-00JY.tree
@@ -1,9 +1,9 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Definition}
-\title{Production comparison evidence record}
+\title{Model-instance comparison evidence record}
 \tag{ftip}
-\p{A production record contains architecture/checkpoint identity, parameter
+\p{A model-instance record contains architecture/checkpoint identity, parameter
 count, data and post-training recipe, optimizer, precision, hardware, cache
 policy, training and inference cost vectors, task suite, and independent
 evaluation seed. A missing field makes an architecture attribution unknown.}

--- a/trees/ftip-00K1.tree
+++ b/trees/ftip-00K1.tree
@@ -1,9 +1,9 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Remark}
-\title{Mandatory production-instantiation gate}
+\title{Mandatory model-instance gate}
 \tag{ftip}
-\p{A toy theorem may enter a production comparison only with an explicit map
+\p{A toy theorem may enter a model-instance comparison only with an explicit map
 from its state, interface, and cost assumptions to measured model records. If
 that map is absent, retain the toy result as a finite obstruction and report
-the production conclusion as unknown.}
+the model-instance conclusion as unknown.}

--- a/trees/ftip-00K2.tree
+++ b/trees/ftip-00K2.tree
@@ -2,7 +2,7 @@
 \meta{agent-authored}{true}
 \title{Kimi Delta Attention versus Transformer}
 \tag{ftip}
-\tag{production-example}
+\tag{measured-example}
 \transclude{ftip-00K3}
 \transclude{ftip-00K4}
 \transclude{ftip-00K5}

--- a/trees/ftip-00K3.tree
+++ b/trees/ftip-00K3.tree
@@ -1,7 +1,7 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Definition}
-\title{KDA production instantiation record}
+\title{KDA model-instance record}
 \tag{ftip}
 \p{For a Kimi Delta Attention (KDA) versus full-attention baseline study,
 record the exact Kimi Linear checkpoint, layer mix, context length, hardware,

--- a/trees/ftip-00K4.tree
+++ b/trees/ftip-00K4.tree
@@ -3,7 +3,7 @@
 \taxon{Example}
 \title{KDA and Transformer matched-cost worksheet}
 \tag{ftip}
-\tag{production-example}
+\tag{measured-example}
 \p{A valid worksheet pairs the same task prompts, post-training data and
 feedback, optimizer family, evaluation protocol, and quality target. It then
 reports parameter count, training FLOPs, inference FLOPs, wall time, memory,

--- a/trees/ftip-00K8.tree
+++ b/trees/ftip-00K8.tree
@@ -1,7 +1,7 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Definition}
-\title{Production comparison decision rule}
+\title{Model-instance comparison decision rule}
 \tag{ftip}
 \p{Call architecture A more cost-efficient than B at quality #{q} only when
 both #{C_A(q)} and #{C_B(q)} are observed under the same declared protocol,

--- a/trees/ftip-00KF.tree
+++ b/trees/ftip-00KF.tree
@@ -1,7 +1,7 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Remark}
-\title{Open production questions}
+\title{Open model-instance questions}
 \tag{ftip}
 \p{The next empirical study should compare KDA, full attention, and any JEPA
 candidate with public checkpoints or reproducible training, fixed evaluation

--- a/trees/ftip-00KP.tree
+++ b/trees/ftip-00KP.tree
@@ -1,7 +1,7 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Definition}
-\title{Depth-reuse production record}
+\title{Depth-reuse model-instance record}
 \tag{ftip}
 \p{For a depth-reuse comparison, record shared weights, pass count, stopping
 rule, recurrent state, training objective, token and pass FLOPs, prefill and

--- a/trees/ftip-00KT.tree
+++ b/trees/ftip-00KT.tree
@@ -6,4 +6,4 @@
 \p{The cited looped, virtual-depth, latent-feedback, and recirculation results
 do not show that more passes always improve capability, that parameter sharing
 dominates added parameters, or that inference-time gains transfer to training
-or to another task family. Each transfer requires a matched production record.}
+or to another task family. Each transfer requires a matched model-instance record.}

--- a/trees/ftip-00KU.tree
+++ b/trees/ftip-00KU.tree
@@ -1,0 +1,17 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Measured KDA and Transformer comparison}
+\tag{ftip}
+\tag{production-example}
+\p{This subsection instantiates the comparison protocol with the Kimi Linear
+report. It records what can be calculated from the published setup and keeps
+unreported quantities as unknown rather than filling them with assumptions.}
+\transclude{ftip-00KV}
+\transclude{ftip-00KW}
+\transclude{ftip-00KX}
+\transclude{ftip-00KY}
+\transclude{ftip-00KZ}
+\transclude{ftip-00L0}
+\transclude{ftip-00L1}
+\transclude{ftip-00L2}
+\transclude{ftip-00L3}

--- a/trees/ftip-00KU.tree
+++ b/trees/ftip-00KU.tree
@@ -2,7 +2,7 @@
 \meta{agent-authored}{true}
 \title{Measured KDA and Transformer comparison}
 \tag{ftip}
-\tag{production-example}
+\tag{measured-example}
 \p{This subsection instantiates the comparison protocol with the Kimi Linear
 report. It records what can be calculated from the published setup and keeps
 unreported quantities as unknown rather than filling them with assumptions.}

--- a/trees/ftip-00KV.tree
+++ b/trees/ftip-00KV.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Published Kimi Linear operating point}
+\tag{ftip}
+\p{The Kimi Linear report describes a hybrid with 3 billion activated and
+48 billion total parameters, trained with 1.4 trillion tokens. Its displayed
+architecture uses three Kimi Delta Attention layers for each Multi-head Latent
+Attention layer. These are properties of the reported model, not definitions
+of every KDA or Transformer implementation \citef{kimi2025linear}.}

--- a/trees/ftip-00KW.tree
+++ b/trees/ftip-00KW.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Published efficiency observations}
+\tag{ftip}
+\p{At one million tokens the report gives a decoding time per output token of
+1.84 milliseconds for Kimi Linear and 11.48 milliseconds for its MLA baseline,
+and reports up to 75 percent lower KV-cache use. It also reports a 3.98-fold
+acceleration at the displayed 128k RULER point. These numbers are measured
+under the paper's hardware, kernels, precision, batch, and workload; they are
+not capability ratios \citef{kimi2025linear}.}

--- a/trees/ftip-00KX.tree
+++ b/trees/ftip-00KX.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Quality target and cost readout}
+\tag{ftip}
+\p{For a reported benchmark score q, use the same task, prompt law, scoring
+rule, and post-training condition for both systems. The comparison records the
+smallest measured cost at which each system reaches q, when such a measurement
+exists. A throughput or cache ratio is not substituted for this iso-quality
+cost.}

--- a/trees/ftip-00KY.tree
+++ b/trees/ftip-00KY.tree
@@ -3,7 +3,7 @@
 \taxon{Definition}
 \title{Kimi Linear measurement record}
 \tag{ftip}
-\p{The production record must identify the exact checkpoint and revision,
+\p{The model-instance record must identify the exact checkpoint and revision,
 KDA/MLA layer pattern, parameter counts, tokenizer, context length, hardware,
 kernel versions, precision, batch, sequence lengths, decoding policy, and
 whether the result is pretraining, supervised tuning, or reinforcement

--- a/trees/ftip-00KY.tree
+++ b/trees/ftip-00KY.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Kimi Linear measurement record}
+\tag{ftip}
+\p{The production record must identify the exact checkpoint and revision,
+KDA/MLA layer pattern, parameter counts, tokenizer, context length, hardware,
+kernel versions, precision, batch, sequence lengths, decoding policy, and
+whether the result is pretraining, supervised tuning, or reinforcement
+learning. Missing fields make the corresponding architecture attribution
+unknown.}

--- a/trees/ftip-00KZ.tree
+++ b/trees/ftip-00KZ.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Common-recipe reading of the Kimi result}
+\tag{ftip}
+\p{The report's identical-training-recipe comparison is evidence for the
+fixed-recipe arm: the architecture is changed while the declared recipe is
+held common. It does not identify the best attainable KDA or Transformer
+frontier, because architecture-specific tuning and systems choices are not
+optimized by that arm alone \citef{kimi2025linear}.}

--- a/trees/ftip-00L0.tree
+++ b/trees/ftip-00L0.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{A computable cost-ratio worksheet}
+\tag{ftip}
+\p{Let #{c_K(q)} and #{c_T(q)} be measured inference costs for Kimi Linear and
+the Transformer reference at the same declared score #{q} and context length.
+Then the worksheet reports #{\rho_{K/T}(q)=c_K(q)/c_T(q)} together with the
+full cost vectors. If either threshold is unmeasured, the ratio is left
+undefined rather than inferred from the paper's speedup plot.}

--- a/trees/ftip-00L1.tree
+++ b/trees/ftip-00L1.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Hybrid attention is not pure linear attention}
+\tag{ftip}
+\p{Kimi Linear combines KDA with periodic full-attention layers. A measured
+advantage therefore identifies the reported hybrid intervention, not a claim
+that a purely linear recurrent architecture has the same quality or ceiling.
+The layer pattern belongs in the architecture record.}

--- a/trees/ftip-00L2.tree
+++ b/trees/ftip-00L2.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Demonstrated performance is a lower bound}
+\tag{ftip}
+\p{The published benchmark scores demonstrate attainable points for the
+reported checkpoints and protocol. They do not establish a representational
+ceiling, a universal scaling law, or a claim that additional cost cannot
+improve either architecture.}

--- a/trees/ftip-00L3.tree
+++ b/trees/ftip-00L3.tree
@@ -1,9 +1,9 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Remark}
-\title{Production gate for the architecture question}
+\title{Model-instance gate for the architecture question}
 \tag{ftip}
 \p{This example supports the motivating comparison only after a paired
-production record supplies a common quality target and declares the training,
+model-instance record supplies a common quality target and declares the training,
 post-training, inference, and systems coordinates. Toy state bounds remain
 finite obstructions until such a record supplies a justified reduction.}

--- a/trees/ftip-00L3.tree
+++ b/trees/ftip-00L3.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Production gate for the architecture question}
+\tag{ftip}
+\p{This example supports the motivating comparison only after a paired
+production record supplies a common quality target and declares the training,
+post-training, inference, and systems coordinates. Toy state bounds remain
+finite obstructions until such a record supplies a justified reduction.}


### PR DESCRIPTION
## Summary

Adds a bounded model-instance subsection inside the existing architecture chapter. The note reads the published Kimi Linear setup as a fixed-recipe comparison and records the quantities needed for a reproducible Kimi Delta Attention versus Transformer study.

The addition records:

- the reported 3B activated / 48B total parameter operating point and 3:1 KDA/MLA layer pattern;
- published latency, cache, and long-context acceleration observations with their hardware and workload limits;
- a quality-target and iso-quality cost readout;
- the model-instance measurement record and missing-field rule;
- the distinction between fixed-recipe evidence and tuned frontiers;
- a computable cost-ratio worksheet without inventing unreported thresholds;
- the hybrid-attention and demonstrated-lower-bound limitations.

No new chapter or global notation is introduced. Toy results remain non-transferable without a measured model-instance record.

## Verification

- `just chk`
- `CI=1 just build`
- `just verify-render`
- model graph: 738 files, 738 reachable exactly once, no cycles or missing references
- targeted `./lize.sh ftip-0001`: 227 A4 pages
- PDF SHA-256: `28dfd132a3c34b9223116b4a2c942e932f642f1ac9f6ae40884de9b4847d94f2`