### PR TITLE
Add measured model comparison ledger

### DIFF
--- a/trees/ftip-00JF.tree
+++ b/trees/ftip-00JF.tree
@@ -23,3 +23,4 @@ model instances without the stated interface and measurement gates.}
 \transclude{ftip-00K2}
 \transclude{ftip-00K9}
 \transclude{ftip-00KU}
+\transclude{ftip-00L4}

--- a/trees/ftip-00L4.tree
+++ b/trees/ftip-00L4.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Comparison ledger for a measured model pair}
+\tag{ftip}
+\tag{measured-example}
+\p{A comparison ledger turns the model-instance record into an auditable
+pair of rows. It does not add a new capability measure: it makes the declared
+task, intervention, evaluation, and cost coordinates explicit before any
+frontier is plotted.}
+\transclude{ftip-00L5}
+\transclude{ftip-00L6}
+\transclude{ftip-00L7}
+\transclude{ftip-00L8}
+\transclude{ftip-00L9}
+\transclude{ftip-00LA}
+\transclude{ftip-00LB}
+\transclude{ftip-00LC}
+\transclude{ftip-00LD}
+\transclude{ftip-00LE}
+\transclude{ftip-00LF}
+\transclude{ftip-00LG}

--- a/trees/ftip-00L5.tree
+++ b/trees/ftip-00L5.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Comparison pair identity}
+\tag{ftip}
+\p{The ledger names the two systems, exact checkpoint or training commit,
+architecture variant, parameter counts, tokenizer, and context limit. A label
+such as ``Transformer'' is insufficient when attention, cache, or layer
+patterns differ.}

--- a/trees/ftip-00L6.tree
+++ b/trees/ftip-00L6.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Common task and evaluation row}
+\tag{ftip}
+\p{Both rows use the same task family, prompt and data law, scoring rule,
+sampling seeds, stopping rule, and evaluator version. Any exception is a
+separate comparison arm, not an unrecorded architecture effect.}

--- a/trees/ftip-00L7.tree
+++ b/trees/ftip-00L7.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Training and post-training coordinates}
+\tag{ftip}
+\p{Record data volume, token order policy, optimizer and schedule, supervised
+tuning, feedback or reinforcement procedure, update count, and selection
+rule. The common-recipe arm fixes these coordinates; the equal-tuning arm
+allows predeclared alternatives with equal search resources.}

--- a/trees/ftip-00L8.tree
+++ b/trees/ftip-00L8.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Inference and systems coordinates}
+\tag{ftip}
+\p{Record hardware, software and kernel versions, precision, batch, cache
+policy, sequence lengths, warm-up procedure, concurrency, and decoding
+settings. A kernel or cache change that alters numerical computation is marked
+as an intervention rather than hidden as an implementation detail.}

--- a/trees/ftip-00L9.tree
+++ b/trees/ftip-00L9.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Cost-vector row}
+\tag{ftip}
+\p{Each ledger row reports training FLOPs, inference FLOPs, wall time, memory,
+energy when available, and context length as a vector #{\mathbf c}. The
+primary scalar #{C} and its weights are declared beside the vector; omitted
+coordinates are marked unknown.}

--- a/trees/ftip-00LA.tree
+++ b/trees/ftip-00LA.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Repeated measurement rule}
+\tag{ftip}
+\p{For each fixed workload and system, record warm-up runs, repetition count,
+random seeds, and the aggregation rule. Report mean and dispersion for time,
+memory, and score; a single fastest run cannot define a cost frontier.}

--- a/trees/ftip-00LB.tree
+++ b/trees/ftip-00LB.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Paired uncertainty readout}
+\tag{ftip}
+\p{When the same evaluation items are used, report paired score differences
+and an uncertainty procedure fixed before inspecting the result. Confidence
+intervals quantify sampling variation; they do not repair unmatched training,
+systems, or task coordinates.}

--- a/trees/ftip-00LC.tree
+++ b/trees/ftip-00LC.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Kimi Linear ledger rows}
+\tag{ftip}
+\p{For the Kimi Linear report, one row records the hybrid KDA/MLA checkpoint
+and one row records the specified MLA baseline. The ledger copies the paper's
+training recipe and evaluation configuration, then marks hardware, kernel,
+batch, and sequence-length values at the exact measurement point
+\citef{kimi2025linear}.}

--- a/trees/ftip-00LD.tree
+++ b/trees/ftip-00LD.tree
@@ -1,0 +1,8 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Unknown fields remain unknown}
+\tag{ftip}
+\p{A missing cost, seed, or evaluator field prevents the corresponding
+iso-quality or causal comparison. It is reported as unknown or bounded by an
+explicit interval; it is not reconstructed from a headline speedup.}

--- a/trees/ftip-00LE.tree
+++ b/trees/ftip-00LE.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Admissible ledger comparison}
+\tag{ftip}
+\p{A ledger comparison is admissible for a stated estimand only when every
+coordinate named by that estimand is present in both rows and the matching
+rules were fixed before score inspection. Otherwise the ledger is descriptive
+and cannot support the stronger estimand.}

--- a/trees/ftip-00LF.tree
+++ b/trees/ftip-00LF.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Ledger outputs}
+\tag{ftip}
+\p{A completed ledger emits the paired score estimate, the selected scalar
+costs, the full cost vectors, uncertainty summaries, and a list of unmatched
+or unknown fields. These outputs are sufficient to reproduce the plotted
+frontier point without asserting a universal architecture ordering.}

--- a/trees/ftip-00LG.tree
+++ b/trees/ftip-00LG.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Ledger scope and transfer limit}
+\tag{ftip}
+\p{The ledger supports comparison of the named model instances and protocol.
+It does not establish that another KDA implementation, Transformer variant,
+optimizer, hardware stack, or task family has the same ordering. Each transfer
+requires a new completed ledger.}


### PR DESCRIPTION
## Summary

Adds a bounded comparison ledger inside the existing architecture chapter. It turns the model-instance record into two auditable rows before a capability frontier is plotted.

The ledger specifies:

- pair identity, checkpoint and architecture fields;
- common task and evaluation coordinates;
- training and post-training coordinates;
- inference and systems coordinates;
- cost vectors and declared scalarization;
- repeated measurements and paired uncertainty;
- a Kimi Linear versus MLA-baseline ledger example;
- explicit unknown-field and transfer rules.

No new chapter or capability score is introduced.

## Verification

- `just chk`
- `CI=1 just build`
- `just verify-render` (2245 XML/HTML pairs)
- model graph: 751 files, 751 reachable exactly once, no cycles or missing references
- targeted `./lize.sh ftip-0001`: 230 A4 pages
- PDF SHA-256: `9ebbea91cbfa70bdf7e06a9e90018ca7ca1137d82e705ff40bc49bc4f2c66bb5`
