### PR TITLE
Add conditional frontier and saturation readout

### DIFF
--- a/trees/ftip-00JF.tree
+++ b/trees/ftip-00JF.tree
@@ -24,3 +24,4 @@ model instances without the stated interface and measurement gates.}
 \transclude{ftip-00K9}
 \transclude{ftip-00KU}
 \transclude{ftip-00L4}
+\transclude{ftip-00LH}

--- a/trees/ftip-00LH.tree
+++ b/trees/ftip-00LH.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Conditional frontier and saturation readout}
+\tag{ftip}
+\tag{measured-example}
+\p{This subsection states what a finite matched study can and cannot say
+about capability as a function of one declared cost. It reports a conditional
+frontier and a declared saturation target, not a universal intelligence law.}
+\transclude{ftip-00LI}
+\transclude{ftip-00LJ}
+\transclude{ftip-00LK}
+\transclude{ftip-00LL}
+\transclude{ftip-00LM}
+\transclude{ftip-00LN}
+\transclude{ftip-00LO}
+\transclude{ftip-00LP}
+\transclude{ftip-00LQ}
+\transclude{ftip-00LR}

--- a/trees/ftip-00LI.tree
+++ b/trees/ftip-00LI.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Finite cost grid}
+\tag{ftip}
+\p{Choose a finite ordered grid #{0<C_1<\cdots<C_m} and evaluate each
+architecture at every declared grid point under the same task and protocol.
+The resulting values #{\widehat V_A(C_i)} are observations of the restricted
+frontier, not its values between grid points.}

--- a/trees/ftip-00LJ.tree
+++ b/trees/ftip-00LJ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Observed upper envelope}
+\tag{ftip}
+\p{For an observed score #{s_A(C_i)} define the discrete upper envelope
+#{U_A(C_i)=\max_{j\leq i}s_A(C_j)}. It is a descriptive monotone summary of
+the measured points; it is not evidence that unmeasured costs attain the
+envelope or that extra cost cannot reduce score.}

--- a/trees/ftip-00LK.tree
+++ b/trees/ftip-00LK.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Uncertainty bands on the frontier}
+\tag{ftip}
+\p{Attach a predeclared uncertainty interval #{I_A(C_i)} to each score and
+carry those intervals through score differences and threshold crossings. A
+finite band describes sampling and measurement variation; it does not cover
+unmeasured training procedures or architectures.}

--- a/trees/ftip-00LL.tree
+++ b/trees/ftip-00LL.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Declared saturation target}
+\tag{ftip}
+\p{Fix a quality target #{q}, tolerance #{\varepsilon>0}, and cost increment
+#{\delta>0}. A study calls an architecture #{\varepsilon}-saturated at #{C}
+only relative to its allowed intervention class when the restricted frontier
+has certified gain at most #{\varepsilon} from #{C} to #{C+\delta}.}

--- a/trees/ftip-00LM.tree
+++ b/trees/ftip-00LM.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{Conditional saturation certificate}
+\tag{ftip}
+\p{If a declared upper bound #{U} satisfies #{V_A(C+\delta)\leq U} and a
+measured point satisfies #{V_A(C)\geq U-\varepsilon}, then the possible gain
+over the increment is at most #{\varepsilon}. This is a conditional bound for
+the named frontier; it proves no universal saturation of intelligence.}

--- a/trees/ftip-00LN.tree
+++ b/trees/ftip-00LN.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Finite observations do not prove a ceiling}
+\tag{ftip}
+\p{For any finite set of measured costs and scores, another admissible
+frontier can agree at every measured point and improve at an unmeasured cost.
+Therefore a finite comparison can establish a measured lower bound or a
+conditional certificate, but not a universal architecture ceiling.}

--- a/trees/ftip-00LO.tree
+++ b/trees/ftip-00LO.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{One-factor cost interpretation}
+\tag{ftip}
+\p{The primary cost #{C} is a declared scalarization of the recorded cost
+vector. A frontier statement is conditional on its units and weights; the
+same paired measurements may produce a different ordering under a different
+scalarization.}

--- a/trees/ftip-00LP.tree
+++ b/trees/ftip-00LP.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Crossing architecture frontiers}
+\tag{ftip}
+\p{Two architectures may alternate in the observed ordering across costs:
+one can score higher at small #{C} while the other catches up at larger #{C}.
+Thus a single comparison point cannot establish a global ordering or a common
+ceiling.}

--- a/trees/ftip-00LQ.tree
+++ b/trees/ftip-00LQ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Frontier report for the KDA study}
+\tag{ftip}
+\p{A Kimi Delta Attention versus Transformer study should publish the cost
+grid, paired scores, uncertainty intervals, scalarization weights, and the
+model-instance ledger identifier. The report may then state which measured
+points are Pareto or iso-quality comparisons under that protocol.}

--- a/trees/ftip-00LR.tree
+++ b/trees/ftip-00LR.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Frontier transfer limit}
+\tag{ftip}
+\p{The conditional frontier is indexed by architecture, intervention class,
+task family, evaluation law, and cost scalarization. Changing any of these
+coordinates creates a new estimand; no ordering transfers automatically to a
+new checkpoint, optimizer, hardware stack, or task family.}


### PR DESCRIPTION
## Summary

Adds a bounded frontier readout inside the existing architecture chapter. It specifies finite cost grids, observed envelopes, uncertainty bands, a declared saturation target, and explicit limits on what finite measurements can establish.

The note:

- keeps the primary cost as a declared scalarization of the recorded cost vector;
- distinguishes measured points from unmeasured costs;
- defines an epsilon saturation certificate relative to a named frontier and cost increment;
- gives a conditional bound under an explicit upper bound;
- records why finite observations cannot prove a universal architecture ceiling;
- shows that architecture orderings may cross across cost levels;
- states the transfer limits for the KDA comparison.

No new chapter, universal intelligence function, or architecture ordering is introduced.

## Verification

- `just chk`
- `CI=1 just build`
- `just verify-render` (2256 XML/HTML pairs)
- model graph: 762 files, 762 reachable exactly once, no cycles or missing references
- targeted `./lize.sh ftip-0001`: 231 A4 pages
- PDF SHA-256: `bc6f49c03c03f3e2de9f723dd024dbd08a06c60554fdc59bb4514ce2a8dfce73`
