### PR TITLE
Add transfer limits and comparison study design

### DIFF
--- a/trees/ftip-00JF.tree
+++ b/trees/ftip-00JF.tree
@@ -25,3 +25,4 @@ model instances without the stated interface and measurement gates.}
 \transclude{ftip-00KU}
 \transclude{ftip-00L4}
 \transclude{ftip-00LH}
+\transclude{ftip-00LS}

--- a/trees/ftip-00LS.tree
+++ b/trees/ftip-00LS.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Transfer limits and study design for matched model-instance comparisons}
+\tag{ftip}
+\tag{measured-example}
+\p{This subsection specifies how a conditional architecture comparison may be
+instantiated without changing the architecture-neutral formulation. It is a
+study design, not a universal ranking of architectures.}
+\transclude{ftip-00LT}
+\transclude{ftip-00LU}
+\transclude{ftip-00LV}
+\transclude{ftip-00LW}
+\transclude{ftip-00LX}
+\transclude{ftip-00LY}
+\transclude{ftip-00LZ}
+\transclude{ftip-00M0}
+\transclude{ftip-00M1}
+\transclude{ftip-00M2}

--- a/trees/ftip-00LT.tree
+++ b/trees/ftip-00LT.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Matched model-instance record}
+\tag{ftip}
+\p{A model-instance record names the architecture, parameterization or
+checkpoint, training and post-training recipe, optimizer, execution stack,
+inference budget, task family, evaluation law, and recorded cost vector. Two
+records are comparable only after the fields held fixed and the fields allowed
+to vary are declared.}

--- a/trees/ftip-00LU.tree
+++ b/trees/ftip-00LU.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Pair identity and comparison unit}
+\tag{ftip}
+\p{A comparison unit is a pair of model-instance records evaluated on the
+same task family and evaluation law, together with a declared cost
+scalarization. A Transformer reference and a Kimi Delta Attention instance
+may form such a pair only when the remaining coordinates are documented.}

--- a/trees/ftip-00LV.tree
+++ b/trees/ftip-00LV.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Common-recipe comparison}
+\tag{ftip}
+\p{The common-recipe comparison applies the same declared data, optimizer,
+post-training procedure, budgets, and evaluation protocol to each architecture,
+subject to interface-compatible parameter choices. It measures behavior under
+that recipe; it does not measure the best attainable result for either
+architecture.}

--- a/trees/ftip-00LW.tree
+++ b/trees/ftip-00LW.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Equal-tuning-budget comparison}
+\tag{ftip}
+\p{The equal-tuning-budget comparison permits architecture-specific tuning,
+but fixes the tuning data, number of trials, stopping rule, and tuning cost.
+It measures practical performance under equal search effort rather than a
+representation-only limit.}

--- a/trees/ftip-00LX.tree
+++ b/trees/ftip-00LX.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Restricted-envelope comparison}
+\tag{ftip}
+\p{A restricted envelope is the supremum of the declared evaluation score
+over an explicitly bounded class of training, post-training, and inference
+procedures at cost at most #{C}. The restriction is part of the statement;
+the envelope is not an unrestricted architectural ceiling.}

--- a/trees/ftip-00LY.tree
+++ b/trees/ftip-00LY.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Coordinate-change rule}
+\tag{ftip}
+\p{Changing the optimizer, post-training method, hardware or kernel,
+precision, context policy, or evaluation law changes a comparison coordinate.
+A score difference after such a change belongs to the new intervention, unless
+the study explicitly estimates the interaction.}

--- a/trees/ftip-00LZ.tree
+++ b/trees/ftip-00LZ.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Architecture-family transfer matrix}
+\tag{ftip}
+\p{A transfer matrix records which interfaces and budgets permit a comparison
+among a Transformer reference, Kimi Delta Attention, looped or depth-reused
+variants, and JEPA-like systems. A blank or incompatible cell is an
+incomparability finding, not a missing score to be imputed.}

--- a/trees/ftip-00M0.tree
+++ b/trees/ftip-00M0.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Toy-to-model-instance transfer gate}
+\tag{ftip}
+\p{A toy representation or recurrence result may motivate a hypothesis, but
+it is not transferred to a model instance until its interface, task, cost
+accounting, numerical regime, and evaluation protocol are instantiated and
+checked. Failure of any gate leaves the result illustrative only.}

--- a/trees/ftip-00M1.tree
+++ b/trees/ftip-00M1.tree
@@ -1,0 +1,9 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Negative-result and stopping report}
+\tag{ftip}
+\p{A completed comparison reports the tested cost grid, excluded
+configurations, stopping rule, uncertainty, and negative results. Stopping
+without a detected difference is evidence about the declared study, not proof
+that the architectures have equal potential.}

--- a/trees/ftip-00M2.tree
+++ b/trees/ftip-00M2.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Open comparison questions}
+\tag{ftip}
+\p{The remaining questions are whether a declared interface supports a fair
+Kimi Delta Attention--Transformer comparison, how looped computation changes
+the frontier under matched budgets, and which JEPA interface can be fixed
+without silently changing the task. None is settled by the study design
+alone.}


### PR DESCRIPTION
Adds a compact study-design subsection under the existing architecture section. It defines matched model-instance records, common-recipe, equal-tuning-budget, and restricted-envelope comparisons; separates intervention coordinates; records architecture-family comparability; gates transfer from toy results to concrete model instances; and requires negative-result reporting. No new chapter or universal architecture ranking is introduced.