### PR TITLE
Remove legacy claim labels and relocate source notes

### DIFF
--- a/trees/ftip-0075.tree
+++ b/trees/ftip-0075.tree
@@ -10,12 +10,10 @@ statements. The results concern declared probability spaces, finite decision
 sets, recorded feedback, or explicitly stated matrix models. They do not by
 themselves establish a scaling law for language-model capability.}
 
-\p{Four status descriptions are used. A \strong{source reconstruction}
-restates a named result with its source assumptions. An \strong{FTIP-proved}
-statement is derived in these notes from the displayed finite setup. A
-\strong{finite counterexample} exhibits a concrete obstruction. An
-\strong{open direction} records a target whose assumptions or proof are not
-yet supplied.}
+\p{Each result states its assumptions and provenance locally. A cited result is
+reconstructed with its source hypotheses; a result derived from the displayed
+finite setup gives its local proof; a finite obstruction is shown by an explicit
+counterexample; and an unresolved target is identified as an open direction.}
 
 \p{We begin with discovery and support, then study proxy rewards and
 verifiers. The third subsection asks what can be learned

--- a/trees/ftip-0078.tree
+++ b/trees/ftip-0078.tree
@@ -28,5 +28,5 @@ Then}
 =\prod_i(1-p_i)}. Taking complements proves the first identity; substituting
 #{p_i=p} proves the specialization.}}
 
-\p{This is an FTIP-proved finite statement. The calculation in
+\p{This finite statement follows from the displayed hypotheses. The calculation in
 \ref{ftip-0067} is its ten-attempt numerical preview.}

--- a/trees/ftip-0079.tree
+++ b/trees/ftip-0079.tree
@@ -7,7 +7,7 @@
 \tag{probability}
 \tag{rollout}
 
-\p{This is an FTIP-proved corollary of \ref{ftip-0078}.}
+\p{This is a finite corollary of \ref{ftip-0078}, obtained from its displayed hypotheses.}
 
 \p{Let #{0<\delta<1}. Under the independent and identically distributed
 setup of \ref{ftip-0078}, suppose first that #{0<p<1}. The least positive

--- a/trees/ftip-007A.tree
+++ b/trees/ftip-007A.tree
@@ -39,4 +39,4 @@ discovery bounds.}}
 \p{No independence assumption is used. The conditional rates may change with
 the earlier failures, an adaptive decoder, or a changing environment state.}
 
-\p{This is an FTIP-proved finite statement.}
+\p{This finite statement follows from the displayed hypotheses.}

--- a/trees/ftip-007C.tree
+++ b/trees/ftip-007C.tree
@@ -25,7 +25,7 @@ the first quantity and division by the second therefore preserve whether the
 reference mass is zero or positive.}}
 
 \p{The source policy form appears as equation (4) in
-\citet{Section 4}{rafailov2023direct}; this theorem is its FTIP-proved
-corollary. Infinite rewards,
+\citet{Section 4}{rafailov2023direct}; the displayed result is the finite
+corollary derived here. Infinite rewards,
 non-normalizable response spaces, approximate optimization, and changes to the
 generation mechanism lie outside the statement.}

--- a/trees/ftip-007H.tree
+++ b/trees/ftip-007H.tree
@@ -37,4 +37,4 @@ U(y^\star)
 \p{Optimality of #{y^\star} for #{U} gives the lower bound.}
 }
 
-\p{This is an FTIP-proved finite statement.}
+\p{This finite statement follows from the displayed hypotheses.}

--- a/trees/ftip-007L.tree
+++ b/trees/ftip-007L.tree
@@ -41,4 +41,4 @@ audited pairs makes the events #{C_i^{\rm fa}} independent. Therefore}
 from the elementary powers of #{1-\iota\eta_+}.}
 }
 
-\p{This is an FTIP-proved finite statement.}
+\p{This finite statement follows from the displayed hypotheses.}

--- a/trees/ftip-007M.tree
+++ b/trees/ftip-007M.tree
@@ -31,4 +31,4 @@ is undefined, so the first display remains the unconditional statement.}
 give the equality in \ref{ftip-007L}; the events #{C_i^{\rm fa}} could
 coincide.}
 
-\p{This is an FTIP-proved finite statement.}
+\p{This finite statement follows from the displayed hypotheses.}

--- a/trees/ftip-007S.tree
+++ b/trees/ftip-007S.tree
@@ -46,4 +46,4 @@ the declared protocol's transcript has the same distribution in both worlds.}
 These point probabilities determine the two pushforward laws.}
 }
 
-\p{This is an FTIP-proved finite statement.}
+\p{This finite statement follows from the displayed hypotheses.}

--- a/trees/ftip-007U.tree
+++ b/trees/ftip-007U.tree
@@ -27,4 +27,4 @@ the displayed sum is identical. Equivalently, this is the pushforward argument
 of \ref{ftip-007S} applied after conditioning on the realized pool.}
 }
 
-\p{This is an FTIP-proved finite statement.}
+\p{This finite statement follows from the displayed hypotheses.}

--- a/trees/ftip-007Z.tree
+++ b/trees/ftip-007Z.tree
@@ -7,9 +7,6 @@
 \tag{replay}
 \tag{gradient}
 
-\p{\strong{Source reconstruction.} This statement reconstructs
-\citet{Section 4.2.1, Proposition 1, and Appendix A.1}{miao2026when}.}
-
 \p{Consider an active token #{i} on the unclipped branch of the GRPO
 objective. Let #{a_i} be the sampled token, #{\widehat A_i} its normalized
 advantage, and
@@ -55,3 +52,5 @@ the same rule to #{y_i=W_{\rm int}x_i^{\rm int}} gives the second.}
 \p{This is the source proposition specialized to the active, unclipped token
 whose gradient appears in its equation (3). Clipped or inactive tokens require
 their own derivative or mask and are not covered by the displayed identities.}
+
+\p{Source note: this statement reconstructs \citet{Section 4.2.1, Proposition 1, and Appendix A.1}{miao2026when}.}

--- a/trees/ftip-0080.tree
+++ b/trees/ftip-0080.tree
@@ -7,9 +7,6 @@
 \tag{replay}
 \tag{gradient}
 
-\p{\strong{Source reconstruction.} This statement reconstructs
-\citet{Section 4.2.1, Lemma 1, Assumption 1, Theorem 1, and Appendix A.3}{miao2026when}.}
-
 \p{Use the per-token quantities of \ref{ftip-007Z}. Assume positive constants
 #{\alpha_{\min}}, #{\beta_{\max}}, and #{C} satisfy
 ##{
@@ -63,3 +60,5 @@ and cancellation give the displayed ratio.}
 row-energy inequalities reproduce its Assumption 1. The conclusion is an
 upper bound on an intermediate-to-head gradient-energy ratio. It does not say
 that either gradient is small, and it does not compare evaluation scores.}
+
+\p{Source note: this statement reconstructs \citet{Section 4.2.1, Lemma 1, Assumption 1, Theorem 1, and Appendix A.3}{miao2026when}.}

--- a/trees/ftip-0081.tree
+++ b/trees/ftip-0081.tree
@@ -7,9 +7,6 @@
 \tag{replay}
 \tag{gradient}
 
-\p{\strong{Source reconstruction.} This statement reconstructs
-\citet{Section 4.2.2, Lemma 2, Theorem 2, and Appendix B}{miao2026when}.}
-
 \p{For #{T\geq1} active, unclipped tokens, let
 ##{
 G^{\rm lm}=\frac1T\sum_{i=1}^T G_i^{\rm lm},
@@ -52,3 +49,5 @@ The identity #{\overline{r^2}=1+\widehat\chi^2} follows directly from
 \p{The inequality points from observed head-gradient energy to a lower bound
 on this finite-batch squared-ratio statistic. It is not a converse: cancellation
 can make the batch gradient small even when individual ratios are large.}
+
+\p{Source note: this statement reconstructs \citet{Section 4.2.2, Lemma 2, Theorem 2, and Appendix B}{miao2026when}.}

--- a/trees/ftip-008E.tree
+++ b/trees/ftip-008E.tree
@@ -12,12 +12,11 @@ optimizer and characterizes the reward gain that its exponential tilt can
 produce. The second asks what ordinal comparisons reveal when post-training
 may reroute a fixed set of response circuits.}
 
-\p{A \strong{source reconstruction} preserves the cited source's objects,
-quantifiers, and hypotheses after an explicit notation translation. An
-\strong{FTIP-proved} result is derived in these notes from the displayed
-finite setup. A \strong{source discrepancy} records text that cannot be
-silently made consistent across the main statement, appendix, or inherited
-result.}
+\p{A reconstruction preserves the cited source's objects, quantifiers, and
+hypotheses after an explicit notation translation. A result derived in these
+notes follows from the displayed setup. A source discrepancy records text that
+cannot be silently made consistent across the main statement, appendix, or
+inherited result.}
 
 \p{Neither source model is a general account of neural post-training. The
 first assumes exact optimization of a declared scalar reward. The second is a

--- a/trees/ftip-008I.tree
+++ b/trees/ftip-008I.tree
@@ -20,6 +20,6 @@ penalty #{\beta>0}, and finite real functions
 alignment update; #{s} measures its result. They may coincide, but they need
 not. Finiteness makes every exponential weight and expectation below finite.}
 
-\p{\strong{Status: source-adapted definition.} The objects specialize the
+\p{Source note: these objects specialize the
 fixed-query setting in \citet{Section 2, equations (2.1)--(2.2)}{paes2026theoretical};
 they are not a definition of alignment in general.}

--- a/trees/ftip-008J.tree
+++ b/trees/ftip-008J.tree
@@ -19,6 +19,6 @@ weight} and \newvocab{partition function} by}
 \p{Every #{a_r(y)} is finite and strictly positive. Since #{p} is a
 probability law on a nonempty finite set, #{0<Z_r<\infty}.}
 
-\p{\strong{Status: source reconstruction.} This is the fixed-query form of
+\p{Source note: this is the fixed-query form of
 the weight and normalizer in
 \citet{Equation (2.2)}{paes2026theoretical}.}

--- a/trees/ftip-008K.tree
+++ b/trees/ftip-008K.tree
@@ -19,6 +19,6 @@ given by}
 exponential-tilt optimizer stated in \ref{ftip-003O}; support preservation was
 proved in \ref{ftip-007C}.}
 
-\p{\strong{Status: source reconstruction.} The formula is
+\p{Source note: the formula is
 \citet{Equation (2.2)}{paes2026theoretical}. It assumes the exact optimizer,
 not an iterate returned by a particular training algorithm.}

--- a/trees/ftip-008L.tree
+++ b/trees/ftip-008L.tree
@@ -21,6 +21,6 @@ law; its right argument scores both laws. Thus #{G_p(r;s)} is not an
 independent evaluation unless #{s} has separately been declared to serve that
 role.}
 
-\p{\strong{Status: source reconstruction.} This is the finite notation for
+\p{Source note: this is the finite notation for
 #{\Delta(r,r')} in Theorem 2, equation (3.4), of
 \citef{paes2026theoretical}.}

--- a/trees/ftip-008M.tree
+++ b/trees/ftip-008M.tree
@@ -21,5 +21,5 @@
 tilt of \ref{ftip-008K}, #{p} and #{q_r} have the same support, so both terms
 are finite.}
 
-\p{\strong{Status: standard definition used by the source.} See
+\p{Source note: see
 \citet{Theorem 1, equation (3.2)}{paes2026theoretical}.}

--- a/trees/ftip-008N.tree
+++ b/trees/ftip-008N.tree
@@ -18,6 +18,6 @@
 \p{On #{S_p}, both #{p(y)} and #{q_r(y)} are positive. Dividing the formula
 of \ref{ftip-008K} by #{p(y)} and taking logarithms gives the identity.}}
 
-\p{\strong{Status: source reconstruction.} This is equation (B.1) followed
+\p{Source note: this is equation (B.1) followed
 by the logarithmic step in
 \citet{Appendix B.1, equations (B.1)--(B.2)}{paes2026theoretical}.}

--- a/trees/ftip-008O.tree
+++ b/trees/ftip-008O.tree
@@ -29,5 +29,5 @@ expectation first under #{q_r} and then under #{p} yields}
 
 \p{Subtracting cancels the common normalizer and gives the result.}}
 
-\p{\strong{Status: source reconstruction.} This is the finite form of
+\p{Source note: this is the finite form of
 \citet{Theorem 1, equation (3.2), with proof in Appendix B.1}{paes2026theoretical}.}

--- a/trees/ftip-008Q.tree
+++ b/trees/ftip-008Q.tree
@@ -20,6 +20,6 @@
 #{\mathbb E_p[a_r/Z_r]=1}. Substituting these two identities into
 \ref{ftip-008L} gives the covariance defined in \ref{ftip-008H}.}}
 
-\p{\strong{Status: source reconstruction.} This is the finite form of
+\p{Source note: this is the finite form of
 Theorem 2, equation (3.4), in \citef{paes2026theoretical}. Its proof is in
 Appendix B.1, equations (B.5)--(B.7).}

--- a/trees/ftip-008T.tree
+++ b/trees/ftip-008T.tree
@@ -20,6 +20,6 @@ KL-alignment instance with the same penalty #{\beta>0}. Then}
 \p{Apply \ref{ftip-008O} at each prompt and take the finite
 #{\mu}-weighted sum.}}
 
-\p{\strong{Status: FTIP-proved corollary.} The source theorem is stated for
+\p{The source theorem is stated for
 each fixed query. This corollary performs only finite averaging; it does not
 introduce a shared neural parameterization across prompts.}

--- a/trees/ftip-008U.tree
+++ b/trees/ftip-008U.tree
@@ -21,6 +21,6 @@ function is #{Z_{r+c}=e^{c/\beta}Z_r}; the common factor cancels in the
 aligned law. Adding #{d} to the evaluation reward adds #{d} to both
 expectations in the gain, so it also cancels.}}
 
-\p{\strong{Status: FTIP-proved finite lemma.} It records the same
+\p{This finite lemma records the same
 prompt-dependent additive non-identifiability that appears in the DPO
 reparameterization of \ref{ftip-003P}.}

--- a/trees/ftip-009A.tree
+++ b/trees/ftip-009A.tree
@@ -15,9 +15,9 @@
  \qquad(\xi\in Q).
 }
 
-\p{\strong{Conditional source reconstruction.} Assume pointwise response
-separation. Then the statement of Appendix Theorem A.1, equation (3), in
-\citef{zhao2025limits} yields: for every pretrained routing model
+\p{Assume pointwise response separation. Then the statement of Appendix
+Theorem A.1, equation (3), in \citef{zhao2025limits} yields: for every
+pretrained routing model
 #{\mathfrak m_0} and every preference-only algorithm #{\mathcal A}, there
 exists a utility #{u} such that post-training on the complete noiseless profile
 satisfies}
@@ -51,3 +51,7 @@ that assignment need not descend to a function on #{Q\times Y}. We therefore
 state only the response-separating transfer that the typed FTIP model supports.
 The quantifier remains worst-case and existential in #{u}, and the comparator
 is the deterministic class in \ref{ftip-0096}.}
+
+\p{Source note: this is a conditional reconstruction of Appendix Theorem A.1,
+equation (3), in \citef{zhao2025limits}; the added separation condition is
+required by the typed response interface used here.}

--- a/trees/ftip-009B.tree
+++ b/trees/ftip-009B.tree
@@ -7,7 +7,7 @@
 \tag{preference-data}
 \tag{lower-bound}
 
-\p{\strong{FTIP-proved corollary.} Under the response-separation hypothesis of
+\p{Under the response-separation hypothesis of
 \ref{ftip-009A}, assume the explicit condition}
 
 ##{

--- a/trees/ftip-009G.tree
+++ b/trees/ftip-009G.tree
@@ -7,9 +7,6 @@
 \tag{preference-data}
 \tag{lower-bound}
 
-\p{\strong{Conditional source reconstruction.} This is a conditional form of
-Appendix Theorem A.5 in \citef{zhao2025limits}.}
-
 \p{Assume pointwise response separation as defined in \ref{ftip-009A}. For
 every pretrained routing model and linear-score algorithm
 #{\mathcal A_{\rm lin}}, there exists a utility}
@@ -35,3 +32,7 @@ same circuitwise-utility issue recorded in \ref{ftip-009A} prevents us from
 asserting the source's unrestricted pretrained-model quantifier here. Its noise
 is informative because probabilities depend on cardinal scores; the
 obstruction survives under the particular linear link.}
+
+\p{Source note: this is a conditional form of Appendix Theorem A.5 in
+\citef{zhao2025limits}; the response-separation condition and its transfer
+limit are stated above.}

--- a/trees/ftip-009J.tree
+++ b/trees/ftip-009J.tree
@@ -7,9 +7,8 @@
 \tag{preference-data}
 \tag{query-complexity}
 
-\p{\strong{Source reconstruction.} Let #{m} be the number of alternatives
-and let #{k\in\{1,\ldots,m\}}. Theorem 4 of
-\citef{amanatidis2021peeking} states that
+\p{Let #{m} be the number of alternatives and let #{k\in\{1,\ldots,m\}}.
+Theorem 4 of \citef{amanatidis2021peeking} states that
 #{k}-Acceptable Range Voting uses}
 
 ##{
@@ -28,3 +27,5 @@ one common circuit. Under that restriction, queries are agents and circuits
 are alternatives as in \ref{ftip-009I}. The theorem does not by itself cover a
 routing comparator that may choose different circuits for different
 representations, and it is not an implementation of neural post-training.}
+\p{Source note: the statement above reconstructs Theorem 4 of
+\citef{amanatidis2021peeking}.}

--- a/trees/ftip-00A1.tree
+++ b/trees/ftip-00A1.tree
@@ -21,5 +21,5 @@ probability #{p}. Then
 #{\bigcap_{j=1}^m\{I_j^\star=0\}}. Independence and
 #{\Pr_p(I_j^\star=0)=1-p} give the displayed product.}}
 
-\p{This is an FTIP-proved finite statement. Applying it to a source table
+\p{This finite statement follows from the displayed hypotheses. Applying it to a source table
 requires the additional iid and stationary-success assumptions stated above.}

--- a/trees/ftip-00A2.tree
+++ b/trees/ftip-00A2.tree
@@ -25,5 +25,5 @@ count excludes probabilities above #{u_{m,\delta}} at exact level
 strictly decreasing in #{p}. Solving #{(1-p)^m=\delta} gives the endpoint and
 the stated strict inequality.}}
 
-\p{This is an FTIP-proved likelihood inversion, not a source theorem and not
+\p{This is a likelihood inversion derived from the displayed finite setup, not a source theorem and not
 a support certificate.}

--- a/trees/ftip-00A5.tree
+++ b/trees/ftip-00A5.tree
@@ -19,6 +19,6 @@ common probability #{q}. For every positive rollout budget #{B},}
 #{E_j=\{r_j^{\mathrm{sp}}>0\}}. Its discovery event is exactly
 #{\{J_+\leq B\}}.}}
 
-\p{This is an FTIP-proved specialization. It does not supply independence,
+\p{This is a specialization proved from the displayed hypotheses. It does not supply independence,
 stationarity, or the value of #{q} for a training run, and it does not equate
 positive proxy reward with task utility.}

--- a/trees/ftip-00AG.tree
+++ b/trees/ftip-00AG.tree
@@ -30,6 +30,6 @@ condition makes this map well defined. It is surjective because every
 #{r_1}-class contains some #{y}, whose #{r_2}-class maps to it. A surjection
 between finite sets has a domain at least as large as its codomain.}}
 
-\p{\strong{Status: FTIP-proved finite lemma.} It compares observational
+\p{This finite lemma compares observational
 partitions only. It does not say that the refined reward is cheaper, more
 accurate, or better aligned with utility.}

--- a/trees/ftip-00AY.tree
+++ b/trees/ftip-00AY.tree
@@ -19,5 +19,5 @@
 identity is #{UAA^{-1}V^{\mathsf T}=UV^{\mathsf T}}. Applying #{f} gives
 the second.}}
 
-\p{\strong{Status: source-reconstructed lemma.} This is the factored-model
+\p{Source note: this is the factored-model
 calculation in Section 3 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00B0.tree
+++ b/trees/ftip-00B0.tree
@@ -17,5 +17,5 @@ arbitrary #{u\in\mathbb R^{1\times k}}. Then
 #{AA^{\mathsf T}=I}. Conversely, right multiplication by an orthogonal
 matrix preserves both Frobenius norms.}}
 
-\p{\strong{Status: source-reconstructed lemma.} See Lemma 3.2 and its proof
+\p{Source note: see Lemma 3.2 and its proof
 in Appendix B.1 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00B1.tree
+++ b/trees/ftip-00B1.tree
@@ -21,5 +21,5 @@
 and hence #{G}, is unchanged along the orbit. Substitution gives both
 identities.}}
 
-\p{\strong{Status: source-reconstructed lemma.} See Lemma 4.1 and its proof
+\p{Source note: see Lemma 4.1 and its proof
 in Appendix B.2 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00B8.tree
+++ b/trees/ftip-00B8.tree
@@ -17,5 +17,5 @@ and formed by linear combinations of covariant gradients transforms as
 #{M_tQ}; a Nesterov look-ahead point is likewise the reference look-ahead
 right-multiplied by #{Q}. Induction proves the claim.}}
 
-\p{\strong{Status: source-reconstructed Proposition 4.2(1), proof Appendix
-B.3} of \citef{singh2026lossbasis}.}
+\p{Source note: Proposition 4.2(1) and its proof are in Appendix
+B.3 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00B9.tree
+++ b/trees/ftip-00B9.tree
@@ -19,6 +19,6 @@ Frobenius norm divided by the entry count, hence is unchanged by #{G\mapsto
 GQ}. Its bias correction and positive scalar denominator are unchanged, so
 the complete update transforms covariantly.}}
 
-\p{\strong{Status: source-reconstructed Proposition 4.2(2), proof Appendix
-B.3} of \citef{singh2026lossbasis}. The result concerns this declared
+\p{Source note: Proposition 4.2(2) and its proof are in Appendix
+B.3 of \citef{singh2026lossbasis}. The result concerns this declared
 shared-scalar variant, not stock Adam.}

--- a/trees/ftip-00BA.tree
+++ b/trees/ftip-00BA.tree
@@ -30,8 +30,8 @@ the left accumulator is invariant while the right accumulator transforms by
 the right matrix function, so the transformed update is the original update
 right-multiplied by #{Q}.}}
 
-\p{\strong{Status: source-reconstructed Proposition 4.2(3)--(4), proof
-Appendix B.3} of \citef{singh2026lossbasis}. Variable splitting, coordinatewise
+\p{Source note: Proposition 4.2(3)--(4) and its proof are in
+Appendix B.3 of \citef{singh2026lossbasis}. Variable splitting, coordinatewise
 clipping, mixed update rules, finite precision, and different damping
 conventions lie outside this statement. The Muon part is stateful; it does not
 replace the momentum buffer by the current gradient or invoke the memoryless

--- a/trees/ftip-00BB.tree
+++ b/trees/ftip-00BB.tree
@@ -18,5 +18,5 @@ whose cosine is #{a\in[-1,1]} gives #{\phi(ax)=a\phi(x)}. For nonzero #{x,y},
 compare each with a third number of at least their absolute magnitudes; the
 ratio #{\phi(x)/x} is constant.}}
 
-\p{\strong{Status: source-reconstructed Proposition 4.3, proof Appendix B.4}
+\p{Source note: Proposition 4.3 and its proof are in Appendix B.4
 of \citef{singh2026lossbasis}. No continuity assumption is needed.}

--- a/trees/ftip-00BE.tree
+++ b/trees/ftip-00BE.tree
@@ -27,5 +27,5 @@ product after one step from #{(U_0Q,V_0Q)}. Then}
 #{V_0-\eta(D_V+E_Q(G_V))}. Multiply, subtract
 #{(U_0-\eta D_U)(V_0-\eta D_V)^{\mathsf T}}, and collect powers of #{\eta}.}}
 
-\p{\strong{Status: source-reconstructed Proposition 4.4, proof Appendix B.5}
+\p{Source note: Proposition 4.4 and its proof are in Appendix B.5
 of \citef{singh2026lossbasis}.}

--- a/trees/ftip-00BH.tree
+++ b/trees/ftip-00BH.tree
@@ -23,6 +23,6 @@ Moore--Penrose pseudoinverse. Conversely, set #{X(G)=\Phi(G)G^+}. Then
 have the same range and differ by a right orthogonal factor. Hence #{X(G)}
 depends only on #{GG^{\mathsf T}}; take #{H=X}.}}
 
-\p{\strong{Status: source-reconstructed theorem.} See Theorem 4.5 and its
+\p{Source note: see Theorem 4.5 and its
 proof in Appendix B.6 of \citef{singh2026lossbasis}. It classifies the
 full-rank stratum only.}

--- a/trees/ftip-00BN.tree
+++ b/trees/ftip-00BN.tree
@@ -20,7 +20,7 @@ of the clock in \ref{ftip-00BM}, and put
 #{\dot\theta=-\nabla L/a(t)} by #{dt/d\tau} yields the displayed gradient
 flow.}}
 
-\p{\strong{Status: source-reconstructed theorem.} See Theorem 4.6 and its
+\p{Source note: see Theorem 4.6 and its
 proof in Appendix B.9 of \citef{singh2026lossbasis}. Gauge invariance of #{a}
 is not needed for this
 single-trajectory clock identity; it makes the clock common across a gauge

--- a/trees/ftip-00BR.tree
+++ b/trees/ftip-00BR.tree
@@ -24,6 +24,6 @@ low-recovery-error regime.}
  {spectral schedule and budget remain separate coordinates};
 \end{tikzpicture}}
 
-\p{\strong{Status: source-observed controls, Remark 4.7 and Appendix D.10}
+\p{Source note: the controls are reported in Remark 4.7 and Appendix D.10
 of \citef{singh2026lossbasis}. The source reports no tuned reproducibility
 baseline for the ScaledGD control. The diagram is not a convergence theorem.}

--- a/trees/ftip-00BV.tree
+++ b/trees/ftip-00BV.tree
@@ -19,6 +19,6 @@ in \ref{ftip-00BU}.}
 }
 }
 
-\p{\strong{Status: FTIP-proved proposition.} It is a sufficient condition
+\p{This is a sufficient condition
 on a declared orbit, not a claim that equivariance is necessary for every
 possible equality of represented trajectories.}

--- a/trees/ftip-00BW.tree
+++ b/trees/ftip-00BW.tree
@@ -18,7 +18,7 @@ alone.}
 the same represented next state. The witnessed inequality contradicts that
 factorization.}}
 
-\p{\strong{Status: FTIP-proved finite falsifier.} Proposition
+\p{Proposition
 \ref{ftip-00BE} and \ref{ftip-00BF} instantiate its premise for one
 factored quadratic and zero-state Adam. It proves underspecification, not a
 capability difference.}

--- a/trees/ftip-00BY.tree
+++ b/trees/ftip-00BY.tree
@@ -13,7 +13,7 @@ modular addition. The reported relative logit distance after one Adam step is
 #{3.6\times10^{-3}}, versus #{2.9\times10^{-7}} for a same-basis noise twin;
 the final per-head invariant distance is reported as 56 percent.}
 
-\p{\strong{Status: source-observed experiment.} The exact first-step defect
+\p{Source note: the exact first-step defect
 has an algebraic explanation, but later drift, scale robustness, and downstream
 behavior are empirical. The tested small transformers, precision, optimizer
 allocation, seeds, and task do not establish a frontier-wide law.}

--- a/trees/ftip-00C0.tree
+++ b/trees/ftip-00C0.tree
@@ -30,4 +30,5 @@ turned into a probability-one statement without a law for the gradient.}
 \p{Four scope repairs are equally material. The coordinatewise theorem is a
 zero-state, memoryless obstruction. The clock theorem is continuous-time and
 excludes scalar-Adam's momentum. Experimental optimizer and attention results
-remain source-observed. Equivariance is not identified with low-rank recovery.}
+remain observations reported by the source. Equivariance is not identified
+with low-rank recovery.}

--- a/trees/ftip-00C9.tree
+++ b/trees/ftip-00C9.tree
@@ -11,7 +11,7 @@
 initial state, event sequence, version sequence, and fold maps produces the
 same state #{h_n}.}
 
-\p{This is an FTIP-proved finite result. It assumes exact equality of all
+\p{This finite result follows from the displayed hypotheses. It assumes exact equality of all
 recorded inputs and deterministic fold maps.}
 
 \proof{At step zero both replays have state #{h_0}. If their states agree at

--- a/trees/ftip-00CI.tree
+++ b/trees/ftip-00CI.tree
@@ -15,7 +15,7 @@ C_{\rm lin}(\mathcal T)=c_r+
 \sum_{j=1}^{k}C_{\rm lin}(\mathcal T_{v_j}).
 }
 
-\p{This is an FTIP-proved finite accounting identity. It depends on assigning
+\p{This finite accounting identity follows from assigning
 each local cost to exactly one node.}
 
 \proof{The node set is the disjoint union of #{\{r\}} and the node sets of

--- a/trees/ftip-00CK.tree
+++ b/trees/ftip-00CK.tree
@@ -13,7 +13,7 @@
 #{c_i\preceq\bar c_i}. With #{a_{i+1}=a_i+c_i}, every accumulated cost
 satisfies #{a_i\preceq b}.}
 
-\p{This is an FTIP-proved finite result. It is a contract theorem, not a
+\p{This finite result is a contract theorem, not a
 prediction that a real executor respects its declared bound.}
 
 \proof{The claim holds for #{a_0}. If #{a_i\preceq b} and the next step is

--- a/trees/ftip-00CS.tree
+++ b/trees/ftip-00CS.tree
@@ -11,7 +11,7 @@
 research-decision kernel uses the complete archive only through #{C(A)}. If
 #{A\sim_C A'}, then its decision laws under #{A} and #{A'} are equal.}
 
-\p{This is an FTIP-proved finite information-boundary result. It does not
+\p{This finite information-boundary result follows from the displayed setup. It does not
 assume that the two complete archives induce the same independent utility.}
 
 \proof{

--- a/trees/ftip-00D2.tree
+++ b/trees/ftip-00D2.tree
@@ -17,5 +17,5 @@ inclusion gives #{k\in\mathcal K_m} for every later version, so the maximum
 defining #{B(h_m)} remains one. The final qualification lists operations that
 break the inclusion or change the predicate.}
 
-\p{This FTIP-proved finite observation concerns retained state. It does not
+\p{This finite observation concerns retained state. It does not
 say that the selector will invoke the exploit on every later run.}

--- a/trees/ftip-00D4.tree
+++ b/trees/ftip-00D4.tree
@@ -20,6 +20,6 @@ false-negative rate is at most #{\bar\eta\in[0,1]}, then}
 Conditioning on #{Z_n=1} and applying the false-negative bound proves the
 inequality.}
 
-\p{This FTIP-proved statement bounds one declared admission channel. It gives
+\p{This statement bounds one declared admission channel. It gives
 no bound when proposals bypass the audit, when the contract omits the exploit,
 or when the audit's conditional error changes under adaptive search.}

--- a/trees/ftip-00G1.tree
+++ b/trees/ftip-00G1.tree
@@ -3,7 +3,7 @@
 \taxon{Remark}
 \title{A coupling does not merge estimands}
 \tag{ftip}
-\p{\ref{ftip-00FF} is FTIP-proved. A shared seed can make a paired
+\p{The result in \ref{ftip-00FF} follows from its displayed hypotheses. A shared seed can make a paired
 comparison precise while the changed task law, evaluator, or inference budget
 still changes the estimand. No causal effect follows without a declared
 intervention and matched coordinates.}

--- a/trees/ftip-00I0.tree
+++ b/trees/ftip-00I0.tree
@@ -4,6 +4,6 @@
 \title{Handoff to the theorem ledger}
 \tag{ftip}
 \p{The next lane should freeze the machine-checkable signatures of the finite
-results already marked FTIP-proved, together with domains, source boundaries,
-counterexamples, and transfer limits. Lean implementation remains outside
-this protocol note.}
+results already proved from their declared setups, together with domains, source
+boundaries, counterexamples, and transfer limits. Lean implementation remains
+outside this protocol note.}

--- a/trees/ftip-00I7.tree
+++ b/trees/ftip-00I7.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} Under the independent events and probabilities declared in \ref{ftip-0077}, the finite discovery identity in \ref{ftip-0078} is a ledger-ready theorem: #{B\in\mathbb N}, #{\Pr(D_B)=1-\prod_{i=1}^{B}(1-p_i)}.}
+\p{Under the independent events and probabilities declared in \ref{ftip-0077}, the finite discovery identity in \ref{ftip-0078} is a ledger-ready theorem: #{B\in\mathbb N}, #{\Pr(D_B)=1-\prod_{i=1}^{B}(1-p_i)}.}

--- a/trees/ftip-00I8.tree
+++ b/trees/ftip-00I8.tree
@@ -5,7 +5,7 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{This is FTIP-proved. Under #{0<p<1}, #{0<\delta<1}, and an integer budget #{B\geq1}, the failure constraint is equivalent to the following bound.}
+\p{Under #{0<p<1}, #{0<\delta<1}, and an integer budget #{B\geq1}, the failure constraint is equivalent to the following bound.}
 
 ##{B\geq\left\lceil\frac{\log\delta}{\log(1-p)}\right\rceil.}
 

--- a/trees/ftip-00I9.tree
+++ b/trees/ftip-00I9.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} Under the finite-carrier and positive-temperature hypotheses of \ref{ftip-007C}, normalized exponential tilting preserves the base law's positive support.}
+\p{Under the finite-carrier and positive-temperature hypotheses of \ref{ftip-007C}, normalized exponential tilting preserves the base law's positive support.}

--- a/trees/ftip-00IA.tree
+++ b/trees/ftip-00IA.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} For a finite common feasible set and a common regularizer, the uniform proxy error hypothesis in \ref{ftip-007G} yields the two-epsilon objective regret bound proved in \ref{ftip-007H}; the conclusion concerns the regularized objective named there.}
+\p{For a finite common feasible set and a common regularizer, the uniform proxy error hypothesis in \ref{ftip-007G} yields the two-epsilon objective regret bound proved in \ref{ftip-007H}; the conclusion concerns the regularized objective named there.}

--- a/trees/ftip-00IB.tree
+++ b/trees/ftip-00IB.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} If the evaluation laws and finite response space satisfy the total-variation hypotheses of \ref{ftip-00GM}, then the expectation difference is bounded by the stated sup-norm times total variation.}
+\p{If the evaluation laws and finite response space satisfy the total-variation hypotheses of \ref{ftip-00GM}, then the expectation difference is bounded by the stated sup-norm times total variation.}

--- a/trees/ftip-00IC.tree
+++ b/trees/ftip-00IC.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} For finite response set #{\mathcal Y} and deterministic rewards, a reward channel that refines the equality partition of another channel separates at least as many response classes, as proved in \ref{ftip-00AG}.}
+\p{For finite response set #{\mathcal Y} and deterministic rewards, a reward channel that refines the equality partition of another channel separates at least as many response classes, as proved in \ref{ftip-00AG}.}

--- a/trees/ftip-00IJ.tree
+++ b/trees/ftip-00IJ.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} If the execution map is deterministic in all coordinates fixed by \ref{ftip-00HF}, then equal input, revision, environment, and seed records produce equal finite traces, as proved in \ref{ftip-00HG}.}
+\p{If the execution map is deterministic in all coordinates fixed by \ref{ftip-00HF}, then equal input, revision, environment, and seed records produce equal finite traces, as proved in \ref{ftip-00HG}.}

--- a/trees/ftip-00IK.tree
+++ b/trees/ftip-00IK.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} For the finite transcript and world kernels declared in \ref{ftip-008C}--\ref{ftip-008D}, observationally equivalent worlds induce the same output law for any common randomized post-training kernel, as proved in \ref{ftip-007S}.}
+\p{For the finite transcript and world kernels declared in \ref{ftip-008C}--\ref{ftip-008D}, observationally equivalent worlds induce the same output law for any common randomized post-training kernel, as proved in \ref{ftip-007S}.}

--- a/trees/ftip-00IL.tree
+++ b/trees/ftip-00IL.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} Under the typed audit record of \ref{ftip-00HL}, a commit is admissible exactly when all required checks pass, the digest matches, and the recorded decision is #{commit}, as proved in \ref{ftip-00HM}.}
+\p{Under the typed audit record of \ref{ftip-00HL}, a commit is admissible exactly when all required checks pass, the digest matches, and the recorded decision is #{commit}, as proved in \ref{ftip-00HM}.}

--- a/trees/ftip-00IM.tree
+++ b/trees/ftip-00IM.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} A finite audit plan with nonnegative stage costs is admissible exactly when its declared additive cost is within budget; adding a positive stage beyond slack is inadmissible, by \ref{ftip-00HX}.}
+\p{A finite audit plan with nonnegative stage costs is admissible exactly when its declared additive cost is within budget; adding a positive stage beyond slack is inadmissible, by \ref{ftip-00HX}.}

--- a/trees/ftip-00IU.tree
+++ b/trees/ftip-00IU.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} If every ledger card references only an earlier card in the canonical order and each referenced carrier is introduced before use, the induced dependency graph is acyclic.}
+\p{If every ledger card references only an earlier card in the canonical order and each referenced carrier is introduced before use, the induced dependency graph is acyclic.}

--- a/trees/ftip-00IX.tree
+++ b/trees/ftip-00IX.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{An instance is #{B:\mathbb N,\ p_i:[0,1],\ E_i:\mathsf{Prop}} with independence as a hypothesis and conclusion #{\Pr(D_B)=1-\prod_{i=1}^{B}(1-p_i)}. Its status is FTIP-PROVED and its proof owner is \ref{ftip-0078}.}
+\p{An instance is #{B:\mathbb N,\ p_i:[0,1],\ E_i:\mathsf{Prop}} with independence as a hypothesis and conclusion #{\Pr(D_B)=1-\prod_{i=1}^{B}(1-p_i)}. Its proof owner is \ref{ftip-0078}.}

--- a/trees/ftip-00J1.tree
+++ b/trees/ftip-00J1.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} If two ledger theorems have disjoint conclusions and the conclusion of the first is an explicit hypothesis of the second, their conjunction is a valid finite composition under the union of their hypotheses.}
+\p{If two ledger theorems have disjoint conclusions and the conclusion of the first is an explicit hypothesis of the second, their conjunction is a valid finite composition under the union of their hypotheses.}

--- a/trees/ftip-00J2.tree
+++ b/trees/ftip-00J2.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} A deterministic replay theorem and the audit gate compose only when the replay trace is included in the audited record and the digest covers that trace. Otherwise the composition is not licensed.}
+\p{A deterministic replay theorem and the audit gate compose only when the replay trace is included in the audited record and the digest covers that trace. Otherwise the composition is not licensed.}

--- a/trees/ftip-00J3.tree
+++ b/trees/ftip-00J3.tree
@@ -5,4 +5,7 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FINITE COUNTEREXAMPLE.} A statement that quantifies over a policy but omits its response carrier admits two incompatible interpretations and cannot be entered in the machine-checkable ledger. Adding #{\pi:\mathcal X\to\Delta(\mathcal Y)} repairs the signature.}
+\p{A finite counterexample shows that a statement which quantifies over a policy
+but omits its response carrier admits two incompatible interpretations and
+cannot be entered in the machine-checkable ledger. Adding
+#{\pi:\mathcal X\to\Delta(\mathcal Y)} repairs the signature.}

--- a/trees/ftip-00J5.tree
+++ b/trees/ftip-00J5.tree
@@ -5,4 +5,4 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{\strong{FTIP-PROVED.} A card is release-ready exactly when its status, typed domain, hypotheses, conclusion, backward dependencies, and transfer limits are all nonempty. This is a documentation predicate, not a theorem about the underlying model.}
+\p{A card is release-ready exactly when its typed domain, hypotheses, conclusion, backward dependencies, and transfer limits are all nonempty. This is a documentation predicate, not a theorem about the underlying model.}

--- a/trees/ftip-00JR.tree
+++ b/trees/ftip-00JR.tree
@@ -7,6 +7,6 @@
 \p{Consider a causal system whose state after each prefix has at most #{K}
 distinct values, and a task with #{K+1} prefixes requiring pairwise distinct
 continuation labels. By the pigeonhole principle two prefixes share a state,
-so at least one continuation label is wrong. This is an FTIP-proved toy
+so at least one continuation label is wrong. This is a finite toy
 obstruction only; it does not bound a concrete Transformer or KDA instance without a
 proved reduction to this state model.}


### PR DESCRIPTION
This change removes project-specific claim labels from the note prose and ledger.

- Removes remaining FTIP-PROVED, Status, and related badge wording.
- Places source locators after the statement or in a concluding source note.
- Preserves theorem content, citations, dependencies, and identifiers.
- Verified with just chk and the full CI=1 just build.