### PR TITLE
Simplify example narratives and calculations

### DIFF
--- a/trees/ftip-0004.tree
+++ b/trees/ftip-0004.tree
@@ -14,11 +14,11 @@ and budget alter measured success.}
     text width=28mm, minimum height=10mm},
   flow/.style={-{Stealth[length=2mm]}, thick}
 ]
-\node[box] (model) at (0,0) {one model\\success mass $p=.6$};
-\node[box] (one) at (4.0,1.25) {one draw\\budget $b_1=1$};
-\node[box] (three) at (4.0,-1.25) {up to three draws\\budget $b_3=3$};
-\node[box] (jone) at (8.0,1.25) {$J_1=.6$};
-\node[box] (jthree) at (8.0,-1.25) {$J_3=.936$};
+\node[box] (model) at (0,0) {one model\\success mass $p$};
+\node[box] (one) at (4.0,1.25) {one draw\\budget $1$};
+\node[box] (three) at (4.0,-1.25) {up to $k$ draws\\budget $k$};
+\node[box] (jone) at (8.0,1.25) {success $p$};
+\node[box] (jthree) at (8.0,-1.25) {success $1-(1-p)^k$};
 \draw[flow] (model) -- (one);
 \draw[flow] (model) -- (three);
 \draw[flow] (one) -- (jone);
@@ -27,15 +27,15 @@ and budget alter measured success.}
 
 \p{Assume independent draws and a declared perfect checker that recognizes a
 correct candidate when one appears. The one-draw procedure succeeds with
-#{J_1=p=0.6}. The three-draw procedure succeeds whenever not all three draws
+#{J_1=p}. A procedure allowed up to #{k} draws succeeds whenever not all draws
 fail:
 ##{
-  J_3=1-(1-p)^3=1-0.4^3=0.936.
+  J_k=1-(1-p)^k.
 }
 Both procedures query the same conditional distribution.}
 
 \p{Policy performance under a specified interaction and evaluation procedure
-is standard in \citet{Section 3.5}{sutton2018reinforcement}. The arithmetic
+is standard in \citet{Section 3.5}{sutton2018reinforcement}. The formula
 demonstrates procedural dependence. Independence and a perfect checker are
 declared toy assumptions, not properties attributed to a frontier language
 model.}

--- a/trees/ftip-000J.tree
+++ b/trees/ftip-000J.tree
@@ -7,7 +7,7 @@
 \tag{language-model}
 \tag{probability}
 
-\p{Along one branch of a three-symbol prefix tree, edge probabilities
+\p{Along one branch of a three-symbol prefix tree, conditional token laws
 determine both continuation probability and negative log-likelihood.}
 
 \tikzfig{\begin{tikzpicture}[
@@ -19,24 +19,19 @@ determine both continuation probability and negative log-likelihood.}
 \node[state] (p1) at (2.7,0) {$ab$};
 \node[state] (p2) at (5.4,0) {$aba$};
 \node[state] (p3) at (8.1,0) {$aba\mathtt{EOS}$};
-\node[font=\scriptsize] (o1) at (2.7,-1.2) {other mass $1/2$};
-\node[font=\scriptsize] (o2) at (5.4,-1.2) {other mass $3/4$};
-\node[font=\scriptsize] (o3) at (8.1,-1.2) {other mass $1/5$};
-\draw[flow] (p0) -- node[font=\scriptsize, fill=white] {$b:1/2$} (p1);
-\draw[flow] (p1) -- node[font=\scriptsize, fill=white] {$a:1/4$} (p2);
-\draw[flow] (p2) -- node[font=\scriptsize, fill=white] {$\mathtt{EOS}:4/5$} (p3);
-\draw[dashed] (p0) -- (o1);
-\draw[dashed] (p1) -- (o2);
-\draw[dashed] (p2) -- (o3);
+\draw[flow] (p0) -- node[font=\scriptsize, fill=white] {$p_1$} (p1);
+\draw[flow] (p1) -- node[font=\scriptsize, fill=white] {$p_2$} (p2);
+\draw[flow] (p2) -- node[font=\scriptsize, fill=white] {$p_3$} (p3);
 \end{tikzpicture}}
 
-\p{Let the vocabulary be #{\{a,b,\mathtt{EOS}\}} and declare the three edge
-probabilities shown above. The continuation #{(b,a,\mathtt{EOS})} has
+\p{Let the vocabulary be #{\{a,b,\mathtt{EOS}\}} and let #{p_i} be the
+displayed conditional probability at step #{i}. The continuation
+#{(b,a,\mathtt{EOS})} has
 ##{
  \Pr(b,a,\mathtt{EOS}\mid a)
- =\tfrac12\cdot\tfrac14\cdot\tfrac45=\tfrac1{10},
+ =p_1p_2p_3,
  \qquad
- -\log\Pr=\log 10\approx2.303.
+ -\log\Pr=-\sum_{i=1}^{3}\log p_i.
 }}
 
 \p{The multiplication follows the causal product in

--- a/trees/ftip-000T.tree
+++ b/trees/ftip-000T.tree
@@ -7,8 +7,8 @@
 \tag{transformer}
 \tag{attention}
 
-\p{For four positions, the displayed causal mask identifies every key
-visible to each query.}
+\p{For four positions, a causal mask admits the current and earlier keys and
+excludes every future key.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
@@ -21,18 +21,14 @@ visible to each query.}
 0&0&0&-\infty\\
 0&0&0&0
 \end{smallmatrix}\right]$};
-\node[box] (row) at (6.0,0) {row $3$: $(1,0,2,5)+M_{3,:}$\\
-$=(1,0,2,-\infty)$};
-\draw[flow] (mask) -- node[font=\scriptsize, fill=white] {add to logits} (row);
+\node[box] (row) at (6.0,0) {query position $3$\\keys $1,2,3$ visible\\key $4$ excluded};
+\draw[flow] (mask) -- (row);
 \end{tikzpicture}}
 
-\p{Rows index querying positions and columns index key positions. For row
-three, exponentiating the masked logits gives
-#{(e,1,e^2,0)}. Hence its normalized weights are
-##{
- \frac{(e,1,e^2,0)}{e+1+e^2},
-}
-and the fourth token contributes exactly zero to position three.}
+\p{Rows index querying positions and columns index key positions. In row
+three, the first three entries remain available and the fourth receives
+#{-\infty}; after softmax the fourth token therefore contributes exactly
+zero.}
 
 \p{The construction is the autoregressive mask of
 \citet{Section 3.2.3}{vaswani2017attention}. It enforces a dependency

--- a/trees/ftip-000Z.tree
+++ b/trees/ftip-000Z.tree
@@ -7,8 +7,9 @@
 \tag{mixture-of-experts}
 \tag{deepseek}
 
-\p{A four-expert toy router permits an explicit top-two mixture before
-comparison with current DeepSeek-V4-Flash-0731 configuration fields.}
+\p{A routed mixture-of-experts layer uses router scores to activate only a
+declared subset of routed experts, then combines their outputs with any shared
+expert path.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
@@ -16,31 +17,18 @@ comparison with current DeepSeek-V4-Flash-0731 configuration fields.}
   flow/.style={-{Stealth[length=2mm]}, thick},
   dropped/.style={-{Stealth[length=2mm]}, dashed}
 ]
-\node[box] (router) at (0,0) {router logits\\$(2,1,0,-1)$};
-\node[box] (e1) at (3.4,1.5) {$E_1(h)=1$\\selected};
-\node[box] (e2) at (3.4,0.5) {$E_2(h)=3$\\selected};
-\node[box] (e3) at (3.4,-0.5) {$E_3$\\dropped};
-\node[box] (e4) at (3.4,-1.5) {$E_4$\\dropped};
-\node[box] (mix) at (7.4,0) {weighted output\\$1.538$};
-\draw[flow] (router) -- (e1);
-\draw[flow] (router) -- (e2);
-\draw[dropped] (router) -- (e3);
-\draw[dropped] (router) -- (e4);
-\draw[flow] (e1) -- (mix);
-\draw[flow] (e2) -- (mix);
+\node[box] (token) at (0,0) {token state\\$h$};
+\node[box] (router) at (3.0,0) {router\\top-$k$ selection};
+\node[box] (experts) at (6.0,0) {selected routed\\experts};
+\node[box] (mix) at (9.0,0) {shared and routed\\expert output};
+\draw[flow] (token) -- (router);
+\draw[flow] (router) -- (experts);
+\draw[flow] (experts) -- (mix);
 \end{tikzpicture}}
 
-\p{\strong{SCHEMATIC.} Retaining logits #{2} and #{1} gives normalized
-weights
-#{(e/(e+1),1/(e+1))\approx(0.731,0.269)}. Thus
-##{
-  y=0.731\,E_1(h)+0.269\,E_2(h)
-    =0.731+0.807=1.538.
-}}
-
-\p{\strong{DIRECT.} The revision-pinned configuration
+\p{The revision-pinned configuration
 \citelink{https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/7872f01b1d1fe23eabc4c98b48bffcef5a386062/config.json}
 declares #{256} routed experts, #{6} experts selected per token, and one
-shared expert. The four-expert arithmetic illustrates only the top-k
-interface. No reconstruction of the artifact's router logits, load
-balancing, or expert outputs is intended.}
+shared expert. This instantiates the selection interface while leaving the
+artifact's router scores, load-balancing mechanism, and expert outputs
+unspecified.}

--- a/trees/ftip-0013.tree
+++ b/trees/ftip-0013.tree
@@ -7,8 +7,9 @@
 \tag{transformer}
 \tag{deepseek}
 
-\p{Two aligned rows juxtapose a finite decoder shape trace with the
-provenance boundary around DeepSeek-V4-Flash-0731.}
+\p{A decoder pipeline maps token identifiers through hidden states to logits;
+the released model instance and family report provide different evidence
+about that pipeline.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
@@ -18,31 +19,26 @@ provenance boundary around DeepSeek-V4-Flash-0731.}
   unknown/.style={-{Stealth[length=2mm]}, thick, dotted}
 ]
 \node[box] (ids) at (0,1.35) {three\\token IDs};
-\node[box] (h0) at (2.7,1.35) {$H^{(0)}$\\shape $3\times4$};
-\node[box] (blocks) at (5.4,1.35) {two causal\\blocks};
-\node[box] (logits) at (8.1,1.35) {logits\\shape $3\times3$};
+\node[box] (h0) at (2.7,1.35) {hidden\\states};
+\node[box] (blocks) at (5.4,1.35) {causal\\blocks};
+\node[box] (logits) at (8.1,1.35) {next-token\\logits};
 \draw[flow] (ids) -- (h0);
 \draw[flow] (h0) -- (blocks);
 \draw[flow] (blocks) -- (logits);
 \node[box] (artifact) at (0,-1.35) {V4-Flash-0731\\artifact};
-\node[box] (direct) at (2.7,-1.35) {DIRECT\\pinned config};
-\node[box] (family) at (5.4,-1.35) {INHERITED\\family report};
-\node[box] (delta) at (8.1,-1.35) {UNKNOWN\\0731 delta};
+\node[box] (direct) at (2.7,-1.35) {pinned\\configuration};
+\node[box] (family) at (5.4,-1.35) {family\\report};
+\node[box] (delta) at (8.1,-1.35) {0731-specific\\delta unknown};
 \draw[flow] (artifact) -- (direct);
 \draw[inherited] (artifact) to[bend left=12] (family);
 \draw[unknown] (artifact) to[bend left=18] (delta);
 \end{tikzpicture}}
 
-\p{\strong{SCHEMATIC.} For a toy vocabulary of size #{3}, sequence length
-#{3}, hidden width #{4}, and two blocks, the shapes are
-#{(3)\to(3\times4)\to(3\times4)\to(3\times3)}; the last logit row determines
-the next-token law.}
-
-\p{\strong{DIRECT.} The pinned configuration
+\p{The pinned configuration
 \citelink{https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/7872f01b1d1fe23eabc4c98b48bffcef5a386062/config.json}
 declares 43 layers, hidden width 4096, 64 attention heads, and one
-key--value head. \strong{INHERITED.} Section 2 of the family report
+key--value head. Section 2 of the family report
 \citelink{https://arxiv.org/abs/2606.19348} describes the preview
-architecture. \strong{UNKNOWN.} Neither source identifies a complete
-0731-specific architecture or training delta. The toy trace checks dimensions;
-it is not a small copy of the released model.}
+architecture. Neither source identifies a complete 0731-specific architecture
+or training delta. The diagram records the interface, not a small copy of the
+released model.}

--- a/trees/ftip-001D.tree
+++ b/trees/ftip-001D.tree
@@ -7,8 +7,8 @@
 \tag{pretraining}
 \tag{attention}
 
-\p{Packing two short documents into one row exposes the additional mask
-needed to prevent cross-document attention.}
+\p{Packing documents into one row requires a block-causal mask so that each
+token attends only within its own document and to earlier positions there.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
@@ -22,20 +22,10 @@ needed to prevent cross-document attention.}
 \draw[flow] (b) -- (pack);
 \end{tikzpicture}}
 
-\p{Index the packed row by #{1,\ldots,5}. Set #{M_{ij}=0} only when tokens
-#{i,j} belong to the same document and #{j\leq i}; otherwise set
-#{M_{ij}=-\infty}. Then
-##{
-M=\left[\begin{smallmatrix}
-0&-\infty&-\infty&-\infty&-\infty\\
-0&0&-\infty&-\infty&-\infty\\
--\infty&-\infty&0&-\infty&-\infty\\
--\infty&-\infty&0&0&-\infty\\
--\infty&-\infty&0&0&0
-\end{smallmatrix}\right].
-}
-In particular, position #{b_3} can inspect #{b_1,b_2,b_3} but not
-#{a_1,a_2}.}
+\p{For a packed row, set #{M_{ij}=0} only when tokens #{i,j} belong to the
+same document and #{j\leq i}; otherwise set #{M_{ij}=-\infty}. Thus a token
+in document #{B} cannot inspect any token in document #{A}, even when #{A}
+precedes #{B} in storage.}
 
 \p{The within-document triangle instantiates the causal mask in
 \ref{ftip-000S}. The block boundary instantiates the packing convention in

--- a/trees/ftip-001F.tree
+++ b/trees/ftip-001F.tree
@@ -7,38 +7,28 @@
 \tag{pretraining}
 \tag{loss}
 
-\p{Two equal-length records make the full empirical loss directly comparable
-with a one-record minibatch estimate.}
+\p{Two equal-length records make a full empirical loss directly comparable
+with a minibatch estimate, while exposing the assumptions behind unbiasedness.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
     text width=29mm, minimum height=11mm},
   flow/.style={-{Stealth[length=2mm]}, thick}
 ]
-\node[box] (a) at (0,1.15) {record $A$\\losses $(\log 2,\log 4)$};
-\node[box] (b) at (0,-1.15) {record $B$\\losses $(\log 5,\log 10)$};
-\node[box] (full) at (4.1,0) {four-token mean\\$\tfrac14\log 400$};
-\node[box] (batch) at (8.2,0) {batch $A$ mean\\$\tfrac12\log 8$};
+\node[box] (a) at (0,1.15) {record $A$\\token losses};
+\node[box] (b) at (0,-1.15) {record $B$\\token losses};
+\node[box] (full) at (4.1,0) {all-token\\mean};
+\node[box] (batch) at (8.2,0) {one-record\\minibatch mean};
 \draw[flow] (a) -- (full);
 \draw[flow] (b) -- (full);
 \draw[flow] (a) to[bend left=8] (batch);
 \end{tikzpicture}}
 
-\p{The full token-average negative log-likelihood is
-##{
- \widehat L
- =\frac{\log 2+\log 4+\log 5+\log 10}{4}
- =\frac{\log 400}{4}\approx1.498.
-}
-A minibatch containing only record #{A} gives
-##{
- \widehat L_A=\frac{\log 2+\log 4}{2}
- =\frac{\log 8}{2}\approx1.040.
-}
-Sampling one of the two equal-length records uniformly makes
-#{\mathbb E[\widehat L_{\rm batch}]=\widehat L}.}
+\p{Let #{\ell_{ij}} denote the token loss at position #{j} of record #{i}.
+The full token-average loss is the mean of all #{\ell_{ij}}, while a
+one-record minibatch averages only the losses from its sampled record. Uniform
+sampling of equal-length records makes the latter unbiased for the former.}
 
-\p{The preceding loss and estimator definitions specialize to the displayed
-numbers. Equal record lengths
-make the estimator unbiased here; unequal lengths, padding, dependence, and
-optimizer noise remain outside its scope.}
+\p{The preceding loss and estimator definitions apply to this equal-length
+record setup. Equal record lengths make the estimator unbiased here; unequal
+lengths, padding, dependence, and optimizer noise remain outside its scope.}

--- a/trees/ftip-001L.tree
+++ b/trees/ftip-001L.tree
@@ -24,24 +24,19 @@ evidence about how the corresponding weights were trained.}
 \draw[flow] (artifact) -- (weights);
 \draw[flow] (weights) -- (tokenizer);
 \draw[flow] (tokenizer) -- (config);
-\node[box] (direct) at (1.35,-1.35) {DIRECT\\0731 config};
-\node[box] (family) at (4.05,-1.35) {INHERITED\\optimizer/data report};
-\node[box] (delta) at (6.75,-1.35) {UNKNOWN\\0731 training delta};
+\node[box] (direct) at (1.35,-1.35) {0731\\configuration};
+\node[box] (family) at (4.05,-1.35) {family\\optimizer/data report};
+\node[box] (delta) at (6.75,-1.35) {0731 training\\delta unknown};
 \draw[flow] (artifact) -- (direct);
 \draw[inherited] (artifact) to[bend right=10] (family);
 \draw[unknown] (artifact) to[bend right=14] (delta);
 \end{tikzpicture}}
 
-\p{\strong{SCHEMATIC.} For a toy vocabulary size #{3} and width #{2}, an
-embedding component has shape #{3\times2} and therefore six scalar entries.
-The tokenizer must emit only indices #{0,1,2}; emitting index #{3} makes the
-manifest inconsistent before any probability is evaluated.}
-
-\p{\strong{DIRECT.} The pinned DeepSeek-V4-Flash-0731 configuration
+\p{The pinned DeepSeek-V4-Flash-0731 configuration
 \citelink{https://huggingface.co/deepseek-ai/DeepSeek-V4-Flash-0731/blob/7872f01b1d1fe23eabc4c98b48bffcef5a386062/config.json}
-declares architecture and numeric-format fields.
-\strong{INHERITED.} Sections 2.4 and 4 of the V4 family report
+declares architecture and numeric-format fields. Sections 2.4 and 4 of the
+V4 family report
 \citelink{https://arxiv.org/abs/2606.19348} describe a mixed
 Muon/AdamW optimizer allocation and pretraining data construction.
-\strong{UNKNOWN.} The exact 0731 data mixture, optimizer schedule, and
+The exact 0731 data mixture, optimizer schedule, and
 post-preview training delta remain undisclosed by those sources.}

--- a/trees/ftip-001U.tree
+++ b/trees/ftip-001U.tree
@@ -7,8 +7,8 @@
 \tag{evaluation}
 \tag{inference}
 
-\p{One fixed policy produces different measured success rates when evaluation
-stops after one rather than two tokens.}
+\p{One fixed policy can receive different measured success rates when the
+evaluation horizon changes.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
@@ -16,22 +16,21 @@ stops after one rather than two tokens.}
   flow/.style={-{Stealth[length=2mm]}, thick}
 ]
 \node[box] (policy) at (0,0) {one policy\\three complete outcomes};
-\node[box] (b1) at (4.0,1.25) {budget $b=1$\\accept short only};
-\node[box] (b2) at (4.0,-1.25) {budget $b=2$\\accept short or long};
-\node[box] (j1) at (8.0,1.25) {success probability\\$.3$};
-\node[box] (j2) at (8.0,-1.25) {success probability\\$.7$};
+\node[box] (b1) at (4.0,1.25) {short horizon\\accept short only};
+\node[box] (b2) at (4.0,-1.25) {longer horizon\\accept short or long};
+\node[box] (j1) at (8.0,1.25) {success\\short trajectories};
+\node[box] (j2) at (8.0,-1.25) {success\\short and long};
 \draw[flow] (policy) -- (b1);
 \draw[flow] (policy) -- (b2);
 \draw[flow] (b1) -- (j1);
 \draw[flow] (b2) -- (j2);
 \end{tikzpicture}}
 
-\p{Declare three mutually exclusive complete trajectories: a one-token
-correct answer with probability #{0.3}, a two-token correct answer with
-probability #{0.4}, and a wrong answer with probability #{0.3}. A truncation
-budget of one token observes success only on the first trajectory, giving
-#{0.3}. A budget of two observes both correct trajectories, giving
-#{0.3+0.4=0.7}.}
+\p{Partition complete trajectories into those that finish within the short
+horizon, those requiring additional tokens, and failures. The short protocol
+counts only the first class; the longer protocol may count the first two.
+Thus the measured score depends on the declared horizon even though the
+policy is unchanged.}
 
 \p{Making an evaluation horizon explicit follows finite-horizon policy
 evaluation in \citet{Chapter 3}{sutton2018reinforcement}. Only truncation is

--- a/trees/ftip-0027.tree
+++ b/trees/ftip-0027.tree
@@ -7,8 +7,8 @@
 \tag{language-model}
 \tag{environment}
 
-\p{A depth-two prefix tree represents token emission as a finite interaction
-stopped either by an end token or by a hard length cap.}
+\p{A prefix tree represents token emission as a finite interaction stopped
+either by an end token or by a hard length cap.}
 
 \tikzfig{\begin{tikzpicture}[
   state/.style={draw, rounded corners=2pt, align=center, font=\small,
@@ -20,21 +20,17 @@ stopped either by an end token or by a hard length cap.}
 \node[state] (a) at (3.0,-1.25) {$a$};
 \node[state] (ae) at (6.5,0) {$a\mathtt{EOS}$\\stop};
 \node[state] (aa) at (6.5,-2.0) {$aa$\\length stop};
-\draw[flow] (root) -- node[font=\scriptsize, fill=white] {$1/4$} (e0);
-\draw[flow] (root) -- node[font=\scriptsize, fill=white] {$3/4$} (a);
-\draw[flow] (a) -- node[font=\scriptsize, fill=white] {$1/2$} (ae);
-\draw[flow] (a) -- node[font=\scriptsize, fill=white] {$1/2$} (aa);
+\draw[flow] (root) -- (e0);
+\draw[flow] (root) -- (a);
+\draw[flow] (a) -- (ae);
+\draw[flow] (a) -- (aa);
 \end{tikzpicture}}
 
-\p{Take vocabulary #{\{a,\mathtt{EOS}\}}. The three terminal histories have
-probabilities
-##{
- \Pr(\mathtt{EOS})=\tfrac14,\qquad
- \Pr(a\mathtt{EOS})=\tfrac34\cdot\tfrac12=\tfrac38,\qquad
- \Pr(aa)=\tfrac34\cdot\tfrac12=\tfrac38,
-}
-which sum to one. The last history terminates because the declared maximum
-length is two, not because the policy emitted #{\mathtt{EOS}}.}
+\p{Take vocabulary #{\{a,\mathtt{EOS}\}}. The terminal histories are an
+immediate end token, an end token after #{a}, and a length-capped history
+#{aa}. Their probabilities are products of the conditional token laws and
+sum to one. The last history terminates because the declared maximum length
+is reached, not because the policy emitted #{\mathtt{EOS}}.}
 
 \p{The causal token product is given in
 \citet{Section 3}{phuong2022formal}. The finite representation distinguishes

--- a/trees/ftip-004N.tree
+++ b/trees/ftip-004N.tree
@@ -7,39 +7,38 @@
 \tag{rlvr}
 \tag{optimization}
 
-\p{Four binary rollout rewards yield group-relative advantages and four
-clipped surrogate terms.}
+\p{A rollout group is normalized to relative advantages and then passed to a
+clipped surrogate objective.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
     text width=29mm, minimum height=11mm},
   flow/.style={-{Stealth[length=2mm]}, thick}
 ]
-\node[box] (reward) at (0,0) {$r=(1,1,0,0)$\\$\bar r=1/2,\ s=1/2$};
-\node[box] (adv) at (4.0,0) {$\widehat A=(1,1,-1,-1)$\\
-$\rho=(1.3,.9,.7,1.1)$};
-\node[box] (terms) at (8.0,0) {clipped terms\\$(1.2,.9,-.8,-1.1)$};
+\node[box] (reward) at (0,0) {rollout\\rewards};
+\node[box] (adv) at (4.0,0) {group-relative\\advantages};
+\node[box] (terms) at (8.0,0) {clipped\\surrogate terms};
 \draw[flow] (reward) -- (adv);
 \draw[flow] (adv) -- node[font=\scriptsize, fill=white] {$\epsilon=.2$} (terms);
 \end{tikzpicture}}
 
-\p{Use the population standard deviation #{s=1/2}, so
-#{\widehat A_i=(r_i-\bar r)/s}. For current-to-behaviour ratios
-#{\rho=(1.3,0.9,0.7,1.1)} and clip interval #{[0.8,1.2]}, define each
-pointwise term by}
+\p{For a rollout group with rewards #{r_i}, form a group mean and scale and
+set #{\widehat A_i=(r_i-\bar r)/s}. For current-to-behaviour ratios #{\rho_i}
+and clip interval #{[1-\epsilon,1+\epsilon]}, define each pointwise term by}
 
 ##{
 \begin{aligned}
 \ell_i=\min\{&\rho_i\widehat A_i,\\
-&\operatorname{clip}(\rho_i,0.8,1.2)\widehat A_i\}.
+&\operatorname{clip}(\rho_i,1-\epsilon,1+\epsilon)\widehat A_i\}.
 \end{aligned}
 }
 
-\p{The four terms are #{(\ell_1,\ell_2,\ell_3,\ell_4)
-=(1.2,0.9,-0.8,-1.1)}, whose mean is #{0.05}.}
+\p{The mean of the resulting terms is the group contribution to the update;
+its value depends on the sampled rewards, ratios, and clip width.}
 
 \p{Group-relative normalization is grounded in
 \citet{Section 4.1}{shao2024deepseekmath}, while clipping is grounded in
-\citet{Section 3}{schulman2017proximal}. The chosen divisor and ratios are
-declared toy values; a positive surrogate mean alone gives no guarantee of
-improved held-out performance after an optimizer step.}
+\citet{Section 3}{schulman2017proximal}. The normalization convention and
+ratios must be declared by the training protocol; a positive surrogate mean
+alone gives no guarantee of improved held-out performance after an optimizer
+step.}

--- a/trees/ftip-004W.tree
+++ b/trees/ftip-004W.tree
@@ -16,29 +16,25 @@ a single rollout record.}
   flow/.style={-{Stealth[length=2mm]}, thick},
   inherited/.style={-{Stealth[length=2mm]}, thick, dashed}
 ]
-\node[box] (actor) at (0,1.35) {actor emits\\tokens $1{:}4$};
-\node[box] (wal) at (4.0,1.35) {token write-ahead log\\
-and key--value cache\\state at $4$};
-\node[box] (resume) at (8.0,1.35) {resume at\\token $5$};
+\node[box] (actor) at (0,1.35) {actor emits\\token stream};
+\node[box] (wal) at (4.0,1.35) {write-ahead log\\and key--value cache};
+\node[box] (resume) at (8.0,1.35) {resume from\\saved state};
 \node[box] (api) at (0,-1.35) {sandbox API\\job $j$};
-\node[box] (run) at (4.0,-1.35) {runtime\\limit $2$ s};
-\node[box] (evidence) at (8.0,-1.35) {evidence\\exit $0$, $3/3$ tests};
+\node[box] (run) at (4.0,-1.35) {runtime\\limit};
+\node[box] (evidence) at (8.0,-1.35) {evidence\\record};
 \draw[flow] (actor) -- (wal);
 \draw[inherited] (wal) -- node[font=\scriptsize, fill=white] {preempt/resume} (resume);
 \draw[flow] (api) -- (run);
 \draw[flow] (run) -- (evidence);
 \end{tikzpicture}}
 
-\p{\strong{SCHEMATIC.} If four emitted tokens each cost one generation unit,
-resuming from the displayed state avoids regenerating four units. The
-sandbox job then contributes the declared evidence tuple
-#{(j,\text{exit }0,\text{three tests passed})}.}
+\p{A write-ahead log and cached state allow a resumable rollout; a sandbox
+execution contributes a separately recorded evidence tuple. The two records
+should remain distinguishable when lifecycle cost is audited.}
 
-\p{\strong{INHERITED.} Token-granular write-ahead logging with key--value
-cache recovery and DeepSeek Elastic Compute (DSec), the report's named
-sandbox interface, are described
+\p{Token-granular write-ahead logging with key--value cache recovery and
+DeepSeek Elastic Compute (DSec), the report's named sandbox interface, are described
 in Sections 5.2.3 and 5.2.5 of the DeepSeek-V4 family report
-\citelink{https://arxiv.org/abs/2606.19348}.
-\strong{UNKNOWN.} The sources cited here leave open whether
-DeepSeek-V4-Flash-0731 used this job, resource limit, rollout schedule, or
-sandbox configuration.}
+\citelink{https://arxiv.org/abs/2606.19348}. The cited sources do not establish
+that DeepSeek-V4-Flash-0731 used this job, resource limit, rollout schedule,
+or sandbox configuration.}

--- a/trees/ftip-0067.tree
+++ b/trees/ftip-0067.tree
@@ -7,8 +7,8 @@
 \tag{compute}
 \tag{rollout}
 
-\p{A componentwise lifecycle allocation and a ten-rollout calculation separate
-resource accounting from finite observation probability.}
+\p{A componentwise lifecycle allocation separates resource accounting from
+the finite number of rollouts available for observation.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
@@ -16,11 +16,11 @@ resource accounting from finite observation probability.}
   flow/.style={-{Stealth[length=2mm]}, thick}
 ]
 \node[box] (budget) at (0,0) {componentwise\\budget $\mathbf B$};
-\node[box] (data) at (3.5,1.55) {data $0$ tokens\\feedback $20$ calls};
-\node[box] (roll) at (3.5,0) {rollouts\\$10$ attempts};
-\node[box] (verify) at (3.5,-1.55) {environment\\$40$ sandbox s};
-\node[box] (update) at (7.0,1.0) {updates $15\times10^{12}$ FLOPs\\storage $6$ GB};
-\node[box] (eval) at (7.0,-1.0) {evaluation\\$12$ calls};
+\node[box] (data) at (3.5,1.55) {data\\tokens};
+\node[box] (roll) at (3.5,0) {rollouts\\attempts};
+\node[box] (verify) at (3.5,-1.55) {environment\\time};
+\node[box] (update) at (7.0,1.0) {parameter\\updates};
+\node[box] (eval) at (7.0,-1.0) {evaluation\\calls};
 \draw[flow] (budget) -- (data);
 \draw[flow] (budget) -- (roll);
 \draw[flow] (budget) -- (verify);
@@ -28,23 +28,18 @@ resource accounting from finite observation probability.}
 \draw[flow] (budget) -- (eval);
 \end{tikzpicture}}
 
-\p{In the coordinate order of \ref{ftip-005H}, declare
-#{\mathbf B=(0,20,10,40,15,6,12)} with units respectively equal to data
-tokens, verifier calls, rollout attempts, sandbox seconds, trillions of
-floating-point operations, gigabytes, and evaluator calls. The rollout
-coordinate therefore permits #{N=10} independent attempts. If each attempt
-has declared success probability #{p=0.02}, then
+\p{In the coordinate order of \ref{ftip-005H}, declare a lifecycle budget
+vector #{\mathbf B}. Its rollout coordinate permits #{N} attempts. If each
+attempt has declared success probability #{p}, then
 ##{
- \Pr(\text{at least one success})=1-(1-p)^N
- =1-0.98^{10}\approx0.183
- \leq Np=0.2.
+ \Pr(\text{at least one success})=1-(1-p)^N\leq Np.
 }
 Only the rollout coordinate enters this calculation; no sum or conversion
-among the seven coordinates is defined.}
+among heterogeneous coordinates is defined.}
 
 \p{The finite bound is the union bound applied to Bernoulli rollouts;
 finite-horizon success probabilities are standard policy-evaluation objects
-in \citet{Section 3.5}{sutton2018reinforcement}. Independence is used only
-for the displayed exact probability. The seven-coordinate budget is
-illustrative: neither empirical optimality nor interchangeability of its
-heterogeneous units is inferred from it.}
+in \citet{Section 3.5}{sutton2018reinforcement}. Independence is needed only
+for the displayed exact expression. The budget vector is illustrative:
+neither empirical optimality nor interchangeability of heterogeneous units is
+inferred from it.}

--- a/trees/ftip-006B.tree
+++ b/trees/ftip-006B.tree
@@ -7,7 +7,7 @@
 \tag{checkpoint}
 \tag{trajectory}
 
-\p{Leading rank-one projectors encode a toy checkpoint direction without
+\p{Leading rank-one projectors encode a checkpoint direction without
 inheriting the arbitrary signs of singular vectors.}
 
 \tikzfig{\begin{tikzpicture}[
@@ -17,16 +17,11 @@ inheriting the arbitrary signs of singular vectors.}
     text width=36mm, minimum height=12mm},
   flow/.style={-{Stealth[length=2mm]}, thick}
 ]
-\node[box] (obs) at (0,1.25) {$L_1=\left[\begin{smallmatrix}1&0\\0&0\end{smallmatrix}\right]$\\
-$L_2=\left[\begin{smallmatrix}2&0\\0&0\end{smallmatrix}\right]$};
-\node[box] (proj) at (4.0,1.25) {$P_u=P_v=\left[\begin{smallmatrix}1&0\\0&0\end{smallmatrix}\right]$\\
-magnitudes $1,2$};
-\node[box] (forecast) at (8.0,1.25) {$\widehat L_3=\left[\begin{smallmatrix}3&0\\0&0\end{smallmatrix}\right]$};
-\node[wide] (jump) at (7.7,-1.35) {forecast checkpoint\\
-$\widehat W_3=W_2+\widehat L_3$};
-\node[wide] (recover) at (3.8,-1.35) {measured update\\
-$R=\left[\begin{smallmatrix}-.2&0\\0&0\end{smallmatrix}\right]$\\
-$W_{\rm rec}=\widehat W_3+R$};
+\node[box] (obs) at (0,1.25) {observed\\checkpoint deltas};
+\node[box] (proj) at (4.0,1.25) {sign-invariant\\projectors};
+\node[box] (forecast) at (8.0,1.25) {forecast\\next delta};
+\node[wide] (jump) at (7.7,-1.35) {forecast\\checkpoint};
+\node[wide] (recover) at (3.8,-1.35) {measured\\recovery update};
 \draw[flow] (obs) -- (proj);
 \draw[flow] (proj) -- node[font=\scriptsize, fill=white] {extrapolate} (forecast);
 \draw[flow] (forecast) -- (jump);
@@ -34,10 +29,10 @@ $W_{\rm rec}=\widehat W_3+R$};
 \end{tikzpicture}}
 
 \p{For either singular-vector representation #{(u,v)} or #{(-u,-v)}, the
-projectors #{P_u=uu^\top} and #{P_v=vv^\top} are unchanged. Extrapolating
-the observed magnitudes #{1,2} to #{3} gives the displayed
-#{\widehat L_3}; a measured recovery update #{R=-0.2P_u} then adjusts the
-jump without changing its represented one-dimensional subspace.}
+projectors #{P_u=uu^\top} and #{P_v=vv^\top} are unchanged. A trajectory
+forecaster can extrapolate the observed projector-aligned deltas to a next
+checkpoint, after which a measured recovery update can correct the forecast
+without changing the represented one-dimensional subspace.}
 
 \p{The history-to-delta-to-recovery order is a toy illustration of NExt,
 described in \citelink{https://arxiv.org/abs/2604.11446}. NExt models signed

--- a/trees/ftip-00CL.tree
+++ b/trees/ftip-00CL.tree
@@ -7,31 +7,30 @@
 \tag{compute}
 \tag{diagram}
 
-\p{Take two cost coordinates: thousands of output tokens and tool calls. The
-root delegates to two children, and the left child delegates once more.}
+\p{Use two cost coordinates, such as output tokens and tool calls. The root
+delegates to two children, and one child delegates once more.}
 
 \tikzfig{\begin{tikzpicture}[
  box/.style={draw,rounded corners,align=center,text width=29mm,
  minimum height=10mm,font=\small},
  arr/.style={->,>=stealth,semithick}
 ]
-\node[box] (r) at (0,1.8) {root $r$\\$c_r=(5,1)$};
-\node[box] (a) at (-3.0,0) {child $a$\\$c_a=(3,2)$};
-\node[box] (b) at (3.0,0) {child $b$\\$c_b=(4,0)$};
-\node[box] (d) at (-3.0,-1.8) {descendant $d$\\$c_d=(2,1)$};
+\node[box] (r) at (0,1.8) {root $r$\\local cost $c_r$};
+\node[box] (a) at (-3.0,0) {child $a$\\local cost $c_a$};
+\node[box] (b) at (3.0,0) {child $b$\\local cost $c_b$};
+\node[box] (d) at (-3.0,-1.8) {descendant $d$\\local cost $c_d$};
 \draw[arr] (r) -- (a);
 \draw[arr] (r) -- (b);
 \draw[arr] (a) -- (d);
 \path (0,-2.6);
 \end{tikzpicture}}
 
-\p{The child-subtree costs are #{C_{\rm lin}(\mathcal T_a)=(5,3)} and
-#{C_{\rm lin}(\mathcal T_b)=(4,0)}. Therefore}
+\p{The cost of a child subtree is its local cost plus the costs of all
+descendants. Therefore}
 
 ##{
-C_{\rm lin}(\mathcal T)=(5,1)+(5,3)+(4,0)=(14,4).
+C_{\rm lin}(\mathcal T)=c_r+C_{\rm lin}(\mathcal T_a)+C_{\rm lin}(\mathcal T_b).
 }
 
-\p{Charging only the root would hide nine thousand output tokens and three
-tool calls. Charging descendant work both locally and again at the parent
-would double count it.}
+\p{Charging only the root hides descendant work; charging a descendant again
+as a separate parent-local cost double counts it.}


### PR DESCRIPTION
This pass revises fifteen examples whose numerical detail obscured the concept being illustrated.

Changes:
- Replace arbitrary toy values with symbolic variables when the formula, not the number, is the point.
- Retain exact values only for mathematical witnesses or source-reported measurements.
- Reframe architecture and artifact examples around declared setup, mechanism, and evidence boundaries.
- Simplify the checkpoint, routing, lifecycle, stopping, and optimizer narratives.
- Remove remaining visible provenance headings from the revised examples.

The changes do not add sections, alter theorem statements, or change the transclusion graph. The mandatory 006B example now presents the history-to-forecast-to-recovery mechanism without dense matrices. Diagram geometry is addressed in the following focused pass, including 00CW.

Local gates: just chk, CI=1 just build, explicit FTIP PDF render, and adversarial scans passed.
