### PR TITLE
Improve diagram spacing and flow clarity

### DIFF
--- a/trees/ftip-006B.tree
+++ b/trees/ftip-006B.tree
@@ -12,20 +12,18 @@ inheriting the arbitrary signs of singular vectors.}
 
 \tikzfig{\begin{tikzpicture}[
   box/.style={draw, rounded corners=2pt, align=center, font=\small,
-    text width=28mm, minimum height=12mm},
+  text width=22mm, minimum height=12mm},
   wide/.style={draw, rounded corners=2pt, align=center, font=\small,
-    text width=36mm, minimum height=12mm},
+  text width=24mm, minimum height=12mm},
   flow/.style={-{Stealth[length=2mm]}, thick}
 ]
-\node[box] (obs) at (0,1.25) {observed\\checkpoint deltas};
-\node[box] (proj) at (4.0,1.25) {sign-invariant\\projectors};
-\node[box] (forecast) at (8.0,1.25) {forecast\\next delta};
-\node[wide] (jump) at (7.7,-1.35) {forecast\\checkpoint};
-\node[wide] (recover) at (3.8,-1.35) {measured\\recovery update};
+\node[box] (obs) at (0,0) {observed\\checkpoint deltas};
+\node[box] (proj) at (2.7,0) {sign-invariant\\projectors};
+\node[box] (forecast) at (5.4,0) {forecast\\next delta};
+\node[wide] (recover) at (8.1,0) {measured\\recovery update};
 \draw[flow] (obs) -- (proj);
-\draw[flow] (proj) -- node[font=\scriptsize, fill=white] {extrapolate} (forecast);
-\draw[flow] (forecast) -- (jump);
-\draw[flow] (jump) -- (recover);
+\draw[flow] (proj) -- (forecast);
+\draw[flow] (forecast) -- (recover);
 \end{tikzpicture}}
 
 \p{For either singular-vector representation #{(u,v)} or #{(-u,-v)}, the

--- a/trees/ftip-00CW.tree
+++ b/trees/ftip-00CW.tree
@@ -7,16 +7,15 @@
 \tag{research-state}
 \tag{diagram}
 
-\p{The Grothendieck case study gives a concrete chronology. An early fast
-evaluator carried an exploration-only caveat; the working summary later lost
-that caveat and a feasibility condition; a later session recorded an
-unsupported upper bound; a subsequent audit withdrew it.}
+\p{The Grothendieck case study gives a concrete chronology. An early evaluator
+carried an exploration-only caveat; the working summary later lost that caveat
+and a feasibility condition; a later session recorded an unsupported upper
+bound; a subsequent audit withdrew it.}
 
 \tikzfig{\begin{tikzpicture}[
- box/.style={draw,rounded corners,align=center,text width=28mm,
+ box/.style={draw,rounded corners,align=center,text width=25mm,
  minimum height=10mm,font=\small},
  arr/.style={->,>=stealth,semithick},
- lab/.style={font=\scriptsize,fill=white,inner sep=1pt}
 ]
 \node[box] (a) at (-4.2,0) {session 4\\evaluator caveat};
 \node[box] (b) at (-1.4,0) {session 8\\feasibility rule};
@@ -27,8 +26,7 @@ unsupported upper bound; a subsequent audit withdrew it.}
 \draw[arr] (b) -- (c);
 \draw[arr] (c) -- (d);
 \draw[arr] (d) -- (e);
-\draw[arr,dashed] (a) to[bend right=24]
- node[lab,below]{archive retrieval} (e);
+\draw[arr,dashed] (a) to[bend right=22] (e);
 \end{tikzpicture}}
 
 \p{The source reports this sequence in Section 5 and Section 7.1; the


### PR DESCRIPTION
This change redraws the two reported diagrams without changing their claims.

- Simplify the checkpoint-trajectory flow in ftip-006B so each step and arrow is legible.
- Space the chronology and audit nodes in ftip-00CW so nodes and connectors do not overlap.
- Remove nonessential edge text from both figures.

Validation: just chk, git diff --check, CI=1 just build, explicit ftip-0001 PDF render, just verify-render, and visual inspection of both affected pages.