### PR TITLE
Add a reader route through the note suite

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -58,6 +58,34 @@ clipping, and reward design.}
 remark identifies the contributing literature and the questions created by
 that combination.}
 
+\section{How to read these notes}{
+\p{The motivating question is conditional: under a declared task, evaluation
+law, intervention, and scalar resource budget, what reliable capability can a
+specified model instance support, and which changes are attributable to the
+intervention? The note does not assign a context-free intelligence number.}
+
+\p{Read Chapter 1 for the shared model, task, environment, intervention, and
+evaluation interfaces. Chapter 2 fixes the training, post-training,
+alignment, preference, and feedback routes. Chapter 3 develops identification,
+finite limits, and evidence transport. Chapter 5 treats retained state,
+replay, lifecycle, recovery, and reliability. Chapter 6 collects the
+dependency-ordered statements and their assumptions for later formalization.}
+
+\p{Chapter 4 is an optional refinement. Enter it only when a claim names an
+architecture or a computation method: it starts from the decoder-only
+autoregressive reference, then adds only the architecture, optimizer, and
+systems fields needed by the comparison. Its model-instance worksheets and
+cost frontiers are interpreted through the evaluation and reliability rules
+from Chapters 3 and 5; they do not replace the architecture-neutral route.}
+
+\p{A practical reading order is therefore Chapters 1--3, then Chapter 5, and
+finally Chapter 6. For an architecture comparison, insert Chapter 4 between
+Chapters 1 and 3 and carry its declared budgets and transfer limits into the
+later evaluation. Source observations, finite consequences, and open
+questions are stated where they occur; no global claim-status labels are
+needed.}
+}
+
 \transclude{ftip-00J9}
 \transclude{ftip-00JA}
 \transclude{ftip-00JB}


### PR DESCRIPTION
This adds a concise orientation section to the note-suite root. It states the motivating conditional question, explains the six existing chapter wrappers, identifies Chapter 4 as an optional architecture refinement, and gives a practical reading order. No existing section roots or theorem statements are changed, and no new chapter is introduced.

Validation: just chk, git diff --check, CI=1 just build, explicit PDF render, and browser text inspection of the opening pages.