### PR TITLE
fix(ftip): repair shared-weight DGG bounds and clipping [AGENT]

### DIFF
--- a/trees/ftip-007Z.tree
+++ b/trees/ftip-007Z.tree
@@ -2,55 +2,78 @@
 \meta{agent-authored}{true}
 
 \taxon{Theorem}
-\title{Per-token DGG gradient factorization}
+\title{DGG head gradient and shared-weight occurrence sum}
 \tag{ftip}
 \tag{replay}
 \tag{gradient}
 
-\p{Consider an active token #{i} on the unclipped branch of the GRPO
-objective. Let #{a_i} be the sampled token, #{\widehat A_i} its normalized
-advantage, and
+\p{Fix a sampled history and an active token #{i} in the interior of the
+unclipped branch of the GRPO objective. Consider a finite directed acyclic
+computation graph that is differentiable at the parameter point in question.
+Let #{a_i} be the sampled token, #{\widehat A_i} its fixed normalized advantage, and
+#{p_i=\operatorname{softmax}(z_i)} the current distribution on a finite
+vocabulary #{\mathcal V}. With fixed behavior probability #{b_i>0}, set
 ##{
-r_i=\frac{\pi_\theta(a_i\mid h_{L,i})}
-{\pi_{\rm old}(a_i\mid h_{L,i})}.
-}
-Treat #{\widehat A_i} and the behavior-policy denominator as fixed during
-this token update. Let #{e_{a_i}\in\mathbb R^{|\mathcal V|}} be the standard
-basis vector for the sampled token, and define the active-token objective and
-its two weight gradients by
-##{
-\mathcal L_i(\theta)=r_i(\theta)\widehat A_i,
+r_i=\frac{p_i(a_i)}{b_i},
 \qquad
-G_i^{\rm lm}=\nabla_{W_{\rm lm}}\mathcal L_i,
+\mathcal L_i=r_i\widehat A_i,
 \qquad
-G_i^{\rm int}=\nabla_{W_{\rm int}}\mathcal L_i.
+E_i=r_i\widehat A_i(e_{a_i}-p_i).
 }
-Write #{h_{L,i}} for the hidden state entering the language-model head,
-#{x_i^{\rm int}} for the input to an intermediate linear layer, and
-#{J_i=\partial z_i/\partial y_i} for the Jacobian from that layer's output to
-the logits. Define
+Here #{e_{a_i}\in\mathbb R^{|\mathcal V|}} is the sampled-token basis vector.
+The history and sampling decisions are held fixed during differentiation.}
+
+\p{Suppose the output head #{W_{\rm lm}\in
+\mathbb R^{|\mathcal V|\times d_{\rm model}}} is untied: its only path to
+#{\mathcal L_i} is through #{z_i=W_{\rm lm}h_{L,i}}, and
+#{h_{L,i}\in\mathbb R^{d_{\rm model}}} is independent of #{W_{\rm lm}}.
+Then
 ##{
-E_i=r_i\widehat A_i
-\left(e_{a_i}-\pi_\theta(\mathord\cdot\mid h_{L,i})\right).
+G_i^{\rm lm}=\nabla_{W_{\rm lm}}\mathcal L_i
+=E_i h_{L,i}^{\mathsf T}.
 }
-Then the two weight gradients factor as rank-one matrices:
+}
+
+\p{Let #{W_{\rm int}\in\mathbb R^{m\times d}} be a shared intermediate
+weight. Index by a finite set #{\mathcal O_i} every occurrence of this weight
+that can affect #{z_i}, assuming that all such uses have the form
+#{y_o=W_{\rm int}x_o}, with #{x_o\in\mathbb R^d}. First replace these uses
+by independent copies #{W_o} and evaluate them all at #{W_o=W_{\rm int}}.
+Let #{J_{io}\in\mathbb R^{|\mathcal V|\times m}} be the downstream Jacobian
+from node #{y_o} to #{z_i} in this graph, with the other weight copies fixed.
+Define the contribution of occurrence #{o} by
 ##{
-G_i^{\rm lm}=E_i h_{L,i}^{\mathsf T},
-\qquad
-G_i^{\rm int}=(J_i^{\mathsf T}E_i)(x_i^{\rm int})^{\mathsf T}.
+H_{io}=\nabla_{W_o}\mathcal L_i
+=(J_{io}^{\mathsf T}E_i)x_o^{\mathsf T}.
 }
+On tying the copies, the total derivative is
+##{
+G_i^{\rm int}=\nabla_{W_{\rm int}}\mathcal L_i
+=\sum_{o\in\mathcal O_i}H_{io}.
 }
+The head gradient and each occurrence contribution have rank at most one;
+the total shared-weight gradient need not.}
+
+\p{For a layer used once per position in a causal network, the sum includes
+every earlier position whose output affects token #{i}. Reuse across depth
+adds further occurrences. Tying the head to embeddings or other blocks also
+requires their contributions; the displayed head identity assumes that such
+tying is absent.}
 
 \proof{
-\p{For the unclipped token objective, differentiation through the softmax
-gives #{\nabla_{z_i}\mathcal L_i=E_i}. Since
-#{z_i=W_{\rm lm}h_{L,i}}, the outer-product rule gives the first identity.
-The chain rule gives #{\nabla_{y_i}\mathcal L_i=J_i^{\mathsf T}E_i}; applying
-the same rule to #{y_i=W_{\rm int}x_i^{\rm int}} gives the second.}
+\p{Softmax differentiation gives #{\nabla_{z_i}\mathcal L_i=E_i}.
+The outer-product rule gives the untied head identity. In the graph with
+independent copies, #{x_o} does not depend on its own #{W_o}; all downstream
+paths from #{y_o} are included in #{J_{io}}. The chain rule therefore gives
+#{\nabla_{W_o}\mathcal L_i=(J_{io}^{\mathsf T}E_i)x_o^{\mathsf T}}.
+Finally, the derivative of the diagonal map
+#{W_{\rm int}\mapsto(W_o=W_{\rm int})_{o\in\mathcal O_i}}
+adds these partial derivatives.}
 }
 
-\p{This is the source proposition specialized to the active, unclipped token
-whose gradient appears in its equation (3). Clipped or inactive tokens require
-their own derivative or mask and are not covered by the displayed identities.}
-
-\p{Source note: this statement reconstructs \citet{Section 4.2.1, Proposition 1, and Appendix A.1}{miao2026when}.}
+\p{Clipped or inactive terms require their own derivative or mask. Source
+note: \citet{Section 4.2.1, Proposition 1, and Appendix A.1}{miao2026when}
+derives the intermediate outer product through one local application. For a
+shared weight, that calculation gives #{H_{io}}; identifying it with the total
+#{G_i^{\rm int}} omits the other occurrences. The sum above supplies the
+chain rule needed for shared parameters.}

--- a/trees/ftip-0080.tree
+++ b/trees/ftip-0080.tree
@@ -2,33 +2,34 @@
 \meta{agent-authored}{true}
 
 \taxon{Theorem}
-\title{DGG intermediate-to-head gradient-energy bound}
+\title{DGG occurrence-to-head gradient-energy bound}
 \tag{ftip}
 \tag{replay}
 \tag{gradient}
 
-\p{Use the per-token quantities of \ref{ftip-007Z}. Assume positive constants
-#{\alpha_{\min}}, #{\beta_{\max}}, and #{C} satisfy
+\p{Use the per-token quantities and untied head of \ref{ftip-007Z}, and fix
+one occurrence #{o\in\mathcal O_i}. Assume #{d_{\rm model}\geq1} and positive
+constants #{\alpha_{\min}}, #{\beta_{\max}}, and #{C} satisfy
 ##{
 \|h_{L,i}\|_2^2\geq \alpha_{\min}d_{\rm model},
 \qquad
-\|x_i^{\rm int}\|_2^2\leq \beta_{\max}d_{\rm model},
+\|x_o\|_2^2\leq \beta_{\max}d_{\rm model},
 }
 and the two logit-sensitivity bounds
 ##{
-\mathbb E_{j\sim\pi_\theta(\mathord\cdot\mid h_{L,i})}
- \|(J_i)_{j,:}\|_2^2\leq C,
+\mathbb E_{a\sim p_i}
+ \|(J_{io})_{a,:}\|_2^2\leq C,
 \qquad
-\|(J_i)_{a_i,:}\|_2^2\leq C.
+\|(J_{io})_{a_i,:}\|_2^2\leq C.
 }
-If #{\widehat A_i\neq0} and #{\pi_\theta(a_i\mid h_{L,i})<1}, then
+If #{\widehat A_i\neq0} and #{p_i(a_i)<1}, then
 ##{
-\frac{\|G_i^{\rm int}\|_F^2}{\|G_i^{\rm lm}\|_F^2}
+\frac{\|H_{io}\|_F^2}{\|G_i^{\rm lm}\|_F^2}
 \leq
-\frac{\mathcal C_{\rm struct}}
-{(1-\pi_\theta(a_i\mid h_{L,i}))^2},
+\frac{\mathcal C_{\rm occ}}
+{(1-p_i(a_i))^2},
 \qquad
-\mathcal C_{\rm struct}
+\mathcal C_{\rm occ}
 =\frac{4\beta_{\max}C}{\alpha_{\min}}.
 }
 }
@@ -40,14 +41,16 @@ If #{\widehat A_i\neq0} and #{\pi_\theta(a_i\mid h_{L,i})<1}, then
 =\|E_i\|_2^2\|h_{L,i}\|_2^2
 \geq
 r_i^2\widehat A_i^2
-(1-\pi_\theta(a_i\mid h_{L,i}))^2
+(1-p_i(a_i))^2
 \alpha_{\min}d_{\rm model}.
 }
-Expanding #{J_i^{\mathsf T}E_i}, applying
-#{(a-b)^2\leq2a^2+2b^2}, and then using both logit-sensitivity bounds yields
-#{\|J_i^{\mathsf T}E_i\|_2^2\leq4r_i^2\widehat A_i^2C}. Hence
+Write #{J_{io}^{\mathsf T}E_i} as #{r_i\widehat A_i} times the difference
+between the sampled row and the #{p_i}-weighted mean row. The squared-norm
+inequality #{\|u-v\|_2^2\leq2\|u\|_2^2+2\|v\|_2^2}, Jensen's inequality
+for that mean, and the two row-energy bounds give
+#{\|J_{io}^{\mathsf T}E_i\|_2^2\leq4r_i^2\widehat A_i^2C}. Hence
 ##{
-\|G_i^{\rm int}\|_F^2
+\|H_{io}\|_F^2
 \leq4r_i^2\widehat A_i^2C\,
 \beta_{\max}d_{\rm model}.
 }
@@ -56,9 +59,26 @@ nonunit-probability hypotheses make the head lower bound positive. Division
 and cancellation give the displayed ratio.}
 }
 
-\p{The activation inequalities reproduce the source's Lemma 1, while the two
-row-energy inequalities reproduce its Assumption 1. The conclusion is an
-upper bound on an intermediate-to-head gradient-energy ratio. It does not say
-that either gradient is small, and it does not compare evaluation scores.}
+\p{This bounds one occurrence contribution, not the total derivative of a
+shared intermediate weight. For the latter, the sum in \ref{ftip-007Z} gives
+only
+##{
+\|G_i^{\rm int}\|_F
+\leq\sum_{o\in\mathcal O_i}
+\|J_{io}^{\mathsf T}E_i\|_2\|x_o\|_2.
+}
+If the same displayed hypotheses hold for every occurrence, the triangle
+inequality yields the ratio bound
+#{|\mathcal O_i|^2\mathcal C_{\rm occ}/(1-p_i(a_i))^2} for
+#{\|G_i^{\rm int}\|_F^2/\|G_i^{\rm lm}\|_F^2}.
+Controlling only the application at position #{i} does not establish this
+all-occurrence hypothesis or the source's claimed bound for the total gradient.
+The contributing positions, reuse pattern, and Jacobians depend on the
+architecture. Neither bound establishes a small gradient or an evaluation-score
+comparison.}
 
-\p{Source note: this statement reconstructs \citet{Section 4.2.1, Lemma 1, Assumption 1, Theorem 1, and Appendix A.3}{miao2026when}.}
+\p{Source note: the activation and row-energy hypotheses and the local
+inequality follow the calculation in \citet{Section 4.2.1, Lemma 1,
+Assumption 1, Theorem 1, and Appendix A.3}{miao2026when}, with the differentiated
+object restricted to an occurrence contribution. They do not prove the source's
+total shared-weight claim under its local hypotheses.}

--- a/trees/ftip-0081.tree
+++ b/trees/ftip-0081.tree
@@ -7,7 +7,8 @@
 \tag{replay}
 \tag{gradient}
 
-\p{For #{T\geq1} active, unclipped tokens, let
+\p{For #{T\geq1} active, unclipped tokens with fixed sampled histories and
+the untied output head of \ref{ftip-007Z}, let
 ##{
 G^{\rm lm}=\frac1T\sum_{i=1}^T G_i^{\rm lm},
 \qquad
@@ -48,6 +49,8 @@ The identity #{\overline{r^2}=1+\widehat\chi^2} follows directly from
 
 \p{The inequality points from observed head-gradient energy to a lower bound
 on this finite-batch squared-ratio statistic. It is not a converse: cancellation
-can make the batch gradient small even when individual ratios are large.}
+can hide nonunit ratios. The active cancellation example in \ref{ftip-0084}
+states its clipping interval explicitly. The proof uses no intermediate-weight
+bound.}
 
 \p{Source note: this statement reconstructs \citet{Section 4.2.2, Lemma 2, Theorem 2, and Appendix B}{miao2026when}.}

--- a/trees/ftip-0082.tree
+++ b/trees/ftip-0082.tree
@@ -8,7 +8,9 @@
 \tag{evaluation}
 
 \p{The identities in \ref{ftip-007Z}--\ref{ftip-0081} concern gradients,
-importance ratios, activations, and a logit Jacobian. None of their hypotheses
+importance ratios, activations, and occurrence-specific logit Jacobians.
+The intermediate bound controls a local contribution; a shared-weight bound
+needs control over all contributing occurrences. None of their hypotheses
 mentions the fixed independent-evaluation functional #{J_{\rm ev}} of
 \ref{ftip-005E}. They therefore cannot imply that accepting an update preserves
 #{J_{\rm ev}}, or that rejecting one would have prevented a decrease.}

--- a/trees/ftip-0084.tree
+++ b/trees/ftip-0084.tree
@@ -2,24 +2,40 @@
 \meta{agent-authored}{true}
 
 \taxon{Example}
-\title{Counterexample: batch cancellation can hide stale ratios}
+\title{Counterexample: active batch cancellation can hide nonunit ratios}
 \tag{ftip}
 \tag{replay}
 \tag{counterexample}
 
-\p{Fix #{R>1}. On a two-token vocabulary, let both observed tokens have
-#{a_i=1}, current probability #{\pi_\theta(1)=1/2}, and behavior probability
+\p{Fix #{\epsilon_{\rm clip}\in(0,1)} and
+#{1<R<1+\epsilon_{\rm clip}}. On a two-token vocabulary, let both observed
+tokens have #{a_i=1}, current probability #{\pi_\theta(1)=1/2}, and behavior probability
 #{\pi_{\rm old}(1)=1/(2R)}. Take scalar hidden states #{h_{L,1}=h_{L,2}=1}
-and normalized advantages #{\widehat A_1=1}, #{\widehat A_2=-1}. Then
-#{r_1=r_2=R}, but the factors in \ref{ftip-007Z} satisfy
+and fixed normalized advantages #{\widehat A_1=1}, #{\widehat A_2=-1}.
+These may be selected token terms from different rollout members. An untied
+head with both logits zero realizes the current probabilities. Both terms lie
+strictly inside the clipping interval of \ref{ftip-003F}, so the clipped
+surrogate locally agrees with #{\mathcal L_i=r_i\widehat A_i}. Thus
+#{r_1=r_2=R}, and \ref{ftip-007Z} gives
 ##{
 G_1^{\rm lm}=R(1/2,-1/2)^{\mathsf T},
 \qquad
 G_2^{\rm lm}=-G_1^{\rm lm}.
 }
 Consequently #{G^{\rm lm}=0}, while
-#{\widehat\chi^2=R^2-1} can be arbitrarily large.}
+#{\widehat\chi^2=R^2-1>0}. For this fixed clipping rule, the statistic in
+this construction is bounded above by #{(1+\epsilon_{\rm clip})^2-1}.}
+
+\p{For the raw surrogate #{\mathcal L_i=r_i\widehat A_i} considered as a
+separate objective, the same algebra works at every #{R>1} and yields
+arbitrarily large squared-ratio excess. This does not extend the active
+construction to arbitrary #{R} under clipping: when
+#{R>1+\epsilon_{\rm clip}}, the positive-advantage term is locally constant,
+while the negative term remains active. Their clipped gradients are then
+#{0} and #{-R(1/2,-1/2)^{\mathsf T}}, with nonzero mean
+#{(-R/4,R/4)^{\mathsf T}}.}
 
 \p{The example does not contradict \ref{ftip-0081}: that theorem upper-bounds
 batch-gradient energy by a ratio moment. It supplies no lower bound on the
-gradient and no converse from a quiet monitor to fresh data.}
+gradient and no converse from zero batch-gradient energy to ratios equal to
+one. The arbitrary-ratio version concerns only the separate raw surrogate.}

--- a/trees/ftip-00II.tree
+++ b/trees/ftip-00II.tree
@@ -5,4 +5,14 @@
 \tag{ftip}
 \tag{ledger}
 
-\p{The DGG cards \ref{ftip-007Z}--\ref{ftip-0081} and the NExt cards \ref{ftip-0086}--\ref{ftip-008B} remain source reconstructions or empirical observations. Their exact locators and transfer limits are ledger metadata; no universal collapse, capability, or speed theorem is admitted here.}
+\p{The DGG cards \ref{ftip-007Z} through \ref{ftip-0081} distinguish the untied
+head identity and its finite-batch Jensen bound from an intermediate
+occurrence bound. A shared intermediate weight requires the sum over all
+occurrences in \ref{ftip-007Z}; the source's local hypotheses do not establish
+its claimed total-gradient bound. The cancellation example \ref{ftip-0084}
+also separates the active clipping interval from the raw-surrogate extension.}
+
+\p{These DGG statements and the NExt cards \ref{ftip-0086} through \ref{ftip-008B}
+retain their source locators and transfer limits. The NExt empirical
+observations remain empirical; no universal collapse, capability, or speed
+theorem is admitted here.}


### PR DESCRIPTION
The DGG reconstruction treated one use of an intermediate weight as its total derivative, omitting other causal positions and repeated uses across depth. This change sums derivatives over all parameter occurrences and restricts the original energy bound to one occurrence; a total-gradient bound now requires hypotheses at every occurrence. The untied output-head identity and its Jensen bound remain intact.

The cancellation example now stays inside the clipping interval and separately explains the raw-surrogate extension and the nonzero clipped gradient above the threshold. Source and ledger text distinguish these repaired claims from the paper's local calculation.

Validation: finite-difference checks for causal-prefix and repeated-depth sharing; the ten-position counterexample; active and clipped cancellation cases; `just chk`, `just build`, `just verify-render` (2,267 page contracts), and the focused FTIP PDF build and affected-page inspection. Fresh independent adversarial review passed at head `6803cecc87acf524925df5faeedcb80b871822a0`; no substantive findings remain.
