### PR TITLE
fix(ftip): define integrable evaluation and inverse-cost domains [AGENT]

### DIFF
--- a/trees/ftip-001N.tree
+++ b/trees/ftip-001N.tree
@@ -10,7 +10,9 @@
 its instance set, and #{\mathcal O_{\mathsf T}} for its candidate-outcome
 set. A task instance is #{x\in\mathcal X_{\mathsf T}} and a candidate outcome
 is #{o\in\mathcal O_{\mathsf T}}. The symbol #{\mu_{\mathsf T}} denotes a
-probability law on instances.}
+probability law on instances. Equip the instance and outcome sets with
+declared sigma-algebras; #{\mu_{\mathsf T}} is a probability measure on the
+instance sigma-algebra.}
 
 \p{Fix an evaluation-resource dimension #{m_{\mathrm{eval}}\geq1} and write
 #{\mathcal B_{\mathrm{eval}}=\mathbb R_+^{m_{\mathrm{eval}}}} with its
@@ -21,4 +23,8 @@ coordinatewise order. An evaluation inference protocol is written
 set is #{\Omega_E}; its realized seed is #{\omega\in\Omega_E}. It returns utility
 #{u_{\mathsf T}(x,o;\omega)\in\mathbb R^d}. The dimension #{d\geq1} is
 declared by the evaluation: #{d=1} gives scalar utility, while #{d>1} retains
-several outcomes or costs without an implicit weighting.}
+several outcomes or costs without an implicit weighting. Equip both seed
+sets with declared sigma-algebras and #{\mathbb R^d} with its Borel
+sigma-algebra. Products below carry the product sigma-algebra; finite or
+countable discrete spaces may use all subsets. A seed space alone does not
+specify its sampling law.}

--- a/trees/ftip-001T.tree
+++ b/trees/ftip-001T.tree
@@ -7,12 +7,12 @@
 \tag{evaluation}
 
 \p{With the notation of \ref{ftip-001N}, an \newvocab{evaluation utility}
-is a declared function
+is a declared measurable function
 ##{
 u_{\mathsf T}:\mathcal X_{\mathsf T}\times
 \mathcal O_{\mathsf T}\times\Omega_E\longrightarrow\mathbb R^d,
 }
-where #{\Omega_E} is the evaluator's random-seed set. The evaluator applies it
+where #{\Omega_E} is the evaluator's measurable seed space. The evaluator applies it
 only to admissible pairs from \ref{ftip-001O}. A deterministic evaluator is the
 special case in which the value does not depend on #{\omega\in\Omega_E}.}
 
@@ -20,3 +20,12 @@ special case in which the value does not depend on #{\omega\in\Omega_E}.}
 cumulative return is another scalar case. Vector utility keeps qualities such
 as correctness, safety, latency, and tool cost distinct until a later rule
 declares how to compare them.}
+
+\p{Whenever an expected utility vector is used, its composite evaluation
+random variable must be measurable and absolutely integrable in every
+coordinate under the declared joint law. Thus its expectation lies in
+#{\mathbb R^d}. Bounded measurable utility is a sufficient specialization;
+so is finite support for the complete evaluation random variable with finite
+values on that support. Merely taking a finite real value at each seed is
+insufficient for an unbounded evaluator. The scalar protocol comparison in
+\ref{ftip-005D} states its joint law explicitly.}

--- a/trees/ftip-005D.tree
+++ b/trees/ftip-005D.tree
@@ -7,7 +7,7 @@
 \tag{notation}
 
 \p{Fix an evaluation task #{\mathsf T_{\rm ev}} from \ref{ftip-001O} and a
-scalar evaluation utility
+measurable scalar evaluation utility
 #{u_{\mathsf T_{\rm ev}}:\mathcal X_{\mathsf T_{\rm ev}}\times
 \mathcal O_{\mathsf T_{\rm ev}}\times\Omega_E\to\mathbb R}, the #{d=1}
 case of \ref{ftip-001T}. Fix its task law
@@ -15,22 +15,41 @@ case of \ref{ftip-001T}. Fix its task law
 #{\mathsf I_{\rm ev}} from \ref{ftip-001R}, and an inference budget
 #{b\in\mathcal B_{\mathrm{eval}}}. Use the inference-seed space #{\Omega_I}
 and evaluator-seed space #{\Omega_E} from \ref{ftip-001N}. A declared
-evaluation-seed kernel
+probability kernel on these measurable spaces
 #{\Lambda_{\rm ev}(d\xi,d\omega\mid x)} assigns inference and evaluator
 randomness to each instance. Together with #{Q_{\rm ev}}, it gives the joint
 evaluation law
-#{Q_{\rm ev}(dx)\Lambda_{\rm ev}(d\xi,d\omega\mid x)}, which is fixed
+#{\nu_{\rm ev}(dx,d\xi,d\omega)
+=Q_{\rm ev}(dx)\Lambda_{\rm ev}(d\xi,d\omega\mid x)}, which is fixed
 independently of training.}
 
-\p{For an executable artifact #{M}, define only the aliases
+\p{Declare a measurable space #{\mathcal M} of executable artifacts. For
+#{M\in\mathcal M}, define the aliases
 ##{
 \mathsf{Eval}_b(M,x;\xi)
 :=\operatorname{pr}_1\left(\mathsf I_{\rm ev}(M,x,b;\xi)\right),
 \qquad
 U(x,o;\omega):=u_{\mathsf T_{\rm ev}}(x,o;\omega).
 }
-A post-training protocol #{P} produces a random executable artifact #{M_P}
-from the common base artifact #{M_0}; the no-training protocol is #{P_0}.
-Fix also a scalar success threshold #{u_*\in\mathbb R}. Expectations below
-include protocol randomness producing #{M_P}. Evaluation samples drawn from
-the joint evaluation law remain independent of that training randomness.}
+Require #{\mathsf{Eval}_b} to be measurable in #{(M,x,\xi)} and to return
+admissible outcomes on admitted runs.}
+
+\p{Each post-training protocol #{P} has a probability space
+#{(\Omega_P,\Sigma_P,\mathbb P_P)} for its randomness and a measurable
+artifact map #{M_P:\Omega_P\to\mathcal M} produced from the common base
+artifact #{M_0}. The no-training protocol is #{P_0}. The complete evaluation
+law for #{P} is the product #{\mathbb P_P\otimes\nu_{\rm ev}}, expressing
+independence between protocol randomness and the fixed evaluation draw.
+For #{\zeta\in\Omega_P}, write
+##{
+Z_P(\zeta,x,\xi,\omega)
+=U\left(x,\mathsf{Eval}_b(M_P(\zeta),x;\xi);\omega\right).
+}
+This composite is measurable. Every protocol compared through expected
+performance, including the baseline #{P_0}, must satisfy
+##{
+\int |Z_P|\,d(\mathbb P_P\otimes\nu_{\rm ev})<\infty.
+}
+This is the evaluation domain; finite pointwise utility does not replace the
+absolute-integrability condition. Fix also a scalar success threshold
+#{u_*\in\mathbb R}.}

--- a/trees/ftip-005E.tree
+++ b/trees/ftip-005E.tree
@@ -6,12 +6,14 @@
 \tag{ftip}
 \tag{evaluation}
 
-\p{Using the fixed interface in \ref{ftip-005D}, the \strong{expected
-evaluation performance} of a post-training protocol is}
+\p{For a protocol #{P} in the integrable evaluation domain of
+\ref{ftip-005D}, its \strong{expected evaluation performance} is the finite
+real number}
 
 ##{
 \begin{aligned}
 J_{\rm ev}(P)
+&=\int Z_P\,d(\mathbb P_P\otimes\nu_{\rm ev}),\\
 &=\mathbb E\left[
 U\left(X,\mathsf{Eval}_b(M_P,X;\Xi);\Omega\right)
 \right],
@@ -23,4 +25,6 @@ Q_{\rm ev}(dx)\Lambda_{\rm ev}(d\xi,d\omega\mid x).
 
 \p{The label #{\rm ev} abbreviates the task, law, inference protocol,
 budget, utility, and seed law fixed above. Changing any of them changes the
-estimand.}
+estimand. Both positive and negative parts of #{Z_P} have finite expectation;
+an undefined expectation or an infinite value is outside this real-valued
+performance domain.}

--- a/trees/ftip-005F.tree
+++ b/trees/ftip-005F.tree
@@ -6,8 +6,9 @@
 \tag{ftip}
 \tag{evaluation}
 
-\p{The \strong{post-training gain} of protocol #{P}, relative to the
-no-training protocol #{P_0}, is}
+\p{For #{P} and the no-training protocol #{P_0} both satisfying the
+absolute-integrability condition of \ref{ftip-005D}, the
+\strong{post-training gain} is the real-valued difference}
 
 ##{
  \Delta J_{\rm ev}(P)
@@ -16,4 +17,4 @@ no-training protocol #{P_0}, is}
 
 \p{Both terms use the same evaluator, task law, utility, and inference budget.
 The subtraction does not compare different model families or evaluation
-procedures.}
+procedures. In particular, #{+\infty-(+\infty)} is not an admitted gain.}

--- a/trees/ftip-005H.tree
+++ b/trees/ftip-005H.tree
@@ -7,7 +7,8 @@
 \tag{compute}
 
 \p{The realized \strong{lifecycle cost vector} of a protocol is the random
-vector #{C(P)\in\mathbb R_+^7} that records separately}
+vector #{C(P)\in\mathbb R_+^7}, measurable on its declared lifecycle-run
+probability space, that records separately}
 
 ##{
  C(P)=
@@ -18,4 +19,10 @@ vector #{C(P)\in\mathbb R_+^7} that records separately}
 \p{A componentwise lifecycle budget is a vector
 #{\mathbf B\in\mathbb R_+^7}. Each cost coordinate has a declared unit, such as tokens, labels, accelerator
 floating-point operations (FLOPs), sandbox time, bytes, or evaluator calls. A scalar price may be applied
-later, but the typed vector is retained.}
+later, but the typed vector is retained. Each nonnegative coordinate has a
+well-defined expectation in #{[0,+\infty]}; finite realized costs need not
+have finite expectations. A finite componentwise budget excludes protocols
+with any infinite expected-cost coordinate. When costs include the fixed
+independent evaluation draw, the run law may include the product law in
+\ref{ftip-005D}; the accounting record must specify which randomness is
+averaged.}

--- a/trees/ftip-005J.tree
+++ b/trees/ftip-005J.tree
@@ -9,7 +9,12 @@
 \p{For a base artifact #{M_0}, an \strong{admissible protocol class}
 #{\mathfrak P(M_0)} is a declared set of type-correct training procedures.
 Membership fixes which data sources, feedback channels, model changes,
-environment interfaces, and update rules are permitted.}
+environment interfaces, and update rules are permitted. For the expected
+performance comparison, every member also satisfies the measurable generation
+and integrable evaluation domain of \ref{ftip-005D}, and carries the
+measurable nonnegative cost vector of \ref{ftip-005H}. The baseline #{P_0}
+must satisfy the evaluation domain even if it is not feasible at the chosen
+cost budget.}
 
 \p{The class is part of the research question. Enlarging it can only enlarge
 the set of attainable outcomes, but may make a comparison less informative.}

--- a/trees/ftip-005M.tree
+++ b/trees/ftip-005M.tree
@@ -7,7 +7,8 @@
 \tag{optimization}
 
 \p{For a scalar evaluation utility, the \strong{costed post-training
-potential} of #{M_0} under componentwise budget #{\mathbf B} is}
+potential} of #{M_0} under a finite componentwise budget
+#{\mathbf B\in\mathbb R_+^7} is the extended-real supremum}
 
 ##{
  \Phi(M_0,\mathbf B)
@@ -18,5 +19,18 @@ potential} of #{M_0} under componentwise budget #{\mathbf B} is}
  \right\}.
 }
 
-\p{The inequality is componentwise. The value is conditional on every object
-named in the display; it is not an intrinsic constant of the model.}
+\p{Here #{\mathfrak P(M_0)} has the evaluation domain of \ref{ftip-005J},
+so each #{J_{\rm ev}(P)} is real. The expected-cost inequality is componentwise
+in #{[0,+\infty]^7}; it cannot hold against a finite budget if any coordinate
+is infinite. Define #{\sup\varnothing=-\infty}, and use #{+\infty} when
+feasible performance values are unbounded above. Thus #{\Phi} takes values
+in #{\overline{\mathbb R}=\mathbb R\cup\{-\infty,+\infty\}}.}
+
+\p{The potential is finite real exactly when its feasible performance set is
+nonempty and bounded above. For example, a common finite upper bound on
+utility and at least one feasible protocol suffice. This does not guarantee
+that any protocol attains the supremum. Ordinary differences, ratios, or
+derivatives of potential values require finite real operands and any further
+regularity hypotheses needed by that operation. The value is conditional on
+every object named in the display; it is not an intrinsic constant of the
+model.}

--- a/trees/ftip-00JJ.tree
+++ b/trees/ftip-00JJ.tree
@@ -3,12 +3,31 @@
 \taxon{Definition}
 \title{Architecture-indexed evaluation functional}
 \tag{ftip}
-\p{Fix an evaluation protocol #{J} and an architecture #{A}. Define
-#{V_A(C)} as the supremum of #{J(\operatorname{PostTrain}(A,\eta))} over
-allowed interventions #{\eta}.}
+\p{Fix an architecture #{A}, its base artifact, a declared intervention set
+#{\mathfrak I_A}, and the common evaluation interface of \ref{ftip-005D}.
+Each #{\eta\in\mathfrak I_A} specifies a protocol
+#{P_{A,\eta}=\operatorname{PostTrain}(A,\eta)} in that measurable and
+absolutely integrable evaluation domain, with real performance
+#{J_{\rm ev}(P_{A,\eta})}. Let #{c_A(\eta)\in[0,+\infty]} be its scalar
+cost under the study's declared accounting rule: a fixed measured cost or an
+expected nonnegative cost, as specified. For a finite budget
+#{C\in\mathbb R_{\geq0}}, define
+##{
+V_A(C)=\sup\left\{
+J_{\rm ev}(P_{A,\eta}):
+\eta\in\mathfrak I_A,\ c_A(\eta)\leq C
+\right\}\in\overline{\mathbb R}.
+}
+Infinite-cost interventions are infeasible at every such budget.}
 
-\p{Restrict the supremum to interventions whose measured scalar cost is at
-most #{C}.}
+\p{As in \ref{ftip-005M}, the empty feasible set has value #{-\infty}; an
+unbounded-above feasible score set has value #{+\infty}. The value is real
+exactly when that set is nonempty and bounded above. Increasing #{C} enlarges
+the feasible set, so #{V_A} is nondecreasing. A finite supremum need not be
+attained by any intervention.}
 
-\p{The allowed class and evaluation law are part of the definition, so #{V_A}
-is not a universal intelligence function.}
+\p{Frontier differences and derivatives are ordinary real operations only
+where the relevant values are finite, with differentiability additionally
+required for a derivative. Cost ratios use the domain in \ref{ftip-00JP}.
+The allowed intervention set, evaluation law, and accounting rule are part of
+the definition, so #{V_A} is not a universal intelligence function.}

--- a/trees/ftip-00JP.tree
+++ b/trees/ftip-00JP.tree
@@ -3,6 +3,30 @@
 \taxon{Definition}
 \title{Iso-quality cost ratio}
 \tag{ftip}
-\p{For a declared quality #{q}, define #{C_A(q)=\inf\{C:V_A(C)\ge q\}} when
-the set is nonempty. The iso-quality ratio is #{\rho_{A/B}(q)=C_A(q)/C_B(q)}
-when both costs are finite. It compares efficiency, not a universal ceiling.}
+\p{For a finite real target #{q\in\mathbb R} and the frontier of
+\ref{ftip-00JJ}, define the inverse cost
+##{
+C_A(q)=\inf\{C\in\mathbb R_{\geq0}:V_A(C)\geq q\}
+\in[0,+\infty],
+\qquad \inf\varnothing=+\infty.
+}
+The iso-quality ratio is defined only on the domain
+##{
+\rho_{A/B}(q)=\frac{C_A(q)}{C_B(q)},
+\qquad
+0\leq C_A(q)<+\infty,
+\quad 0<C_B(q)<+\infty.
+}
+The architectures must use the same target, evaluation interface, cost units,
+and comparison arm. The ratio compares efficiency under these choices.}
+
+\p{An inverse cost is a threshold infimum, not an executable minimum.
+The infimum over budgets may be unattained; even if a budget satisfies
+#{V_A(C)\geq q}, its performance supremum may be unattained at #{q}.
+An actual target-achieving intervention requires a separate witness.}
+
+\p{Positive individual costs do not guarantee a positive inverse cost.
+For interventions #{\eta_n}, #{n\geq1}, with score #{1} and cost #{1/n},
+the target #{q=1} has #{C_A(1)=0}, although every intervention costs more
+than zero. If both architectures have this family, the putative ratio is
+#{0/0} and is excluded by the displayed domain.}

--- a/trees/ftip-00JS.tree
+++ b/trees/ftip-00JS.tree
@@ -4,7 +4,9 @@
 \title{A conditional saturation certificate}
 \tag{ftip}
 \tag{saturation}
-\p{Let #{V_A} be nondecreasing and bounded above by #{U}. If a declared
-target #{q<U} is reached at cost #{C_q}, then every cost above #{C_q} is within
-#{U-q} of the target upper bound. This elementary certificate is conditional
-on the bound #{U}; it does not assert that real intelligence saturates.}
+\p{Let #{V_A} be the nondecreasing frontier of \ref{ftip-00JJ}, bounded
+above by a finite #{U\in\mathbb R}. If an intervention reaches a real target
+#{q<U} at a finite cost #{C_q\geq0}, then at every finite #{C\geq C_q},
+#{q\leq V_A(C)\leq U}. In particular #{V_A(C)} is real and
+#{0\leq U-V_A(C)\leq U-q}. This elementary certificate is conditional on
+the bound #{U}; it does not assert that real intelligence saturates.}

--- a/trees/ftip-00K0.tree
+++ b/trees/ftip-00K0.tree
@@ -4,7 +4,8 @@
 \title{Matched-protocol difference is an estimand}
 \tag{ftip}
 \p{Given #{n\geq1} evaluation draws, let #{\widehat V_A(C)} be the sample
-mean of the declared score #{J} for architecture #{A} at cost cap #{C}. Under
+mean of finite real evaluation scores for architecture #{A} at a finite
+cost cap #{C\geq0}. Under
 a fixed evaluation law and common-recipe arm, the finite difference
 #{\widehat V_A(C)-\widehat V_B(C)} is a well-defined empirical estimand.}
 

--- a/trees/ftip-00K8.tree
+++ b/trees/ftip-00K8.tree
@@ -4,7 +4,10 @@
 \title{Model-instance comparison decision rule}
 \tag{ftip}
 \p{Call architecture A more cost-efficient than B at quality #{q} only when
-both #{C_A(q)} and #{C_B(q)} are observed under the same declared protocol,
-the confidence procedure and stopping rule are fixed, and all cost-vector
-coordinates needed by the claim are present. Otherwise the comparison is
-descriptive or unknown.}
+the compared threshold costs use the same declared protocol, the confidence
+procedure and stopping rule are fixed, and all cost-vector coordinates needed
+by the claim are present. A ratio additionally requires finite costs and a
+strictly positive denominator as in \ref{ftip-00JP}. State whether the costs
+are measured target-achieving witnesses or justified inverse-frontier values
+#{C_A(q)} and #{C_B(q)}; observing one successful run does not identify those
+infima. Otherwise the comparison is descriptive or unknown.}

--- a/trees/ftip-00L0.tree
+++ b/trees/ftip-00L0.tree
@@ -4,7 +4,11 @@
 \title{Measured iso-quality cost ratio}
 \tag{ftip}
 \p{Let #{c_K(q)} and #{c_T(q)} be measured inference costs for Kimi Linear and
-the Transformer reference at the same declared score #{q} and context length.
-The measured ratio #{\rho_{K/T}(q)=c_K(q)/c_T(q)} is reported together
-with the full cost vectors. If either threshold is unmeasured, the ratio is left
-undefined rather than inferred from the paper's speedup plot.}
+the Transformer reference at the same finite real score #{q} and context
+length, under one accounting rule. If #{0\leq c_K(q)<+\infty} and
+#{0<c_T(q)<+\infty}, the measured ratio
+#{\widehat\rho_{K/T}(q)=c_K(q)/c_T(q)} is reported together with the full
+cost vectors. These measured costs need not be the inverse
+frontier infima of \ref{ftip-00JP}. If either threshold is unmeasured or the
+denominator is zero, the ratio is left undefined rather than inferred from
+the paper's speedup plot.}

--- a/trees/ftip-00LL.tree
+++ b/trees/ftip-00LL.tree
@@ -3,7 +3,9 @@
 \taxon{Definition}
 \title{Declared saturation target}
 \tag{ftip}
-\p{Fix a quality target #{q}, tolerance #{\varepsilon>0}, and cost increment
-#{\delta>0}. A study calls an architecture #{\varepsilon}-saturated at #{C}
+\p{Fix a quality target #{q\in\mathbb R}, tolerance and cost increment
+#{\varepsilon,\delta\in(0,+\infty)}, and a budget #{C\in\mathbb R_{\geq0}}.
+Require both #{V_A(C)} and #{V_A(C+\delta)} to be finite real values.
+A study calls an architecture #{\varepsilon}-saturated at #{C}
 only relative to its allowed intervention class when the restricted frontier
-has certified gain at most #{\varepsilon} from #{C} to #{C+\delta}.}
+has certified gain #{V_A(C+\delta)-V_A(C)\leq\varepsilon}.}

--- a/trees/ftip-00LM.tree
+++ b/trees/ftip-00LM.tree
@@ -3,7 +3,11 @@
 \taxon{Theorem}
 \title{Conditional saturation certificate}
 \tag{ftip}
-\p{If a declared upper bound #{U} satisfies #{V_A(C+\delta)\leq U} and a
-measured point satisfies #{V_A(C)\geq U-\varepsilon}, then the possible gain
-over the increment is at most #{\varepsilon}. This is a conditional bound for
-the named frontier; it proves no universal saturation of intelligence.}
+\p{Take finite real #{U}, #{C\geq0}, #{\delta\geq0}, and
+#{\varepsilon\geq0}, with the nondecreasing frontier of \ref{ftip-00JJ}.
+If a justified upper bound gives #{V_A(C+\delta)\leq U} and a justified
+lower bound gives #{V_A(C)\geq U-\varepsilon}, then
+#{U-\varepsilon\leq V_A(C)\leq V_A(C+\delta)\leq U}. Both endpoint
+values are therefore finite real, and
+#{0\leq V_A(C+\delta)-V_A(C)\leq\varepsilon}. This is a conditional bound
+for the named frontier; it proves no universal saturation of intelligence.}


### PR DESCRIPTION
Expected performance and gain were written as real-valued quantities without sufficient integrability assumptions, while inverse-frontier ratios could divide by zero even when every individual intervention had positive cost.

This change defines the measurable evaluation law and absolute-integrability requirements for each compared protocol and baseline. It declares empty/unbounded supremum conventions, excludes infinite expected costs from finite budgets, and restricts real differences and inverse-cost ratios to their stated domains. It also distinguishes an unattained frontier threshold from an executable witness, and measured cost ratios from inverse-frontier ratios. The changes cover 16 related FTIP pages and preserve their stable addresses.

Validation: analytic checks for signed heavy tails, empty/unbounded/unattained frontiers, positive costs with zero infimum, and bounded scalar/vector examples; all 22 prose regression tests; `just chk`; full `just build`; `just verify-render` (2,266 page pairs); and the 231-page focused FTIP PDF. The 16 affected HTML pages and surrounding routes render without KaTeX errors; affected HTML/PDF layout was inspected. All 773 source pages and 773 HTML pages plus the PDF are archived and hash-verified. A fresh independent adversarial review approved exact head `f83dabc1b913c8a34ac9b762df54fa5105b69ed3` with no unresolved findings. It independently reconstructed the analytic cases and verified all archived source and output payloads.
