### PR TITLE
fix(ftip): study hybrid-attention cost and discovery tradeoffs [AGENT]

### DIFF
--- a/trees/ftip-00KU.tree
+++ b/trees/ftip-00KU.tree
@@ -1,11 +1,14 @@
 \import{macros}
 \meta{agent-authored}{true}
-\title{Measured KDA and Transformer comparison}
+\title{Published hybrid-attention comparison}
 \tag{ftip}
 \tag{measured-example}
-\p{This subsection instantiates the comparison protocol with the Kimi Linear
-report. It records what can be calculated from the published setup and keeps
-unreported quantities as unknown rather than filling them with assumptions.}
+\p{Kimi Linear combines recurrent KDA layers with periodic full MLA
+attention. Its published comparison shows task-dependent score changes and
+lower long-context decoding times. The selected scores in \ref{ftip-00LC},
+the memory estimate in \ref{ftip-00KY}, and the discovery calculation in
+\ref{ftip-00L3} connect these observations to a post-training question:
+when can a cheaper attempt compensate for a possible lower per-attempt success probability?}
 \transclude{ftip-00KV}
 \transclude{ftip-00KW}
 \transclude{ftip-00KX}

--- a/trees/ftip-00KV.tree
+++ b/trees/ftip-00KV.tree
@@ -3,8 +3,15 @@
 \taxon{Example}
 \title{Published Kimi Linear operating point}
 \tag{ftip}
-\p{The Kimi Linear report describes a hybrid with 3 billion activated and
-48 billion total parameters, trained with 1.4 trillion tokens. Its displayed
-architecture uses three Kimi Delta Attention layers for each Multi-head Latent
-Attention layer. These are properties of the reported model, not definitions
-of every KDA or Transformer implementation \citef{kimi2025linear}.}
+\p{The Kimi Linear report compares experimental models pretrained on
+1.4 trillion tokens, each with 48 billion total and 3 billion active
+parameters. Kimi Linear uses three Kimi Delta Attention layers for each
+full Multi-head Latent Attention layer, with no positional encoding (NoPE)
+in its MLA layers; the reference uses full MLA attention
+\citet{Sections 4 and 5.4}{kimi2025linear}. These are properties of the
+reported hybrid architecture.}
+\p{These experimental models are distinct from the released Kimi Linear
+model, pretrained on 5.7 trillion tokens and supporting up to one million
+tokens of context. Appendix D compares that release with Moonlight,
+which has 16 billion total and 3 billion active parameters
+\citet{Section 5.4.1 and Appendix D}{kimi2025linear}.}

--- a/trees/ftip-00KW.tree
+++ b/trees/ftip-00KW.tree
@@ -3,9 +3,22 @@
 \taxon{Example}
 \title{Published efficiency observations}
 \tag{ftip}
-\p{At one million tokens the report gives a decoding time per output token of
-1.84 milliseconds for Kimi Linear and 11.48 milliseconds for its MLA baseline,
-and reports up to 75 percent lower KV-cache use. It also reports a 3.98-fold
-acceleration at the displayed 128k RULER point. These numbers are measured
-under the paper's hardware, kernels, precision, batch, and workload; they are
-not capability ratios \citef{kimi2025linear}.}
+\p{For batch size one at one million tokens, Figure 7 labels
+a #{2.9\times} prefill speedup and a #{2.2\times} decoding speedup for Kimi
+Linear against MLA. Section 6.3 gives #{2.3\times} for the latter point,
+so the graphic and prose differ slightly
+\citet{Figure 7 and Sections 5.6 and 6.3}{kimi2025linear}.}
+\p{The larger-batch comparison in Figure 1(b) gives decoding time per
+output token of 1.84 milliseconds for Kimi Linear and 11.48 milliseconds
+for MLA, with a reported #{6.3\times} speedup. Section 6.3 describes this
+as a theoretical speedup from reallocating saved KV-cache memory to larger
+batches. It illustrates a different use of the memory saving from the
+batch-one latency result
+\citet{Figure 1(b) and Section 6.3}{kimi2025linear}.}
+\p{Figure 1(a) reports RULER scores of 84.3 for Kimi Linear and 81.3 for MLA
+at 128k context, with #{3.98\times} decoding acceleration
+\citet{Figure 1(a)}{kimi2025linear}. The report also gives a reduction of up
+to 75 percent in KV-cache use \citet{Abstract}{kimi2025linear}.
+Together these observations motivate studying context length and batch size
+as separate cost coordinates. The unequal RULER scores and different timing
+regimes are retained when interpreting those points.}

--- a/trees/ftip-00KY.tree
+++ b/trees/ftip-00KY.tree
@@ -1,11 +1,46 @@
 \import{macros}
 \meta{agent-authored}{true}
-\taxon{Definition}
-\title{Kimi Linear measurement record}
+\taxon{Example}
+\title{A cache-memory estimate for hybrid attention}
 \tag{ftip}
-\p{The model-instance record must identify the exact checkpoint and revision,
-KDA/MLA layer pattern, parameter counts, tokenizer, context length, hardware,
-kernel versions, precision, batch, sequence lengths, decoding policy, and
-whether the result is pretraining, supervised tuning, or reinforcement
-learning. Missing fields make the corresponding architecture attribution
-unknown.}
+\p{The cited FLA KDA implementation at commit \code{6b6f546f} stores one active recurrent state
+per sequence, with dimensions determined by the value heads and key/value
+dimensions rather than accumulated context length. Its newly allocated
+state uses float32
+\citelink{https://github.com/fla-org/flash-linear-attention/blob/6b6f546f9bd10a97be1e8cf2f0120de70cfca482/fla/ops/kda/fused_recurrent.py#L262-L283}.
+The optional short-convolution state has one fixed-width kernel buffer per
+channel and sequence
+\citelink{https://github.com/fla-org/flash-linear-attention/blob/6b6f546f9bd10a97be1e8cf2f0120de70cfca482/fla/modules/conv/short_conv.py#L139-L142}.
+This supplies a concrete implementation model for the recurrent part of
+the 3:1 mixture in \ref{ftip-00KV}.}
+
+\p{Consider a stylized comparison with #{4\ell} layers, batch size #{b},
+and context length #{T}, where #{\ell,b,T} are positive integers. Assume each MLA layer
+stores #{\kappa T} bytes per sequence, with the same #{\kappa>0} in both
+designs, and each KDA layer stores one terminal recurrent-plus-convolution
+state of #{\sigma>0} bytes. The active attention-state memories are}
+
+##{
+ M_{\rm MLA}=4b\ell\kappa T,\qquad
+ M_{\rm hybrid}=b\ell(\kappa T+3\sigma),\qquad
+ \frac{M_{\rm hybrid}}{M_{\rm MLA}}
+ =\frac{1}{4}+\frac{3\sigma}{4\kappa T}.
+}
+
+\p{The hybrid uses less active state exactly when #{T>\frac{\sigma}{\kappa}},
+and the ratio tends to #{1/4} as context grows. This explains why replacing
+three quarters of the growing caches can approach a 75-percent saving,
+while fixed recurrent-state overhead can erase the advantage at short
+contexts. The retained MLA layers keep the hybrid's state memory linear
+in #{T}; the whole model is not a fixed-memory recurrent system.}
+
+\p{Weights, training activations, workspaces, allocator padding and saved
+prefix states are outside this active-state calculation. At a fixed device
+memory budget, the estimate predicts more room for simultaneous or longer
+rollouts when attention state dominates. It does not predict a fourfold
+speedup. Training and decoding also use different execution paths: FLA
+selects chunk kernels for gradient-enabled computation and fused recurrence
+for short inference calls
+\citelink{https://github.com/fla-org/flash-linear-attention/blob/6b6f546f9bd10a97be1e8cf2f0120de70cfca482/fla/layers/kda.py#L210-L308}.
+The fixed-state estimate is therefore a useful serving hypothesis, not a
+training-memory or training-speed formula.}

--- a/trees/ftip-00KZ.tree
+++ b/trees/ftip-00KZ.tree
@@ -3,8 +3,17 @@
 \taxon{Example}
 \title{Common-recipe reading of the Kimi result}
 \tag{ftip}
-\p{The report's identical-training-recipe comparison is evidence for the
-fixed-recipe arm: the architecture is changed while the declared recipe is
-held common. It does not identify the best attainable KDA or Transformer
-frontier, because architecture-specific tuning and systems choices are not
-optimized by that arm alone \citef{kimi2025linear}.}
+\p{The report holds its stated pretraining and SFT recipes common across
+the experimental models \citet{Sections 5.4--5.5 and Table 4}{kimi2025linear}.
+The selected observations in \ref{ftip-00LC} compare the resulting trained
+designs, including the hybrid's 3:1 KDA/MLA pattern and NoPE choice. The
+mixed score directions suggest a task-dependent tradeoff rather than one
+ordering of the two architectures.}
+\p{The theoretical mechanism is a change in the cost of maintaining and
+using the prefix: recurrent layers compress it into state, while the retained
+MLA layers preserve growing attention caches. The model in \ref{ftip-00KY}
+predicts the largest memory advantage at long contexts. If this advantage
+reduces the cost of generating useful candidates, \ref{ftip-00L3} predicts
+when more attempts can offset a reduction in per-attempt quality. This is a
+conditional explanation to test through rollout costs and verified success
+rates; it does not require attributing the whole result to KDA alone.}

--- a/trees/ftip-00L3.tree
+++ b/trees/ftip-00L3.tree
@@ -1,9 +1,63 @@
 \import{macros}
 \meta{agent-authored}{true}
-\taxon{Remark}
-\title{Conditions for interpreting an architecture comparison}
+\taxon{Example}
+\title{When cheaper attempts compensate for lower success}
 \tag{ftip}
-\p{This example supports the motivating comparison only after a paired
-model-instance record supplies a common quality target and declares the training,
-post-training, inference, and systems coordinates. Toy state bounds remain
-finite obstructions until such a record supplies a justified reduction.}
+\p{Smaller caches can support more concurrent requests or avoid
+preemption and recomputation. These are actual serving mechanisms in
+vLLM's memory and scheduling guidance
+\citelink{https://github.com/vllm-project/vllm/blob/5db652225f00b55783823ae6606d36925e3e3efe/docs/configuration/optimization.md#L27-L67}.
+For post-training, the useful prediction is therefore about completed
+candidate attempts under a budget, including verification and optimization
+costs, rather than decoding speed alone.}
+
+\p{Use the following cost model on the same hardware. One baseline
+attempt costs #{c>0}; generation accounts for a fraction #{f\in[0,1]}.
+Suppose generation becomes #{s_{\rm gen}>0} times as fast while all other
+cost per attempt stays fixed. The new cost and total attempt-throughput
+factor are}
+
+##{
+ c_K=c\left(1-f+\frac{f}{s_{\rm gen}}\right),\qquad
+ S=\frac{c}{c_K}
+ =\frac{1}{1-f+f/s_{\rm gen}}.
+}
+
+\p{For a fixed budget #{B\geq0}, this model permits
+#{N_M=\lfloor B/c\rfloor} baseline attempts and
+#{N_K=\lfloor B/c_K\rfloor} hybrid attempts. Assume #{N_M,N_K\geq1}
+and verified-success events independent within each set of attempts, with
+respective probabilities #{p_M,p_K\in[0,1]}.
+Then \ref{ftip-0078} gives discovery probabilities
+#{1-(1-p_M)^{N_M}} and #{1-(1-p_K)^{N_K}}. The hybrid matches or
+exceeds baseline discovery exactly when}
+
+##{
+ p_K\geq1-(1-p_M)^{N_M/N_K}.
+}
+
+\p{This follows by comparing the two failure probabilities and taking
+the nonnegative #{N_K}-th root.}
+
+\p{For an illustrative estimate, suppose generation consumes 80 percent
+of the baseline cost and use #{s_{\rm gen}=2.2}, motivated by the batch-one
+decode figure in \ref{ftip-00KW}. Applying that decode factor to the whole
+generation stage is a working approximation, not a measured rollout result.
+Then #{S\approx1.774}; a budget of #{B=10c} buys 10 baseline attempts or
+17 hybrid attempts. If #{p_M=0.10} and #{p_K=0.08}, the discovery
+probabilities are approximately #{0.651} and #{0.758}. The break-even
+hybrid probability is about #{0.0601}. Thus this model predicts that more
+attempts can outweigh a moderate per-attempt quality loss. The assumed
+probabilities are illustrative verified-success rates, not conversions of
+the benchmark scores in \ref{ftip-00LC}.}
+
+\p{The prediction is strongest for long-context, generation-heavy work
+whose saved memory becomes usable rollout capacity. As verification or
+optimization dominates, #{f} shrinks and #{S} approaches one. Correlated
+attempts require the joint-law analysis of \ref{ftip-0077} instead of the
+independent product. Measure completed attempts, verified-success rates and
+total cost under a fixed prompt, decoding and verifier protocol to test the
+tradeoff. In the RLVR round of \ref{ftip-004M}, additional successful
+candidates can improve the available feedback; whether they produce useful
+accepted updates is a further optimizer-and-evaluation question, as
+\ref{ftip-0085} demonstrates.}

--- a/trees/ftip-00LC.tree
+++ b/trees/ftip-00LC.tree
@@ -3,8 +3,30 @@
 \taxon{Example}
 \title{Published Kimi Linear comparison}
 \tag{ftip}
-\p{The Kimi Linear report compares a hybrid KDA/MLA model with an MLA
-baseline. Interpreting its paired measurements requires the training recipe
-and evaluation configuration, together with hardware, kernel, batch, and
-sequence-length conditions at the measurement point
-\citef{kimi2025linear}.}
+\p{Table 4 of the Kimi Linear report compares the experimental models
+pretrained on 1.4 trillion tokens in \ref{ftip-00KV}, after the same
+supervised fine-tuning (SFT) recipe. Both have 48 billion total and
+3 billion active parameters.
+Three selected benchmark scores are
+\citet{Sections 4 and 5.4 and Table 4}{kimi2025linear}:}
+\table{
+  \thead{
+    \tr{\th{Arm}\th{MMLU-Pro}\th{LiveBench}\th{EvalPlus}}
+  }
+  \tbody{
+    \tr{\td{Kimi Linear}\td{67.4}\td{45.2}\td{61.0}}
+    \tr{\td{Full MLA}\td{65.7}\td{45.7}\td{62.6}}
+  }
+}
+\p{The entries use the paper's score units, with larger values better on
+each selected benchmark; LiveBench is reported as Pass@1. Kimi Linear is
+higher on MMLU-Pro and lower on LiveBench and EvalPlus in these observations.
+These are reported point estimates on different tasks, not a single
+capability score; the table supplies no uncertainty estimate.}
+\p{The common recipe uses the K2 pretraining corpus, MuonClip and a shared
+training schedule. SFT proceeds from broad instruction data to targeted
+reasoning tasks; evaluation uses temperature 1.0 and an internal framework
+derived from LM-Harness \citet{Section 5.4}{kimi2025linear}.
+Thus the scores provide a concrete example of how the trained hybrid and
+full-MLA designs respond to the same recipe. The cost mechanism and its
+possible post-training consequences are developed in \ref{ftip-00KZ}.}

--- a/trees/ftip-00LD.tree
+++ b/trees/ftip-00LD.tree
@@ -1,8 +1,16 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Remark}
-\title{Unknown fields remain unknown}
+\title{Measured and assumed costs}
 \tag{ftip}
-\p{A missing cost, seed, or evaluator field prevents the corresponding
-iso-quality or causal comparison. It is reported as unknown or bounded by an
-explicit interval; it is not reconstructed from a headline speedup.}
+\p{A useful cost model can combine measurements with assumptions justified
+by the architecture and its implementation. In \ref{ftip-00L3}, the
+generation share #{f} and speed factor #{s_{\rm gen}} determine a predicted
+attempt-throughput factor. Their assumed values can be varied without
+pretending they were measured in the original experiment.}
+\p{For fixed #{f\in[0,1]}, write #{S(s)=1/(1-f+f/s)} for #{s>0}.
+This function is nondecreasing. An interval #{s_{\rm gen}\in[s_-,s_+]}, with
+#{0<s_-\leq s_+}, therefore gives the conditional range
+#{S\in[S(s_-),S(s_+)]}. This is sensitivity to a chosen assumption range;
+it is a statistical confidence interval only if a sampling argument supplies
+that interpretation.}

--- a/trees/ftip-00LE.tree
+++ b/trees/ftip-00LE.tree
@@ -1,9 +1,16 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Definition}
-\title{Conditions for estimating a paired contrast}
+\title{Measured contrasts and conditional predictions}
 \tag{ftip}
-\p{A paired comparison supports a stated estimand only when every
-coordinate named by that estimand is known for both systems and the matching
-rules were fixed before score inspection. Otherwise the comparison is descriptive
-and cannot support the stronger estimand.}
+\p{A measured paired contrast evaluates the same declared quantity for
+two observed model instances under a specified task, protocol and cost
+accounting. The common-recipe scores in \ref{ftip-00LC} are one example.
+A confirmatory comparison fixes its matching and selection rules before
+examining the scores.}
+\p{A conditional paired prediction instead uses an explicit model to
+supply one or more cost or response quantities, then derives the comparison
+under those assumptions. The discovery probabilities in \ref{ftip-00L3}
+are an example. Such a prediction can be motivated by existing observations
+and guide a later experiment; its unmeasured inputs remain assumptions,
+and agreement with new matched measurements tests the model.}

--- a/trees/ftip-00LF.tree
+++ b/trees/ftip-00LF.tree
@@ -1,9 +1,23 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Example}
-\title{Paired estimates and measurement uncertainty}
+\title{How generation share changes the predicted gain}
 \tag{ftip}
-\p{A paired estimate is accompanied by the selected scalar costs, full cost
-vectors, uncertainty summaries, and unmatched or unknown conditions.
-Reproducing a plotted frontier point requires all quantities used in its
-calculation; the point does not establish a universal architecture ordering.}
+\p{Keep the illustrative generation factor #{s_{\rm gen}=2.2} from
+\ref{ftip-00L3} and vary the baseline generation share #{f}. Its cost model
+gives the following total attempt-throughput factors:}
+\table{
+  \thead{\tr{\th{Generation share}\th{Predicted throughput factor}}}
+  \tbody{
+    \tr{\td{20 percent}\td{1.122}}
+    \tr{\td{50 percent}\td{1.375}}
+    \tr{\td{80 percent}\td{1.774}}
+    \tr{\td{100 percent}\td{2.200}}
+  }
+}
+\p{These calculated values show why the same decoding improvement can
+matter much more for generation-heavy search than for a verifier- or
+optimizer-dominated workload. They suggest measuring the time spent in
+generation, verification and updates before selecting where to invest
+systems effort. A change in the bottleneck changes the useful intervention,
+even when the attention architecture stays fixed.}

--- a/trees/ftip-00LG.tree
+++ b/trees/ftip-00LG.tree
@@ -1,9 +1,16 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Remark}
-\title{Comparisons depend on the measured model instances}
+\title{Testing the predicted architecture tradeoff}
 \tag{ftip}
-\p{The measurements support comparison of the named model instances and protocol.
-They do not establish that another KDA implementation, Transformer variant,
-optimizer, hardware stack, or task family has the same ordering. Each transfer
-requires a new matched comparison.}
+\p{The memory and discovery models predict the strongest benefit when
+long prefixes make attention state expensive, saved capacity improves useful
+rollout throughput, and per-attempt success remains above the break-even
+threshold. Short contexts, expensive verification, or strongly correlated
+attempts can weaken that benefit. These are distinct mechanisms to test,
+rather than a universal ranking of KDA and full attention.}
+\p{A comparison across implementations can retain this reasoning while
+re-estimating state sizes, generation share and success probabilities for
+the new system. Report both the prediction and the matched measurements:
+their agreement or disagreement identifies which mechanism or assumption
+needs revision.}


### PR DESCRIPTION
The hybrid-attention comparison previously described measurement prerequisites without showing readers what the reported results and FTIP theory imply. This change adds the published same-SFT Kimi Linear and MLA scores, separates the reported timing regimes, and develops conditional cache, total attempt-cost and discovery predictions.

The study derives the active-state ratio for a 3:1 recurrent/MLA mixture, then shows when lower attempt cost can offset lower per-attempt verified success. An illustrative budget buys 17 hybrid attempts versus 10 baseline attempts; the exact break-even condition and a generation-share sensitivity table explain which workloads could benefit. Assumptions are informed by cited official implementation practice and kept distinct from the paper's measurements. Stable tree addresses and the existing domain and iso-quality conditions are preserved.

Validation: six source cells and timing/source identities; 486 cache controls, 30 cost controls, 480 discovery controls; 22 existing prose tests; lint, full local site/render verification, eight browser routes and visually inspected equations/tables in the 236-page focused PDF. All 773 archived source blobs match the candidate and all saved source/HTML/PDF hashes pass. A fresh independent adversarial reviewer approved exact head `5dec9fd31e821726547052fc71fa1c55dc19da62` after checking source claims, mathematical and interpretive boundaries, the complete diff, and final artifact hashes and visuals. Its one citation finding was fixed and rechecked; no unresolved findings remain. Fresh exact-head CI is required before merge.
