### PR TITLE
refactor(ftip): consolidate architecture comparison definitions [AGENT]

### DIFF
--- a/trees/ftip-00JV.tree
+++ b/trees/ftip-00JV.tree
@@ -4,6 +4,10 @@
 \title{Common-recipe comparison arm}
 \tag{ftip}
 \p{A common-recipe arm fixes training data, optimizer family, schedule,
-post-training feedback, inference budget, and evaluation draws, then swaps
-only the architecture record. Deviations are recorded rather than silently
-called architecture effects.}
+post-training procedure and feedback, training and post-training budgets,
+inference budget, and evaluation protocol and draws.
+Interface-compatible parameter choices are declared in advance as part of
+each permitted architecture package. The comparison varies that package
+under the common recipe; any further deviation is recorded as a separate
+comparison coordinate. Its score difference measures performance under this
+recipe, not the best attainable result for either architecture.}

--- a/trees/ftip-00JW.tree
+++ b/trees/ftip-00JW.tree
@@ -3,6 +3,9 @@
 \taxon{Definition}
 \title{Equal-tuning-budget comparison arm}
 \tag{ftip}
-\p{Each architecture receives the same tuning-data volume, trial count,
-selection rule, and tuning cost. The resulting frontier measures practical
-efficiency under equal optimization effort, not best possible training.}
+\p{An equal-tuning-budget arm permits architecture-specific tuning under a
+predeclared protocol that fixes the tuning data and its volume, trial count,
+selection rule, stopping rule, and tuning cost for both architectures. The
+cost uses the same declared accounting rule. The resulting comparison
+measures practical performance under this equal optimization effort; it
+does not determine best possible training or a representation-only limit.}

--- a/trees/ftip-00JX.tree
+++ b/trees/ftip-00JX.tree
@@ -3,6 +3,17 @@
 \taxon{Definition}
 \title{Restricted-envelope comparison arm}
 \tag{ftip}
-\p{Declare an allowed intervention class #{\mathcal E_A} for each architecture
-and compare the suprema over #{\mathcal E_A} under the same cost cap. The
-classes must expose exclusions, search budgets, seeds, and stopping rules.}
+\p{A restricted-envelope arm declares an allowed intervention class
+#{\mathcal E_A\subseteq\mathfrak I_A} for each architecture, specifying the
+permitted training, post-training, and inference procedures. The classes
+expose exclusions, search budgets, seeds, and stopping rules. Restrict the
+evaluation functional of \ref{ftip-00JJ} to #{\mathcal E_A} and compare the
+resulting suprema under the same finite cost cap #{C\geq0}, common evaluation
+law, and common declared cost accounting.}
+
+\p{The measurable, integrable evaluation domain and extended-real
+conventions of \ref{ftip-00JJ} apply: an empty feasible class has value
+#{-\infty}, an unbounded-above feasible score set has value #{+\infty}, and
+a finite supremum need not be attained. The allowed class is part of the
+comparison, so its envelope is a restriction-dependent quantity, not an
+unrestricted architectural ceiling.}

--- a/trees/ftip-00LV.tree
+++ b/trees/ftip-00LV.tree
@@ -1,10 +1,9 @@
 \import{macros}
 \meta{agent-authored}{true}
-\taxon{Definition}
-\title{Common-recipe comparison}
+\taxon{Remark}
+\title{Paired responses to a common recipe}
 \tag{ftip}
-\p{The common-recipe comparison applies the same declared data, optimizer,
-post-training procedure, budgets, and evaluation protocol to each architecture,
-subject to interface-compatible parameter choices. It measures behavior under
-that recipe; it does not measure the best attainable result for either
-architecture.}
+\p{For a pair of matched model-instance records, the
+\vocabk{common-recipe arm}{ftip-00JV} measures how the permitted architecture
+packages respond to one recipe. A score advantage in this comparison need
+not persist after either package is retuned.}

--- a/trees/ftip-00LW.tree
+++ b/trees/ftip-00LW.tree
@@ -1,9 +1,9 @@
 \import{macros}
 \meta{agent-authored}{true}
-\taxon{Definition}
-\title{Equal-tuning-budget comparison}
+\taxon{Remark}
+\title{Different recipes under equal tuning effort}
 \tag{ftip}
-\p{The equal-tuning-budget comparison permits architecture-specific tuning,
-but fixes the tuning data, number of trials, stopping rule, and tuning cost.
-It measures practical performance under equal search effort rather than a
-representation-only limit.}
+\p{Under the \vocabk{equal-tuning-budget arm}{ftip-00JW}, the two selected
+model instances may use different recipes. That difference is compatible
+with equal predeclared tuning effort; forcing the selected recipes to match
+would answer a different comparison question.}

--- a/trees/ftip-00LX.tree
+++ b/trees/ftip-00LX.tree
@@ -1,9 +1,11 @@
 \import{macros}
 \meta{agent-authored}{true}
-\taxon{Definition}
-\title{Restricted-envelope comparison}
+\taxon{Remark}
+\title{How an allowed class changes its envelope}
 \tag{ftip}
-\p{A restricted envelope is the supremum of the declared evaluation score
-over an explicitly bounded class of training, post-training, and inference
-procedures at cost at most #{C}. The restriction is part of the statement;
-the envelope is not an unrestricted architectural ceiling.}
+\p{In the \vocabk{restricted-envelope arm}{ftip-00JX}, enlarging an allowed
+intervention class at fixed evaluation law, cost accounting, and budget can
+raise its envelope and cannot lower it. A finite search over feasible
+interventions supplies a lower bound from the scores it attains. It certifies
+the supremum only if it covers every feasible intervention or is accompanied
+by a matching upper-bound argument.}


### PR DESCRIPTION
The architecture chapter defined the same three comparison arms twice, with useful constraints split between the two locations. Make the common-recipe, equal-tuning-budget and restricted-envelope definitions canonical, retaining predeclared compatible choices, stopping and selection rules, cost accounting and allowed intervention classes.

Keep the three later stable addresses as interpretive Remarks about recipe-dependent rankings, different selected recipes under equal effort, and restricted-envelope evidence. Preserve the evaluation domains, extended-value and attainment conditions, incoming links, both parent hierarchies and the distinct transfer and negative-result mechanisms.

Validation: analytic and exact-rational comparison controls, 22 existing regression tests, lint/source prose, full local build, rendered-output/prose checks, ten browser routes, and visual inspection of the affected passages in the focused 236-page PDF. All 773 FTIP source and HTML files and the PDF are archived and hash-verified against the frozen source tree.

A fresh independent adversarial review approved the final source and artifacts at `01c3b28b7c4b831588f93b28e3ac97421f74b376`, with no unresolved findings.
