### PR TITLE
fix(ftip): distinguish archive maximizers and correct reliability arithmetic [AGENT]

### DIFF
--- a/trees/ftip-00ER.tree
+++ b/trees/ftip-00ER.tree
@@ -3,10 +3,21 @@
 \taxon{Definition}
 \title{Archive score envelope}
 \tag{ftip}
-\p{For finite task set #{\mathcal T}, define the evaluated mean score of chain
-#{a} by}
+\p{Let #{\mathcal T=\{t_1,\ldots,t_N\}} be a finite task set with
+#{N=|\mathcal T|\geq1}.
+For every chain #{a} in the [finite archive](ftip-00EQ), let #{s_i(a)\in\mathbb R}
+be its score on task #{t_i} under a declared common evaluation law. Define its
+whole-chain mean by}
 ##{J(a)=N^{-1}\sum_{i=1}^N s_i(a).}
-\p{When #{\mathcal A_D} is nonempty, its \newvocab{archive envelope} is}
+\p{For a nonempty archive #{\mathcal A_D}, its \newvocab{archive envelope} is}
 ##{J_D^{\max}=\max_{a\in\mathcal A_D}J(a).}
-\p{The envelope is an evaluation summary; it need not identify one deployable
-chain if scores were obtained under different configurations.}
+\p{The finite real-valued maximum is attained by at least one archived chain.
+It scores a single chain across all tasks; it does not select a different chain
+for each task.}
+\p{Deployment eligibility is a separate condition. A target configuration
+specifies which recorded chains can execute with their stated behavior and
+resource requirements. Maximizing over that eligible subset gives a deployable
+archive choice when the subset is nonempty; if it is empty, there is no eligible
+archived choice. Applying the recorded score to deployment additionally requires
+the same evaluation law. Records from different configurations alone do not
+establish these conditions.}

--- a/trees/ftip-00ET.tree
+++ b/trees/ftip-00ET.tree
@@ -4,8 +4,15 @@
 \title{Finite archive selection bound}
 \tag{ftip}
 \tag{finite-result}
-\p{Let #{a^\star} maximize #{J} over a finite nonempty archive and let #{\hat a}
-be an approximate selector with #{J(\hat a)\geq J(a^\star)-\delta}. Then}
+\p{Under the [archive score definition](ftip-00ER), let #{a^\star} maximize
+#{J} over a finite nonempty archive #{\mathcal A_D}. Let #{\delta\in\mathbb R}
+with #{\delta\geq0}, and let #{\hat a\in\mathcal A_D} satisfy
+#{J(\hat a)\geq J(a^\star)-\delta}. Then}
 ##{0\leq J(a^\star)-J(\hat a)\leq\delta.}
+\proof{
+  \p{Membership of #{\hat a} in the same archive gives
+  #{J(\hat a)\leq J(a^\star)} by maximality. Rearranging the approximation
+  inequality gives the upper bound.}
+}
 \p{This is a finite selection statement under the same evaluation law; it is
 not an optimizer-convergence or generalization theorem.}

--- a/trees/ftip-00F8.tree
+++ b/trees/ftip-00F8.tree
@@ -1,9 +1,22 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Example}
-\title{Archive-best is not one deployable policy}
+\title{Whole-chain maximum and per-task oracle}
 \tag{ftip}
-\p{Two chains can attain their best scores on disjoint task subsets. The
-archive envelope records the larger mean after selecting per-chain evaluations,
-but a deployment that must choose one chain cannot inherit both subsets. A
-common-task, common-seed evaluation is required for a deployable comparison.}
+\p{Consider two equally weighted tasks and an archive containing two chains
+#{a,b}, with score vectors #{(s_1(a),s_2(a))=(1,0)} and
+#{(s_1(b),s_2(b))=(0,1)} under the same evaluation law. The
+[archive envelope](ftip-00ER) is}
+##{J(a)=J(b)=J_D^{\max}=\frac12.}
+\p{Either chain attains this maximum. In contrast, a per-task oracle has value}
+##{\frac12\sum_{i=1}^2\max_{c\in\{a,b\}}s_i(c)=1.}
+\p{The oracle selects #{a} on the first task and #{b} on the second. A
+configuration constrained to select one archived chain before observing task
+identity obtains mean #{1/2} in this example. If task-dependent routing is
+permitted, the resulting combined policy must itself be declared and evaluated,
+including its routing and execution costs. The oracle value is not automatically
+the score of either archived chain.}
+\p{Incompatible execution configurations create a separate obstacle: an
+archived maximizing chain may be ineligible for a named target configuration.
+That feasibility restriction does not alter the distinction between the two
+score functionals above.}

--- a/trees/ftip-00H7.tree
+++ b/trees/ftip-00H7.tree
@@ -3,6 +3,8 @@
 \taxon{Example}
 \title{High aggregate agreement can hide a subgroup failure}
 \tag{ftip}
-\p{A grader that agrees on 99 of 100 easy cases but fails on the one safety
-case has agreement .99 and still fails the declared safety criterion. A
-calibration report therefore stratifies by failure-relevant labels.}
+\p{A grader that agrees on 99 of 100 easy cases but disagrees on the one
+safety case has overall agreement #{99/101\approx0.9802}. Its agreement within
+the safety subgroup is zero. Any positive safety-subgroup agreement threshold
+therefore rejects this grader despite its high overall agreement. A calibration
+report stratifies by failure-relevant labels.}


### PR DESCRIPTION
The archive example conflated the maximum of whole-chain mean scores with a per-task oracle. Keep the finite archive maximum, state its real-valued domain and attained maximizer, and separate eligibility under a named deployment configuration. The two-chain example now computes 1/2 for either fixed chain and 1 for task-dependent oracle selection; any implemented router remains a separately evaluated policy with its costs.

The selector bound now states membership in the same archive and a nonnegative approximation tolerance, with its proof. The grader example gives 99/101 overall agreement and zero agreement within the safety subgroup. Stable addresses, the wrapper/archive/reliability layers and neighboring domain conventions are preserved.

Validation: exact mathematical controls, all 22 existing prose tests and lint, full local build, rendered-output/prose checks, nine browser routes, and a visually inspected 237-page focused PDF passed. All 773 source files, 773 HTML payloads and the PDF are archived and verified against the candidate. A fresh independent adversarial review approved exact head `01df43cc4d0d1a7cd4dab29602c663b6f8094246` with no findings.
