### PR TITLE
fix(ftip): prove the finite noiseless preference bound [AGENT]

### DIFF
--- a/trees/ftip-008Y.tree
+++ b/trees/ftip-008Y.tree
@@ -7,13 +7,17 @@
 \tag{preference-data}
 \tag{source-status}
 
-\p{The results below come from the v1 preprint \citef{zhao2025limits}. Its
-model treats a pretrained system as a finite collection of response circuits
-plus learned maps that route queries to those circuits. Post-training changes
-the routing maps while retaining the circuit collection.}
-
-\p{This is a source assumption, not an architectural theorem about language
-models. In particular, the lower bounds do not prove that real post-training
-creates no circuits, that a neural network decomposes into the displayed
-objects, or that every preference-learning algorithm is subject to the same
-bound outside this model.}
+\p{The routing model and preference limits below are based on the v1 preprint
+\citef{zhao2025limits}. It models a pretrained system as a finite collection
+of response circuits plus learned maps that route queries to those circuits.
+Post-training changes the routing maps while retaining the circuit collection.}
+\p{The [noiseless lower bound](ftip-009A) is proved here under explicit
+pointwise response separation and a deterministic preference-only learner,
+whose returned router may be stochastic. Its finite partition estimate and
+cardinal-utility construction give a restricted reconstruction of the source
+rate; the proof does not establish a randomized-learner extension.}
+\p{The routing model is a source assumption, not an architectural theorem
+about language models. In particular, its lower bounds do not prove that
+real post-training creates no circuits, that a neural network decomposes into
+the displayed objects, or that every preference-learning algorithm obeys the
+same bound outside this model.}

--- a/trees/ftip-009A.tree
+++ b/trees/ftip-009A.tree
@@ -2,53 +2,152 @@
 \meta{agent-authored}{true}
 
 \taxon{Theorem}
-\title{General noiseless preference-distortion lower bound}
+\title{Noiseless preference distortion for deterministic learners}
 \tag{ftip}
 \tag{preference-data}
 \tag{lower-bound}
 
-\p{Call #{C_0} \newvocab{pointwise response-separating} when}
-
+\p{Let #{Q,H} be nonempty finite sets, let
+#{\varnothing\neq\mathfrak E\subseteq H^Q} be finite, and let
+#{C_0=\{c_1,\ldots,c_m\}} be a nonempty finite set of deterministic maps
+#{Q\to Y}. Write #{N=|Q|}, #{r=|H|}, #{p=|\mathfrak E|} and
+#{m=|C_0|}. The query law is uniform on #{Q}. Call #{C_0}
+\newvocab{pointwise response-separating} when}
 ##{
- c_i\neq c_j\quad\Longrightarrow\quad
- c_i(\xi)\neq c_j(\xi)
- \qquad(\xi\in Q).
+ c_i\neq c_j\quad\Longrightarrow\quad c_i(q)\neq c_j(q)
+ \qquad(q\in Q).
 }
-
-\p{Assume pointwise response separation. Then the statement of Appendix
-Theorem A.1, equation (3), in \citef{zhao2025limits} yields: for every
-pretrained routing model
-#{\mathfrak m_0} and every preference-only algorithm #{\mathcal A}, there
-exists a utility #{u} such that post-training on the complete noiseless profile
-satisfies}
-
+\p{Assume this separation. Let #{\mathcal A} be a deterministic
+preference-only learner: from a pretrained model #{\mathfrak m_0} and the
+complete strict ordinal profile, it returns #{(e,h,C_0)} with
+#{e\in\mathfrak E} and a possibly stochastic router
+#{h:H\to\Delta(C_0)}. The comparator class is exactly
+#{\mathcal M_{\rm det}(C_0)} of \ref{ftip-0096}, including every map
+#{H\to C_0} for each #{e\in\mathfrak E}.}
+\p{For every such pretrained model and learner there exists
+#{u:Q\times Y\to[0,1]}, inducing a strict profile, such that}
 ##{
- R_{Q,\mathfrak E,H}
- =\frac{|Q|}
- {\sqrt{|Q|(\log|\mathfrak E|+|H|)}+|H|},
+ \sum_{j=1}^m u(q,c_j(q))=1\quad(q\in Q),
 }
-
+##{
+ R_{Q,\mathfrak E,H}=\frac{N}{\sqrt{N(r+\log p)}+r},
+}
 ##{
  \operatorname{Dist}_u(\mathcal A;\mathfrak m_0)
- \geq
- \Omega\left(
- \min\left\{\sqrt{|C_0|},R_{Q,\mathfrak E,H}\right\}
- \right).
+ \geq\frac1{80}\min\{\sqrt m,R_{Q,\mathfrak E,H}\}.
+}
+\p{Logarithms are natural. Utility averages over the uniform query and the
+learner's router draw as in \ref{ftip-0093}. The comparator maximum exists
+because its class is finite and nonempty. It is positive for the normalized
+utilities above: some constant-circuit route has mean at least #{1/m}.
+A zero learner utility therefore gives distortion #{+\infty}, with no
+#{0/0} case.}
+
+\proof{
+ \p{First, for every normalized nonnegative utility, the comparator value
+ is at least the learner value. Keep the learner's representation map and,
+ on each fiber, choose a circuit maximizing its total utility there. That
+ deterministic choice dominates the stochastic mixture and belongs to the
+ comparator class. Thus distortion is at least one.}
+
+ \p{Put}
+ ##{
+ \begin{aligned}
+ D&=\sqrt{Nr}+\sqrt{\frac N2\log(4p)},&
+ B&=\sqrt{N(r+\log p)},\\
+ T&=\min\{\sqrt m,R_{Q,\mathfrak E,H}\},&
+ x&=\min\{\sqrt m,N/(2D)\}.
+ \end{aligned}
+ }
+ \p{Since #{(\log4)/2<1\leq r} and #{\log p\geq0}, we have
+ #{D\leq2B}. Consequently #{N/(2D)\geq N/(4B)\geq R_{Q,\mathfrak E,H}/4}
+ and #{x\geq T/4}. Every denominator is positive.}
+
+ \p{If #{m=1}, assign utility one to the sole circuit response at every
+ query. Distortion is one and #{T\leq1}. If #{m\geq2} but #{x<2}, assign
+ the same strict normalized values #{2(m-j)/(m(m-1))} to the circuits in
+ index order at every query. Distortion is at least one and #{T<8}, which
+ proves the claimed bound. Extend both assignments by zero to all other
+ responses.}
+
+ \p{In the remaining case set #{k=\lfloor x\rfloor}. Then}
+ ##{
+ 2\leq k\leq\sqrt m,\qquad kD\leq N/2,
+ \qquad k\geq x/2\geq T/8.
+ }
+ \p{Write #{[k]=\{1,\ldots,k\}} and fix a map #{f:Q\to[k]}
+ supplied by \ref{ftip-009C}. At a query with label #{i=f(q)}, fix the strict order
+ putting #{c_i} first and the remaining circuits in increasing index order.
+ Let #{\operatorname{rank}_i(j)\in\{1,\ldots,m\}} be the position of
+ #{c_j}, with the first circuit at rank one, and define}
+ ##{v_i(j)=\frac{2(m-\operatorname{rank}_i(j))}{m(m-1)}.}
+ \p{These values decrease strictly in the fixed order, sum to one and
+ lie in #{[0,2/m]}. The ordinal profile is now fixed independently of the
+ learner's output. Run the deterministic learner on this profile and
+ #{\mathfrak m_0}, obtaining #{(e,h,C_0)}. Write #{h_z(j)=h(z)(c_j)}
+ for the probability of circuit #{c_j} at representation #{z}. For each #{z\in H}, choose
+ #{i_z\in[k]} minimizing #{h_z(j)} over #{j\in[k]}, breaking ties by index.
+ Since #{\sum_{j=1}^k h_z(j)\leq1}, we have #{h_z(i_z)\leq1/k}.}
+
+ \p{Let #{A=\{q:f(q)=i_{e(q)}\}} and #{S=|A|}. The lower partition
+ bound gives}
+ ##{
+ S=\sum_zX_{z,i_z}\geq\sum_z\min_{j\in[k]}X_{z,j}
+ \geq N/k-D\geq N/(2k).
+ }
+ \p{Fix #{\epsilon=1/4}. For #{i=f(q)}, assign}
+ ##{
+ u(q,c_j(q))=
+ \begin{cases}
+ (1-\epsilon)\mathbf1_{j=i}+\epsilon v_i(j),&q\in A,\\
+ (1-\epsilon)/m+\epsilon v_i(j),&q\notin A.
+ \end{cases}
+ }
+ \p{Each row is nonnegative and sums to one. On selected queries the
+ added peak favors the already highest-ranked circuit; on the other
+ queries the same constant is added to every circuit. Hence every row
+ induces exactly the fixed strict order. Pointwise response separation
+ makes these assignments well-defined on #{Q\times Y}; assign zero to
+ responses outside the attained circuit responses. Because the final
+ utility has the unchanged ordinal profile, the deterministic learner
+ returns the same #{(e,h,C_0)}.}
+
+ \p{Write #{W=NU} for total utility. A selected query gives the learner
+ at most #{(1-\epsilon)/k+2\epsilon/m}; any other query gives at most
+ #{(1-\epsilon)/m+2\epsilon/m}. Averaging over the stochastic router yields}
+ ##{
+ W_{\mathcal A}
+ \leq(1-\epsilon)S/k+(1-\epsilon)(N-S)/m+2\epsilon N/m
+ \leq S/k+2N/m.
+ }
+ \p{Choose the deterministic comparator #{e^*=e} and #{h^*(z)=c_{i_z}}.
+ It belongs to the declared class, attains utility at least
+ #{1-\epsilon\geq1/2} on each selected query and nonnegative utility
+ elsewhere. Thus its total utility is at least #{S/2}. If learner utility
+ is zero the bound follows. Otherwise, using #{S\geq N/(2k)} and
+ #{k^2\leq m},}
+ ##{
+ \begin{aligned}
+ \operatorname{Dist}_u
+ &\geq\frac{S/2}{S/k+2N/m}
+ =\frac{k}{2(1+2kN/(mS))}\\
+ &\geq\frac{k}{2(1+4k^2/m)}
+ \geq\frac{k}{10}\geq\frac{T}{80}.
+ \end{aligned}
+ }
 }
 
-\p{The source states that the construction can keep utilities in #{[0,1]}
-and can additionally enforce}
-
-##{
- \sum_{c\in C_0}u\left(\xi,c(\xi)\right)=1
- \qquad(\xi\in Q).
-}
-
-\p{The source states the result for every pretrained model without the added
-separation hypothesis. Its appendix proof orders circuit indices and assigns
-utilities circuitwise; if two circuits return the same response at one query,
-that assignment need not descend to a function on #{Q\times Y}. The
-pointwise response-separation assumption ensures that utilities are
-well-defined on this response domain.
-The quantifier remains worst-case and existential in #{u}, and the comparator
-is the deterministic class in \ref{ftip-0096}.}
+\p{Appendix Theorem A.1 of \citef{zhao2025limits} states the corresponding
+rate for its routing model. Its displayed balancing parameter retains
+#{\log N} factors that are absent from its final rate; the second-moment
+partition bound in \ref{ftip-009C} supplies a separate argument for the
+stated restricted model. Its index-based perturbation on queries outside the
+selected group need not preserve their prescribed favorite; the
+query-dependent rank weights used here preserve it. When circuits collide at
+a query, a circuitwise prescription need not define a response utility;
+pointwise separation excludes that issue.}
+\p{The utility is a worst-case existential choice for each fixed learner.
+The proof permits stochastic inference, but it does not cover internal
+learner randomness: a utility chosen after a realized random output need not
+be one utility valid before the learner's random draw. No claim about
+response-colliding circuits or the separate noisy-preference bound follows.}

--- a/trees/ftip-009B.tree
+++ b/trees/ftip-009B.tree
@@ -7,24 +7,17 @@
 \tag{preference-data}
 \tag{lower-bound}
 
-\p{Under the response-separation hypothesis of
-\ref{ftip-009A}, assume the explicit condition}
-
-##{
- R_{Q,\mathfrak E,H}\geq\sqrt{|C_0|}.
-}
-
-\p{Then for every #{\mathfrak m_0} and #{\mathcal A}, the utility supplied by
-\ref{ftip-009A} satisfies}
-
+\p{Under all hypotheses of \ref{ftip-009A}, including a deterministic
+preference-only learner and pointwise response separation, assume}
+##{R_{Q,\mathfrak E,H}\geq\sqrt{|C_0|}.}
+\p{For every pretrained model and every such learner, the utility supplied
+by that theorem satisfies}
 ##{
  \operatorname{Dist}_u(\mathcal A;\mathfrak m_0)
- \geq\Omega\left(\sqrt{|C_0|}\right).
+ \geq\frac1{80}\sqrt{|C_0|}.
 }
-
-\proof{\p{Under the displayed condition, the minimum in \ref{ftip-009A} is
-#{\sqrt{|C_0|}}.}}
-
+\proof{\p{The displayed growth condition makes the minimum in
+\ref{ftip-009A} equal to #{\sqrt{|C_0|}}.}}
 \p{Theorem 3.3 of \citef{zhao2025limits} gives a square-root rate in its
-large-query regime. The displayed condition specifies a finite regime in which
-the general minimum in \ref{ftip-009A} reduces to its square-root term.}
+large-query regime. The explicit condition above gives a finite regime for
+the reconstructed theorem with its stated learner and response assumptions.}

--- a/trees/ftip-009C.tree
+++ b/trees/ftip-009C.tree
@@ -1,32 +1,66 @@
 \import{macros}
 \meta{agent-authored}{true}
 
-\taxon{Remark}
-\title{Proof dependencies of the noiseless lower bound}
+\taxon{Lemma}
+\title{A simultaneous finite partition bound}
 \tag{ftip}
 \tag{preference-data}
-\tag{proof-route}
+\tag{finite-result}
 
-\p{Appendix A.1 of \citef{zhao2025limits} constructs one preference profile
-that is compatible with many cardinal utilities. Its proof then chooses a
-utility after seeing the algorithm's routing behavior and compares that
-behavior with an attainable deterministic route.}
+\p{Let #{Q,H} be nonempty finite sets with #{N=|Q|} and #{r=|H|}, and
+let #{\mathfrak E\subseteq H^Q} be nonempty and finite with
+#{p=|\mathfrak E|}. For every integer #{k\geq1}, there is a map
+#{f:Q\to[k]} such that, simultaneously for every #{e\in\mathfrak E},}
+##{
+ \begin{aligned}
+ \sum_{z\in H}\max_{j\in[k]}X_{z,j}&\leq\frac Nk+D,\\
+ \sum_{z\in H}\min_{j\in[k]}X_{z,j}&\geq\frac Nk-D,
+ \end{aligned}
+}
+\p{where #{[k]=\{1,\ldots,k\}}, logarithms are natural, and}
+##{
+ X_{z,j}=|\{q\in Q:e(q)=z,\ f(q)=j\}|,
+ \qquad
+ D=\sqrt{Nr}+\sqrt{\frac N2\log(4p)}.
+}
 
-\tikzfig{\begin{tikzpicture}[
- box/.style={draw,rounded corners,align=center,text width=27mm,
- minimum height=9mm,font=\small},
- arr/.style={->,>=stealth,semithick},
- lab/.style={font=\scriptsize,fill=white,inner sep=1pt}
-]
-\node[box] (l) at (-3.5,1.25) {Lemma A.2\\routing partition};
-\node[box] (c) at (0,1.25) {Claim A.3 and\\Fact A.4};
-\node[box] (u) at (-1.75,-1.25) {adversarial bounded\\utility};
-\node[box] (t) at (2.8,-1.25) {Theorem A.1\\distortion};
-\draw[arr] (l) -- (c);
-\draw[arr] (l) -- (u);
-\draw[arr] (c) -- (u);
-\draw[arr] (u) -- node[lab,above]{compare routes} (t);
-\end{tikzpicture}}
+\proof{
+ \p{Choose the labels #{f(q)} independently and uniformly from #{[k]}.
+ Fix #{e,z}, write #{n_z=|e^{-1}(z)|}, and put
+ #{a_j=X_{z,j}-n_z/k}. Each occupancy has variance
+ #{n_z(1/k)(1-1/k)}, so}
+ ##{\mathbb E\sum_{j=1}^k a_j^2=n_z(1-1/k).}
+ \p{The pointwise maximum and minimum satisfy}
+ ##{
+ \begin{aligned}
+ \max_jX_{z,j}&\leq n_z/k+\|a\|_2,\\
+ \min_jX_{z,j}&\geq n_z/k-\|a\|_2.
+ \end{aligned}
+ }
+ \p{Jensen's inequality gives
+ #{\mathbb E\|a\|_2\leq\sqrt{n_z(1-1/k)}}. Summing over #{z} and
+ applying Cauchy--Schwarz yields}
+ ##{
+ \begin{aligned}
+ \mathbb E\sum_z\max_jX_{z,j}&\leq N/k+\sqrt{Nr(1-1/k)},\\
+ \mathbb E\sum_z\min_jX_{z,j}&\geq N/k-\sqrt{Nr(1-1/k)}.
+ \end{aligned}
+ }
+ \p{Changing one label changes only one representation group: one
+ occupancy decreases by one and another increases by one. Its maximum and
+ its minimum each change by at most one. Thus both sums have bounded
+ differences with all #{N} constants equal to one. McDiarmid's inequality,
+ also used in Appendix A.1 of \citef{zhao2025limits}, bounds each relevant
+ one-sided deviation of size #{t} by #{\exp(-2t^2/N)}.}
+ \p{Choose #{t=\sqrt{(N/2)\log(4p)}}. A union bound over both tails and
+ all #{p} representations gives total failure probability at most}
+ ##{2p\exp(-2t^2/N)=\frac12<1.}
+ \p{At least one deterministic labeling satisfies both claimed bounds,
+ since #{\sqrt{Nr(1-1/k)}\leq\sqrt{Nr}}. Empty representation fibers
+ have all occupancies zero and require no exception.}
+}
 
-\p{Appendix A.1 combines the displayed partition and utility constructions.
-The adversarial choice of utility is essential to its worst-case quantifiers.}
+\p{The bound uses a second-moment estimate in place of the occupancy estimate
+in source Lemma A.2. The chosen labeling depends only on
+#{Q,H,\mathfrak E,k}; its existence uses proof randomness and does not assume
+randomness in the learning algorithm.}


### PR DESCRIPTION
The noiseless preference bound previously quoted a rate whose displayed source proof drops logarithmic factors. This change supplies a complete finite proof with constant 1/80 for a deterministic preference-only learner whose returned router may be stochastic, under pointwise response separation. A simultaneous second-moment partition lemma, fixed strict ordinal profile and explicit attainable comparator establish the bound; the square-root corollary inherits every hypothesis.

The four changed sources distinguish this restricted reconstruction from the source's unrestricted claim and from extensions involving randomized learners, colliding responses or noisy preferences. Existing response separation, rate references and finite cardinal-query results remain intact.

Validation: analytic and finite controls, all 22 existing regressions, lint, source/rendered prose, full 2266-page build/output checks, nine local browser routes, all affected pages of the 241-page focused PDF, and complete source/HTML/PDF archive checks passed. A fresh independent adversarial review approved the exact candidate after checking the full finite proof, primary source, complete archived payloads and rendered proof continuations; no findings remain.
