### PR TITLE
feat(ftip): define finite coordination under hard budgets

### DIFF
--- a/trees/ftip-00C2.tree
+++ b/trees/ftip-00C2.tree
@@ -25,3 +25,4 @@ the displayed finite results are proved here.}
 \transclude{ftip-00CD}
 \transclude{ftip-00CN}
 \transclude{ftip-00CY}
+\transclude{ftip-00M3}

--- a/trees/ftip-00M3.tree
+++ b/trees/ftip-00M3.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Finite coordination under hard budgets}
+\tag{ftip}
+\tag{inference}
+
+\p{A harness chooses which computation to run, what to retain, and when to
+stop. To bound the quality attainable by these choices, one must specify
+both the permitted actions and the information available after each action.
+A bound on one scheduler does not yet bound all controllers using the same
+workers.}
+
+\p{Finite decision models make this distinction explicit. They connect
+\ref{ftip-00CJ}'s resource admission rule to the attainable-quality frontier
+of \ref{ftip-00JJ}. Computation selection as information acquisition is
+studied by [Hay, Russell, Tolpin, and Shimony](https://arxiv.org/abs/1207.5879).
+Here a hard horizon is imposed as a separate assumption; almost-sure stopping
+or finite expected cost would not supply such a horizon.}
+
+\transclude{ftip-00M4}

--- a/trees/ftip-00M4.tree
+++ b/trees/ftip-00M4.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Histories, admissible actions, and retained information}
+\tag{ftip}
+
+\p{The controller may use its entire observed history. A smaller state can
+help compute a bound, but its sufficiency must be justified across the
+histories it represents. The examples below separate information that is
+valuable only in combination from information lost by a summary.}
+
+\transclude{ftip-00M5}
+\transclude{ftip-00M6}
+\transclude{ftip-00M7}

--- a/trees/ftip-00M5.tree
+++ b/trees/ftip-00M5.tree
@@ -1,0 +1,61 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Finite controller class with hard resource admission}
+\tag{ftip}
+\tag{compute}
+
+\p{Fix a horizon #{H\in\mathbb N}, finite nonempty observed-history sets
+#{\mathcal H_t} for #{0\leq t\leq H}, an initial law #{\mu} on
+#{\mathcal H_0}, and finite nonempty permitted-action sets #{A_t(h)}
+for #{t<H}. An environment kernel #{K_t(\cdot\mid h,a)} is a probability
+law on histories extending #{h} by action #{a} and its observed outcome.
+The initial law and all kernels are fixed before choosing a controller.}
+
+\p{A controller #{\pi} assigns a probability law
+#{\pi_t(\cdot\mid h)} on #{A_t(h)}. It may depend on every observed
+component of #{h}, including retained traces, generated programs, and
+previous updates. Random choices may be recorded in the history. The class
+#{\Pi(\mathbf B)} consists of all such controllers under the declared
+hard resource vector #{\mathbf B\in\mathbb R_+^m}. It does not require
+a fixed prompt, a memoryless policy, or independent worker outputs.
+Full-history access is allowed in this mathematical class; it may enlarge
+the class of executable controllers with limited memory or computation.}
+
+\p{Each history records accumulated nonnegative cost
+#{\mathbf c(h)\preceq\mathbf B}. Every permitted non-stop action has a
+declared worst-case increment #{\bar{\mathbf c}_t(h,a)} satisfying}
+##{
+\mathbf c(h)+\bar{\mathbf c}_t(h,a)\preceq\mathbf B.
+}
+\p{Every successor in the kernel's support must have realized increment
+between zero and this declared bound, componentwise. Proposal work,
+controller computation, worker calls, communication, verification, failed
+attempts, and persistent updates must be included in whichever resource
+coordinates are bounded; the units remain those of \ref{ftip-005H}.
+This is the enforced-contract assumption of \ref{ftip-00CK}.}
+
+\p{A stop action is always permitted: it commits the current terminal
+artifact and pads the remaining steps with no further cost or change in
+its evaluated quality. At the horizon a fixed evaluator assigns
+#{q(h_H)\in[0,1]} to the committed artifact recorded in the terminal
+history. If the evaluator has random outcomes, include them in the
+history law. Evaluation work must be charged before the zero-cost padding
+begins. Define}
+##{
+J(\pi)=\mathbb E_\pi[q(h_H)],
+\qquad V(\mathbf B)=\sup_{\pi\in\Pi(\mathbf B)}J(\pi).
+}
+
+\p{The artifact identity, evaluator, observations, kernels, and action
+sets are part of the mathematical problem. A training procedure or new
+tool belongs to this frontier only if it is among the permitted actions
+and its effects and costs are represented. Finiteness is an explicit
+restriction on histories, representations, and horizon; a theorem for
+this class does not bound an unrestricted agent that can extend them.}
+
+\p{For an executable system, an upper bound applies only after its
+observations, actions, outcomes, and charged costs are represented by this
+model. Conversely, a mathematical policy supplies an executable lower bound
+only when it has an implementation respecting the stated resource cap;
+an arbitrary history-to-action table does not establish that fact.}

--- a/trees/ftip-00M6.tree
+++ b/trees/ftip-00M6.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Complementary observations defeat one-step information value}
+\tag{ftip}
+
+\p{Let #{X,Y} be independent uniform bits. The terminal artifact is a guess
+for #{X\mathbin\oplus Y}; its quality is one if correct and zero otherwise.
+Two observation actions reveal #{X} and #{Y}, respectively, at cost
+#{c} each, where #{0<c<1/4}. The hard budget permits both observations.
+A terminal guess requires no additional observation cost.}
+
+\p{Without observations, the best expected quality is #{1/2}. Given
+only #{X}, the unrevealed bit #{Y} remains uniform, so the best expected
+quality is still #{1/2}; the same holds with #{X,Y} exchanged. Thus a rule
+that compares stopping with taking one observation and then stopping
+assigns either observation net value #{1/2-c<1/2}. It stops immediately.}
+
+\p{Observing both bits determines their parity. Its expected quality is
+one and its quality minus observation cost is
+#{1-2c>1/2}. Hence neither zero one-step information value nor a myopic
+stopping decision certifies the full controller frontier. This is a finite
+calculation, not an empirical claim about a language model. The scalar
+cost penalty is used only to exhibit the myopic decision; the hard-budget
+quality frontier itself is defined in \ref{ftip-00M5}.}

--- a/trees/ftip-00M7.tree
+++ b/trees/ftip-00M7.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{Erasing an observed bit changes the attainable frontier}
+\tag{ftip}
+
+\p{An initial observation reveals a uniform bit #{Z}. The terminal action
+is a bit #{a}, and quality is #{q=\mathbf 1\{a=Z\}}. Both actions are
+permitted at either history and have the same cost. A full-history
+controller chooses #{a=Z} and attains quality one.}
+
+\p{Now restrict the controller's entire input to a summary that is
+constant at the two initial histories. Its private randomness is
+independent of #{Z}. If it chooses one with probability #{p}, its expected
+quality is #{p/2+(1-p)/2=1/2}. No such summary controller can do better.}
+
+\p{A model that averages the reward of either fixed action over the two
+histories obtains #{1/2}. This is the correct summary-controller value,
+but it underestimates the full-history frontier by #{1/2}. For the
+history #{Z=a}, the actual reward is one, so the averaged value fails as
+a reward upper bound at that history. A pointwise reward upper bound must
+hold at every represented history; agreement only under a tested policy's
+average history distribution does not establish such a certificate.
+The loss of an evaluator caveat in \ref{ftip-00CU} illustrates why such
+retained distinctions can matter in a research harness.}


### PR DESCRIPTION
Adds a finite controller model inside the existing persistent-harness section: observed histories, permitted actions, realized hard budgets, stopping, and terminal quality. Two complete examples show why individually uninformative observations can be useful together and why erasing history can invalidate a value bound.

The six chapter wrappers and existing addresses are preserved. This defines a mathematical controller class; executable policies need their own implementation and cost evidence.

Validation: `just chk` (22 tests and source prose), full `just build` and `just verify-render` (2271 pages), focused FTIP PDF (244 pages), affected HTML/PDF inspection, and fresh independent mathematical and prose review approving `ac2026ca06f8ba76020b9bfef9b5d577e924f664` after correcting the scope of the erased-state warning.
