### PR TITLE
feat(ftip): certify finite controller potential with Bellman bounds

### DIFF
--- a/trees/ftip-00LM.tree
+++ b/trees/ftip-00LM.tree
@@ -11,3 +11,7 @@ lower bound gives #{V_A(C)\geq U-\varepsilon}, then
 values are therefore finite real, and
 #{0\leq V_A(C+\delta)-V_A(C)\leq\varepsilon}. This is a conditional bound
 for the named frontier; it proves no universal saturation of intelligence.}
+
+\p{For the finite controller class with hard resource admission,
+\ref{ftip-00MC} obtains the required bounds from a feasible controller
+and a uniform Bellman certificate.}

--- a/trees/ftip-00M3.tree
+++ b/trees/ftip-00M3.tree
@@ -18,3 +18,4 @@ Here a hard horizon is imposed as a separate assumption; almost-sure stopping
 or finite expected cost would not supply such a horizon.}
 
 \transclude{ftip-00M4}
+\transclude{ftip-00M8}

--- a/trees/ftip-00M8.tree
+++ b/trees/ftip-00M8.tree
@@ -1,0 +1,16 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Upper certificates and remaining potential}
+\tag{ftip}
+
+\p{A feasible controller establishes attainable quality. To bound what
+other controllers could gain, one also needs an upper bound covering all
+permitted actions and histories. Bellman inequalities provide such a
+bound when a state representation has uniform transition and terminal
+quality guarantees. Their difference measures remaining potential within
+the declared class.}
+
+\transclude{ftip-00M9}
+\transclude{ftip-00MA}
+\transclude{ftip-00MB}
+\transclude{ftip-00MC}

--- a/trees/ftip-00M9.tree
+++ b/trees/ftip-00M9.tree
@@ -1,0 +1,34 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Uniform abstraction of the finite history model}
+\tag{ftip}
+
+\p{Use the finite controller model of \ref{ftip-00M5}. For each time,
+choose a finite nonempty state set #{S_t} and a map
+#{\phi_t:\mathcal H_t\to S_t}. Require finite nonempty action sets
+#{A_t(s)} such that #{A_t(h)=A_t(\phi_t(h))} at every history. The state
+retains residual budgets and enough information for the same hard
+admission rule. The controller still observes the full history.}
+
+\p{Let #{Q_t(\cdot\mid h,a)} be the image of the fixed history kernel
+under #{\phi_{t+1}}, and let #{\widehat P_t(\cdot\mid s,a)} be a
+proposed state transition law. Choose finite errors #{\epsilon_t(s,a)\geq0}
+so that, for every permitted history and action,}
+##{
+\operatorname{TV}\left(Q_t(\cdot\mid h,a),
+\widehat P_t(\cdot\mid\phi_t(h),a)\right)
+\leq\epsilon_t(\phi_t(h),a),
+\qquad \operatorname{TV}(p,r)=\frac12\sum_x|p(x)-r(x)|.
+}
+\p{This condition includes histories unvisited by a chosen policy: the
+kernel there is part of the model. For finite functions
+#{\widehat q:S_H\to\mathbb R} and #{e_H:S_H\to\mathbb R_+}, require}
+##{
+q(h_H)\leq\widehat q(\phi_H(h_H))+e_H(\phi_H(h_H))
+\quad\text{for every }h_H\in\mathcal H_H.
+}
+\p{Write #{\nu(s)=\mu\{h:\phi_0(h)=s\}} for the initial state law.
+Low average prediction error on sampled histories does not establish
+these uniform inequalities. The erased-bit example in \ref{ftip-00M7}
+shows why policy-relevant information cannot simply be averaged away.}

--- a/trees/ftip-00MA.tree
+++ b/trees/ftip-00MA.tree
@@ -1,0 +1,60 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Theorem}
+\title{A robust Bellman upper bound for every permitted controller}
+\tag{ftip}
+
+\p{Under \ref{ftip-00M9}, let finite functions #{W_t:S_t\to\mathbb R}
+satisfy #{W_H(s)\geq\widehat q(s)+e_H(s)} and, for every #{t<H},
+#{s\in S_t}, and #{a\in A_t(s)},}
+##{
+W_t(s)\geq\sum_{s'\in S_{t+1}}\widehat P_t(s'\mid s,a)W_{t+1}(s')
++\epsilon_t(s,a)\operatorname{span}(W_{t+1}).
+}
+\p{Here #{\operatorname{span}(f)=\max f-\min f}. Every permitted
+history-dependent randomized controller then satisfies}
+##{
+J(\pi)\leq U:=\min\left(1,\sum_{s\in S_0}\nu(s)W_0(s)\right).
+}
+\p{For any feasible controller #{\pi_0} with a justified finite lower
+bound #{L\leq J(\pi_0)}, the frontier of \ref{ftip-00M5} obeys}
+##{
+L\leq J(\pi_0)\leq V(\mathbf B)\leq U,
+\qquad 0\leq V(\mathbf B)-J(\pi_0)\leq U-L.
+}
+
+\proof{
+\p{For finite probability laws #{p,r}, subtract #{\min f} from #{f}.
+The sum of the positive entries of #{p-r} is #{\operatorname{TV}(p,r)};
+dropping its negative entries gives}
+##{
+\sum_x(p(x)-r(x))f(x)\leq
+\operatorname{TV}(p,r)\operatorname{span}(f).
+}
+\p{Fix any controller. At time #{H}, terminal domination gives
+#{q(h_H)\leq W_H(\phi_H(h_H))}. Suppose that, from every next history,
+its expected terminal quality is bounded by #{W_{t+1}} of the next state.
+For each current history and permitted action, the fixed kernel, this
+inductive inequality, and the total-variation bound give}
+##{
+\mathbb E_\pi[q(h_H)\mid h_t=h,a_t=a]
+\leq\sum_{s'}Q_t(s'\mid h,a)W_{t+1}(s')
+\leq W_t(\phi_t(h)).
+}
+\p{At a history with zero probability under the controller, interpret the
+continuation expectation using its specified future decisions and the
+fixed kernels. Thus the induction holds at every history. Averaging over
+the controller's action randomization preserves the inequality. Backwards
+induction and averaging over #{\mu} give the bound #{\sum_s\nu(s)W_0(s)}.
+The independent bound #{q\leq1} permits clipping at 1. If #{H=0}, terminal
+domination alone gives the same conclusion. Taking the supremum over
+controllers and using #{L\leq J(\pi_0)} proves the remaining inequalities.}
+}
+
+\p{A numerical supersolution is a certificate only after all of its
+inequalities and the abstraction hypotheses are justified. If the model
+bounds hold jointly with probability at least #{1-\delta_M} and the
+lower bound with probability at least #{1-\delta_E}, the bracket holds
+with probability at least #{1-\delta_M-\delta_E} by a union bound. Each
+coverage statement must apply to the selected model or policy; no
+independence between the two events is required.}

--- a/trees/ftip-00MB.tree
+++ b/trees/ftip-00MB.tree
@@ -1,0 +1,44 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Remark}
+\title{Exact occupation flows and expected-cost relaxations}
+\tag{ftip}
+
+\p{Suppose the abstraction is exact: #{Q_t(\cdot\mid h,a)=
+P_t(\cdot\mid\phi_t(h),a)} for all histories and actions, and terminal
+quality is exactly #{q(h_H)=r(\phi_H(h_H))}. A one-sided terminal bound
+with zero error would not imply this equality. Retain the exact legal
+actions and hard-budget state from \ref{ftip-00M9}.}
+
+\p{Introduce nonnegative state masses #{z_t(s)} and action masses
+#{x_t(s,a)}, with #{z_0=\nu}. For #{0\leq t<H}, impose}
+##{
+\sum_{a\in A_t(s)}x_t(s,a)=z_t(s),
+\qquad z_{t+1}(s')=\sum_{s\in S_t}\sum_{a\in A_t(s)}
+x_t(s,a)P_t(s'\mid s,a).
+}
+\p{The linear program maximizes #{\sum_s z_H(s)r(s)}. Every
+full-history controller induces these flows because the next-state law
+given a state and action is exact. Conversely, at positive mass choose
+action #{a} with probability #{x_t(s,a)/z_t(s)}; at zero mass choose any
+legal action. Induction on time reproduces the flows in the original
+history model. Hence the LP optimum equals its mathematical controller
+frontier. For #{H=0}, there are no action flows and the value is #{\nu r}.}
+
+\p{Set #{W_H=r} and recurse with
+#{W_t(s)=\max_{a\in A_t(s)}\sum_{s'}P_t(s'\mid s,a)W_{t+1}(s')}.
+A maximizing action exists by finiteness and gives a policy attaining
+#{\nu W_0}; the Bellman upper bound gives the reverse inequality.
+This proves equality with the optimum and exhibits matching lower and
+upper certificates. It does not establish an efficient implementation
+of the policy. The flow construction is the scalar finite-horizon
+specialization of [Mifrani and Noll, Section 3](https://arxiv.org/abs/2502.13697v3);
+the hard-budget encoding is an additional modeling requirement here.}
+
+\p{If hard admission is replaced by constraints on expected cost,
+the resulting program describes a different class. For #{B>0}, a
+one-step cost equal to #{2B} or zero with probability #{1/2} each has
+expectation #{B}, yet violates cap #{B} with probability #{1/2}.
+An expected-cost model can upper-bound the hard-budget frontier only
+when it is a valid relaxation containing every hard-feasible policy.
+Its own policies need not respect the realized cap.}

--- a/trees/ftip-00MC.tree
+++ b/trees/ftip-00MC.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Corollary}
+\title{Certified marginal potential under nested budgets}
+\tag{ftip}
+
+\p{Fix the task law, evaluator, initial model, tools, observations,
+horizon, and intervention class. For #{\mathbf B\preceq\mathbf B'},
+assume every controller feasible at #{\mathbf B} remains permitted at
+#{\mathbf B'} with the same outcome law. If a feasible controller at
+#{\mathbf B} gives lower bound #{L_{\mathbf B}} and \ref{ftip-00MA}
+gives upper bound #{U_{\mathbf B'}} at #{\mathbf B'}, then}
+##{
+0\leq V(\mathbf B')-V(\mathbf B)
+\leq U_{\mathbf B'}-L_{\mathbf B}.
+}
+\proof{
+\p{Feasibility inclusion gives #{V(\mathbf B)\leq V(\mathbf B')}.
+The lower and upper certificates give
+#{L_{\mathbf B}\leq V(\mathbf B)} and
+#{V(\mathbf B')\leq U_{\mathbf B'}}; subtract to obtain the claim.}
+}
+\p{If the certified gap is at most #{\varepsilon}, this instantiates
+\ref{ftip-00LM}'s conditional saturation statement. An observed plateau
+alone supplies no such upper certificate. Changing an excluded tool,
+representation, or training procedure changes the comparison class.}


### PR DESCRIPTION
Connects the finite hard-budget controller model to a certified interval for attainable quality. A uniform Bellman inequality bounds every permitted history-dependent controller; a feasible policy supplies the lower bound, and nested budgets give a bound on remaining marginal potential.

The patch includes the complete finite proof, an exact occupation-flow and dynamic-programming specialization, and a counterexample separating expected costs from realized hard caps. It adds one certificate subsection and a short link from the existing conditional saturation theorem, preserving the chapter structure and existing addresses.

Validation: source prose and 22 tests, full build/render verification of 2276 page pairs, focused FTIP PDF (247 pages), ten affected browser routes, visual inspection of PDF pages 206–209 including proof continuation, and exact finite arithmetic checks. No solver, general certificate checker, agent experiment, or Lean proof is implemented by this exposition.

Fresh independent mathematical, source, prose, hierarchy, and artifact review approves exact head `94d58ea37f508b9b936e8e2e96bf7a4f55290caa`. A long PDF display was shortened before final approval; proof continuity and final artifacts were rechecked.
