### PR TITLE
docs(ftip): control coordination comparisons and bound fixed-DAG scheduling [AGENT]

### DIFF
--- a/trees/ftip-00M3.tree
+++ b/trees/ftip-00M3.tree
@@ -19,3 +19,5 @@ or finite expected cost would not supply such a horizon.}
 
 \transclude{ftip-00M4}
 \transclude{ftip-00M8}
+\transclude{ftip-00MD}
+\transclude{ftip-00MF}

--- a/trees/ftip-00MD.tree
+++ b/trees/ftip-00MD.tree
@@ -1,0 +1,63 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Comparing controllers at fixed worker capability}
+\tag{ftip}
+
+\p{To isolate coordination, fix the worker checkpoints, tool interfaces,
+prompt templates, evaluator, task law, and hard resource caps before
+varying the controller. Useful comparisons include a fixed serial policy,
+a static worker portfolio, a one-step value-of-information policy, and
+an adaptive policy that retains the full permitted history. Their
+allowed observations must agree. A solver that sees hidden outcomes has
+a different information interface; its optimum supplies an upper bound
+only through a justified relaxation containing the compared policies.}
+
+\p{Use the controls of \ref{ftip-00JV} with controller logic declared as
+the varying coordinate. If controller-specific tuning is permitted,
+apply \ref{ftip-00JW}'s equal tuning data, selection, stopping, and cost
+rules. Compare suprema only within the intervention classes of
+\ref{ftip-00JX}. A separate factorial comparison can vary the checkpoint
+and controller independently, distinguishing learned capability,
+coordination, and their interaction.}
+
+\p{Charge proposal and controller work, all parallel worker work, tool
+and solver use, communication, verification, failures, and retained-state
+updates using \ref{ftip-005H}. Report elapsed time alongside these costs:
+a shorter run with more workers may consume more total computation.
+Apply \ref{ftip-00CJ}'s admission rule before execution and record any
+contract violation separately from the quality of the submitted artifact.}
+
+\p{Finite environments with rational transition laws can expose three
+distinct mechanisms: complementary observations, correlated worker
+failures, and delayed verification or newly revealed dependencies. Keep
+the latent state, observation rules, legal actions, and costs explicit.
+The first family includes \ref{ftip-00M6}; the erased-bit construction in
+\ref{ftip-00M7} tests whether a proposed summary loses decisive information.
+Where the exact model applies, compare attainable policy values with
+\ref{ftip-00MB}'s finite optimum and \ref{ftip-00MA}'s upper certificate.}
+
+\p{The principal quantity is the justified interval
+#{[L_{\mathbf B},U_{\mathbf B}]} for the restricted frontier. A smaller
+gap can result from a better feasible policy, a sharper upper certificate,
+or a more informative valid representation; distinguish these causes.
+In a live system, mean held-out transition accuracy does not justify
+a uniform model-error radius. Empirical quality and cost remain useful
+even when an upper certificate is unavailable.}
+
+\p{Use evaluation instances separate from tuning, and declare task draws,
+repetitions, resource checkpoints, and analysis rules before comparison.
+Repeated runs share an instance and are not automatically independent
+tasks; account for this grouping in the analysis. Report independently
+verified quality, feasibility failures, time to the first valid artifact,
+and charged cost at matched quality. A valid confidence sequence can
+support repeated inspection under its statistical assumptions; see
+[Howard et al.](https://arxiv.org/abs/1810.08240v9). It does not by itself
+justify selecting a new policy on reused evaluation outcomes.}
+
+\p{These controls yield testable predictions. Complementary information
+can favor adaptation over one-step stopping; redundant workers can erase
+a portfolio's gain; delayed verification can make an early apparent
+success expensive to repair. An empirical claim of better coordination
+fails if its advantage disappears after matching access and charging the
+controller's own work. A claim of little remaining potential additionally
+requires the upper certificate, not merely a plateau among tested policies.}

--- a/trees/ftip-00MF.tree
+++ b/trees/ftip-00MF.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Work and critical paths in a fixed task graph}
+\tag{ftip}
+
+\p{When the tasks, dependencies, and durations are fixed, scheduling has
+a useful lower bound independent of the chosen priority rule. This
+isolates avoidable delay in a declared decomposition. Discovering a
+missing dependency or changing a mathematical formulation changes that
+decomposition and is a different intervention.}
+
+\p{The following work-and-chain argument is the classical list-scheduling
+bound associated with [Graham](https://vtda.org/pubs/BSTJ/vol45-1966/articles/bstj45-9-1563.pdf).
+His examples also show that a particular list schedule can worsen after
+an apparently favorable change, such as adding processors. This does
+not contradict monotonicity of the optimal feasible frontier.}
+
+\transclude{ftip-00MG}

--- a/trees/ftip-00MG.tree
+++ b/trees/ftip-00MG.tree
@@ -1,0 +1,54 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{proposition}
+\title{A work and critical-path bound for list scheduling}
+\tag{ftip}
+
+\p{Fix a finite nonempty directed acyclic task graph, positive task
+durations #{p_j}, and #{m} identical processors, where
+#{m\in\mathbb N} and #{m\geq1}. All tasks are
+available at time zero subject only to their precedence constraints.
+Each task uses one processor without interruption; there are no further
+resource, communication, or setup constraints. Let #{W=\sum_j p_j},
+let #{D} be the longest precedence-chain duration, and let #{T^*} be
+the minimum makespan. A work-conserving list schedule starts a ready task
+whenever a processor is free. Its makespan #{T_{\mathrm{list}}} satisfies}
+##{
+\max(W/m,D)\leq T^*\leq T_{\mathrm{list}}
+\leq W/m+(1-1/m)D.
+}
+##{
+T_{\mathrm{list}}\leq(2-1/m)T^*.
+}
+
+\proof{
+\p{At most #{m} units of work can finish per unit time, and every
+precedence chain executes in order. Thus #{W/m\leq T^*} and
+#{D\leq T^*}. Trace backwards from a last-finishing task, repeatedly
+choosing an immediate predecessor with latest completion, until reaching
+a task with no predecessors. These tasks form a precedence chain.}
+\p{Between completion of one chosen predecessor and the next chain
+task's start, all predecessors of that next task are complete. The task
+is ready, so work conservation forces all processors to be busy during
+that gap. The first chain task is ready from time zero. Consequently,
+whenever fewer than #{m} processors are busy before completion, some task
+on this chain is executing, apart from finitely many event times.}
+\p{Let #{I} be the total duration with fewer than #{m} busy processors.
+Then #{I\leq D}. During the rest of the schedule all #{m} processors
+are busy, and during #{I} at least one is busy. Hence}
+##{
+W\geq m(T_{\mathrm{list}}-I)+I.
+}
+##{
+T_{\mathrm{list}}\leq W/m+(1-1/m)I
+\leq W/m+(1-1/m)D.
+}
+\p{The lower bounds on #{T^*} give the last inequality in the statement.}
+}
+
+\p{The ratio #{T_{\mathrm{list}}/\max(W/m,D)} compares the schedule
+with a lower bound that need not be attainable; it is not generally the
+ratio to the optimum. Communication and verification must be modeled as
+work with constraints satisfying these assumptions, or the displayed
+upper bound need not apply. Neither bound certifies the quality of the
+chosen task graph or an unrestricted agent's attainable output quality.}


### PR DESCRIPTION
Controller comparisons need matched information access and full cost accounting before an observed gain can be attributed to coordination. This adds a compact comparison section using the existing recipe, tuning, and intervention definitions, plus a fixed-DAG scheduling diagnostic with a complete work-and-critical-path proof.

The four-file change preserves all six chapter wrappers and existing addresses. It distinguishes measured performance from a certified remaining gap, and states where the classical scheduling bound ceases to apply. It reports no new experiment, solver implementation, or Lean result.

Validation: source prose and lint; full site build and rendered-output contract; focused FTIP PDF with visual inspection of the new section and proof continuations; seven browser routes; and 98,304 exact finite schedule checks. A fresh independent review approved exact head `4158b6f3` on the actual merged predecessor, including the complete proof, primary sources, comparison controls, hashes and rendered continuations. Independent checks included exhaustive and seeded schedules, tight-ratio cases, and an unattainable lower-bound witness.
