### PR TITLE
Formulate conceptual discovery across model generations

### DIFF
--- a/trees/ftip-00JB.tree
+++ b/trees/ftip-00JB.tree
@@ -15,3 +15,5 @@ establish.}
 \transclude{ftip-0075}
 \transclude{ftip-008E}
 \transclude{ftip-009M}
+
+\transclude{ftip-00MH}

--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -1,0 +1,28 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Conceptual discovery across model generations}
+\tag{ftip}
+
+\p{A mathematical breakthrough may require a new representation, a useful
+invariant, or a connection to another domain. The question is whether a
+specified model lineage can discover and acquire that structure within its
+resources, including by improving its own search and training procedures.
+An external contribution might make the same capability affordable.}
+
+\p{This is a proposed separation between complete processes. A plateau in
+one training recipe does not establish it. Nor does the size of unexplored
+mathematics imply that current architectures can only recombine a fixed
+stock of ideas. Useful structure may be generated implicitly by updates,
+through analogy, or by programs constructed during the campaign.}
+
+\p{The acquisition question in \ref{ftip-0007} therefore extends across
+successive learned artifacts. The finite discovery estimates of
+\ref{ftip-0076} apply only when their probability premises cover that
+evolving process. The finite controller certificate in \ref{ftip-00M8}
+illustrates an upper-bound method for a fully specified action class.}
+
+\transclude{ftip-00MI}
+\transclude{ftip-00ML}
+\transclude{ftip-00MN}
+\transclude{ftip-00MO}
+\transclude{ftip-00MQ}

--- a/trees/ftip-00MI.tree
+++ b/trees/ftip-00MI.tree
@@ -1,0 +1,12 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{The complete lineage and its resources}
+\tag{ftip}
+
+\p{The comparison starts from disclosed artifacts and executable operations.
+A lineage includes the models it trains, the controllers it writes, and the
+evidence it retains. Its limits cannot be inferred from the support of one
+initial decoder while allowing the rest of the system to change.}
+
+\transclude{ftip-00MJ}
+\transclude{ftip-00MK}

--- a/trees/ftip-00MJ.tree
+++ b/trees/ftip-00MJ.tree
@@ -1,0 +1,48 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A resource-bounded model lineage}
+\tag{ftip}
+
+\p{Fix a specification}
+##{
+\Xi=(I_0,\mathcal C_0,\Gamma,\mathcal E_0,V,
+\mathcal D,\mathcal F,\mathbf B,\mathbf b_{\mathrm{eval}}).
+}
+\p{Here #{I_0} contains the initial models, corpora, libraries, prompts,
+optimizers, evaluators, software and cached results. The nonempty class
+#{\mathcal C_0} specifies available initial controller programs and their
+constants. The semantics #{\Gamma} specifies executable operations and
+costs; #{\mathcal E_0} specifies baseline observations and tool-response
+laws. The checker #{V}, task law and reveal schedule #{\mathcal D}, allowed
+final artifacts #{\mathcal F}, campaign cap #{\mathbf B} and deployment cap
+#{\mathbf b_{\mathrm{eval}}} are fixed before evaluation. Include the
+no-update procedure as a baseline.}
+
+\p{A campaign is a causal execution starting from this endowment. Its state
+contains available checkpoints, contexts, generated code, retained traces,
+libraries, optimizer state and resource usage. A controller may use only
+its charged accessible state: discarded history must be reconstructed at
+cost. Environment state may remain hidden. All random seeds follow their
+declared laws; a fortunate completed trajectory is not an available program.}
+
+\p{Whenever admitted by #{\Gamma}, operations include model inference,
+proof and program search, tool calls, parallel workers, memory management,
+candidate comparison, reward and credit assignment, synthetic tasks,
+parameter training, architecture changes, and controller replacement.
+Generated controllers execute under the same semantics and caps. Selection,
+evaluation and the controller's own computation are charged. These operations
+may recur in any order; learning need not first produce a complete successful
+trace or an explicitly verbalized idea.}
+
+\p{The lineage is \em{closed relative to} #{(I_0,\mathcal E_0)} when its
+only campaign inputs are scheduled tasks, its randomness and admitted
+environment responses. This allows computation to reveal useful structure.
+A simulator using independent randomness is different from a tool observing
+new hidden world state; the latter access belongs in #{\mathcal E_0}.}
+
+\p{Controller selection is independent of unrevealed instance seeds,
+conditional on declared public family information. This alone does not
+exclude family-wide answer tables: all such constants and preprocessing
+belong in #{I_0}. An asymptotic claim specifies uniform generation across
+instance sizes or explicitly accounts for nonuniform advice and preparation.}

--- a/trees/ftip-00MK.tree
+++ b/trees/ftip-00MK.tree
@@ -1,0 +1,30 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Hard resource accounting across generations}
+\tag{ftip}
+
+\p{For a realized campaign #{\zeta}, let #{\mathbf R(\zeta)} record
+inference work, training work, tool and checker work, total accelerator time,
+peak live memory and storage, peak allocated hardware, wall time and money
+under the declared operational model. Admission requires}
+##{\mathbf R(\zeta)\preceq\mathbf B\quad\text{almost surely}.}
+\p{Stop before an unaffordable operation; a missing result scores zero.
+Charge every failed path, discarded trace, evaluator call, consultation,
+checkpoint comparison and update. Bound the number of transitions by
+charged elementary work or an explicit finite horizon: infinitely many
+free operations are not admitted.}
+
+\p{For additive work coordinates, a portfolio costs shared development
+plus the sum of task-specific work. Shared training is charged once even
+when it benefits many tasks. Peak resources and elapsed time come from the
+actual joint schedule, including communication and sequential dependencies.
+Parallel work is summed across workers. An expected-cost bound does not
+replace this hard cap.}
+
+\p{A scalar budget #{B} is used only after choosing one resource or a
+declared conversion with the remaining constraints fixed. Human time,
+accelerator work and elapsed time have no implicit exchange rate. Model
+pretraining and contributor expertise may be disclosed sunk endowments in
+a marginal comparison. A lifetime-cost claim must also account for producing
+both; unknown historical costs remain unknown.}

--- a/trees/ftip-00ML.tree
+++ b/trees/ftip-00ML.tree
@@ -1,0 +1,10 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Discovery and acquired capability}
+\tag{ftip}
+
+\p{A contribution can help solve a current problem without becoming a
+reusable ability. Discovery and acquisition are therefore separate outcomes,
+both evaluated against a fixed mathematical truth contract.}
+
+\transclude{ftip-00MM}

--- a/trees/ftip-00MM.tree
+++ b/trees/ftip-00MM.tree
@@ -1,0 +1,44 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Signed discovery and fresh-task acquisition}
+\tag{ftip}
+
+\p{Fix the statement translation, allowed axioms, formal library and
+certificate checker #{V}. An answer is a sign #{\sigma\in\{+,-\}} and
+a certificate #{p}. Put #{s_V(x,(\sigma,p))=1} when #{V} accepts #{p} as a
+proof of #{x} for sign #{+}, or of #{\neg x} for sign #{-}; otherwise put
+#{s_V=0}. The failure output #{\bot} scores zero. A proof of excluded middle
+without either signed certificate does not solve the task. A task family
+may assume one signed certificate exists; independence from the allowed
+axioms is otherwise a separate source of failure.}
+
+\p{For a current portfolio #{x_1,\ldots,x_n} with fixed nonnegative
+weights #{w_i} summing to one, a campaign #{P} has discovery score}
+##{Q_{\mathrm{disc}}(P)=\mathbb E\sum_{i=1}^n w_i s_V(x_i,P_i).}
+\p{For one fixed conjecture use a singleton portfolio; its truth need not
+be randomized. The expectation includes the declared task and execution
+randomness, with no assumption of independent attempts.}
+
+\p{After development, freeze an artifact #{A\in\mathcal F\cup\{\bot\}}
+before revealing fresh problems #{x'_1,\ldots,x'_m}, where #{m\geq1}.
+Their identities and solutions are unavailable during development; they
+are conditionally independent of development draws given the declared
+task-family variable. With a fixed deployment procedure #{\mathrm{Deploy}},
+define}
+##{
+Q_{\mathrm{acq}}(P)=\mathbb E\frac1m\sum_{j=1}^m
+s_V(x'_j,\mathrm{Deploy}(A,x'_j;\mathbf b_{\mathrm{eval}})).
+}
+\p{Remove contributor access and feedback into training or checkpoint
+selection. Any permitted adaptation within one test problem is charged
+and discarded before the next. Evaluation work counts in the campaign;
+the per-problem cap is common to both arms. Deployment of #{\bot} fails.}
+
+\p{For model acquisition, #{\mathcal F} contains learned parameters or
+adapters with a common fixed harness. For system acquisition it may instead
+include a bounded acquired library or controller. State which is measured.
+The pair #{(Q_{\mathrm{disc}},Q_{\mathrm{acq}})} does not allow success on
+one coordinate to conceal failure on the other. Imported mathematical
+results and new proof notation require sound translation under #{V},
+including the cost of expanding and checking certificates.}

--- a/trees/ftip-00MN.tree
+++ b/trees/ftip-00MN.tree
@@ -1,0 +1,53 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{The conceptual-discovery conjecture}
+\tag{ftip}
+
+\p{Fix the lineage specification and a separately specified admissible
+class #{\mathfrak V} of contributors. A contributor interacts causally
+from its disclosed background within charged resources, without hidden
+target answers or unrevealed test inputs. Background knowledge may differ
+between arms; target statements, axioms, checker and test law remain fixed.
+The conjectured mechanism is making conceptual structure affordable to
+discover, recognize or acquire under those endowments.}
+
+\p{Let #{\mathcal L(B)} contain every closed campaign admitted by
+\ref{ftip-00MJ} under the chosen scalar cap and other fixed constraints.
+Let #{\mathcal A_v(B)} contain admitted contributor–recipient campaigns,
+including contribution production, failed help, communication, interpretation,
+validation, training and evaluation in the cap. For some specified research
+family and initial lineage, conjecture thresholds
+#{0\leq\tau^-<\tau^+\leq1} and a realistic cap #{B} such that}
+##{
+\begin{gathered}
+\forall P\in\mathcal L(B),\qquad Q_{\mathrm{acq}}(P)\leq\tau^-,\\
+\exists v\in\mathfrak V,\ \exists R\in\mathcal A_v(B),\qquad
+Q_{\mathrm{acq}}(R)\geq\tau^+.
+\end{gathered}
+}
+\p{This is not asserted for every task, model or budget. It allows unaided
+improvements below the threshold. A discovery version uses
+#{Q_{\mathrm{disc}}}; a joint claim requires the same assisted campaign
+to cross both thresholds. An abstract contributor class requires a
+realizable member for an unconditional existence result.}
+
+\p{For a difficulty-indexed family and fixed #{0<\tau\leq1}, define the
+closed work threshold by}
+##{
+B_{\mathrm{closed}}(n,\tau)=
+\inf\{B:\sup_{P\in\mathcal L_n(B)}Q_{\mathrm{acq}}(P)\geq\tau\},
+\qquad \inf\varnothing=+\infty.
+}
+\p{Define #{B_{\mathrm{assisted}}} with the supremum over admissible
+contributors and recipients. A stronger asymptotic conjecture asks for
+positive functions #{L,U} satisfying}
+##{
+B_{\mathrm{closed}}(n,\tau)\geq L(n),\qquad
+B_{\mathrm{assisted}}(n,\tau)\leq U(n),\qquad
+\frac{U(n)}{L(n)}\longrightarrow0.
+}
+\p{An operational crossing additionally requires an actual assisted
+procedure achieving #{\tau} at work at most #{U(n)} and a realistic cap
+#{U(n)\leq B_{\mathrm{real}}(n)<L(n)}. Suprema and infima alone need not
+be attained. Proving these inequalities, refuting one, or identifying a
+precise obstacle to either proof are distinct possible research outcomes.}

--- a/trees/ftip-00MO.tree
+++ b/trees/ftip-00MO.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Conditional obstructions to conceptual discovery}
+\tag{ftip}
+
+\p{One possible lower-bound mechanism is a necessary structural event:
+every successful route must construct or acquire some adequate representation.
+The event must cover alternative proofs and structures learned implicitly
+in parameters. The elementary probability bound below becomes informative
+only when its necessity and uniform probability premises can be established
+from the admitted system.}
+
+\transclude{ftip-00MP}

--- a/trees/ftip-00MP.tree
+++ b/trees/ftip-00MP.tree
@@ -1,0 +1,48 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{proposition}
+\title{A necessary-event bound for an evolving lineage}
+\tag{ftip}
+
+\p{Fix #{B\in\mathbb N} charged elementary transitions and a
+#{[0,1]}-valued realized acquisition score #{Z}, including its evaluation
+randomness. Let #{G_t} mean a specified necessary structural event has
+occurred by transition #{t}. Assume #{G_0} is false,
+#{G_t\subseteq G_{t+1}}, and #{Z\leq\mathbf1_{G_B}} almost surely.
+For deterministic #{\epsilon_t\in[0,1]}, suppose that every admitted
+campaign and every permitted positive-probability history before #{G}
+satisfy}
+##{
+\Pr(G_t\mid\text{that history at }t-1)\leq\epsilon_t,
+\qquad t=1,\ldots,B.
+}
+\p{For general history spaces use the corresponding conditional-kernel
+bound almost everywhere for each admitted campaign. Include histories after
+training and controller replacement. Stopped runs are padded by absorbing
+transitions. Then every admitted #{P} satisfies}
+##{
+Q_{\mathrm{acq}}(P)=\mathbb E Z
+\leq1-\prod_{t=1}^B(1-\epsilon_t)
+\leq\min\{1,\sum_{t=1}^B\epsilon_t\}.
+}
+
+\proof{
+\p{Conditional on not having reached #{G} by #{t-1}, survival at the next
+transition has probability at least #{1-\epsilon_t}. Conditional
+expectation gives}
+##{
+\Pr(G_t^c)\geq(1-\epsilon_t)\Pr(G_{t-1}^c).
+}
+\p{Induction from #{\Pr(G_0^c)=1} gives the product bound. The union
+bound on first-entry events gives the sum bound, while probabilities are
+at most one. Taking expectations of #{Z\leq\mathbf1_{G_B}} proves the
+score bound. For #{B=0}, the empty product is one and the bound is zero.}
+}
+
+\p{If the premise holds with #{\epsilon_t=\epsilon(n)>0} at every work
+budget, then #{B_{\mathrm{closed}}(n,\tau)\geq\frac{\tau}{\epsilon(n)}} for
+integer work budgets. A bound measured for one fixed checkpoint does not
+supply this premise. If other routes can achieve positive score without
+#{G}, the domination assumption fails. Calling #{G} simply “success”
+does not explain a discovery mechanism without an independent probability
+bound. Recognition and learning obstructions may require other arguments.}

--- a/trees/ftip-00MQ.tree
+++ b/trees/ftip-00MQ.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Finite work, permanent barriers, and enumeration}
+\tag{ftip}
+
+\p{Work exceeding a realistic cap, divergence with instance size, and
+permanent unreachability of a fixed target differ. A permanent barrier needs
+closure under all admitted learning, program and architecture changes.
+Excluding the target from a set does not derive that closure. An assisted
+crossing must leave the invariant set while preserving the checker.
+Fair enumeration gives a countercheck.}
+
+\transclude{ftip-00MR}
+\transclude{ftip-00MS}

--- a/trees/ftip-00MR.tree
+++ b/trees/ftip-00MR.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{proposition}
+\title{A permanent barrier requires transition closure}
+\tag{ftip}
+
+\p{Let #{\mathcal R} be a measurable set of complete states. Suppose
+the initial state lies in #{\mathcal R} almost surely, and every admitted
+transition from a permitted history ending in #{\mathcal R} remains in
+#{\mathcal R} with probability one. Suppose no successful terminal state
+lies in #{\mathcal R}. Then for every admitted campaign,}
+##{\Pr(T_{\mathrm{success}}<\infty)=0.}
+
+\proof{
+\p{Induction and conditional expectation imply that the state lies in
+#{\mathcal R} at each finite time with probability one. The countable
+union of the null events of leaving #{\mathcal R} has probability zero.
+Success at finite time would require such a departure.}
+}

--- a/trees/ftip-00MS.tree
+++ b/trees/ftip-00MS.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{proposition}
+\title{Finite certificates defeat an unrestricted never-reachable claim}
+\tag{ftip}
+
+\p{Fix a target with a finite accepted signed certificate under a
+decidable checker. If the baseline admits enumeration of all finite signed
+candidate strings over a finite alphabet in increasing length, checking
+each in finite time, then
+some admitted procedure discovers a certificate in finite total work.}
+
+\proof{
+\p{A finite alphabet has finitely many strings no longer than the
+accepted certificate. Each preceding check terminates, so the sum of
+their finite execution costs and the successful check is finite.}
+}
+
+\p{This assumes enumeration and checking have the required memory and
+other resources as work grows; it does not override fixed hardware caps.
+It gives no useful realistic work bound and no fresh-task acquisition
+guarantee. Short compressed proofs may still be expensive to expand.}
+
+\p{Independent restarted attempts of uniformly bounded cost with fixed
+success probability #{p>0} have expected attempt count #{1/p}. Full token
+support alone does not establish restart access, termination or such a
+fixed probability for an adaptive lineage. Other processes can succeed
+almost surely with infinite expected time. Neither one slow process nor
+one failed search bounds all admitted alternatives.}


### PR DESCRIPTION
Conceptual discovery across model generations needs a comparison that includes the whole evolving lineage and distinguishes finding a result from acquiring reusable capability. This adds that formulation under the existing evaluation chapter, with explicit endowments, charged updates, hard resources, fixed checking and separate discovery/acquisition scores.

The proposed separation remains a conjecture. Three elementary conditional results explain a necessary-event bound, transition-closed permanent barriers, and why finite-certificate enumeration defeats an unrestricted never-reachable claim. The six chapter addresses stay stable.

Validation: independent source and rendered review; `just chk`, full `just build`, `just verify-render` (2,291 XML/HTML pairs), and a fresh focused 257-page PDF. Browser inspection covers hierarchy, equations and proof layout. The focused PDF is local validation evidence.
