### PR TITLE
docs: formalize complementary contributions and acquisition [AGENT]

### DIFF
--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -23,6 +23,7 @@ illustrates an upper-bound method for a fully specified action class.}
 
 \transclude{ftip-00MI}
 \transclude{ftip-00ML}
+\transclude{ftip-00MT}
 \transclude{ftip-00MN}
 \transclude{ftip-00MO}
 \transclude{ftip-00MQ}

--- a/trees/ftip-00MN.tree
+++ b/trees/ftip-00MN.tree
@@ -4,7 +4,7 @@
 \tag{ftip}
 
 \p{Fix the lineage specification and a separately specified admissible
-class #{\mathfrak V} of contributors. A contributor interacts causally
+class #{\mathfrak V} of contributors as in \ref{ftip-00MU}. A contributor interacts causally
 from its disclosed background within charged resources, without hidden
 target answers or unrevealed test inputs. Background knowledge may differ
 between arms; target statements, axioms, checker and test law remain fixed.

--- a/trees/ftip-00MT.tree
+++ b/trees/ftip-00MT.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Affordable complementary contributions}
+\tag{ftip}
+
+\p{A contributor can make a representation, analogy, criticism, discriminating
+question or research direction affordably available to a recipient. The
+relevant properties are the interaction it can produce and what the recipient
+can make of it. Architecture, culture, expertise and developmental history
+can explain these properties without becoming mandatory coordinates of the
+abstract definition. “Contributor” names the technical role; “visitor” is
+its counterpart in a fable.}
+
+\p{Availability, structural quality and realized benefit require different
+arguments. A familiar connection can be novel to a learner's affordable
+repertoire, while a surprising sentence may be useless. The existence of
+infinitely many possible patterns supplies neither a probability of useful
+help nor an unaided computational lower bound.}
+
+\transclude{ftip-00MU}
+\transclude{ftip-00MV}
+\transclude{ftip-00MW}
+\transclude{ftip-00MX}
+\transclude{ftip-00MY}

--- a/trees/ftip-00MU.tree
+++ b/trees/ftip-00MU.tree
@@ -1,0 +1,41 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{A causal contribution process}
+\tag{ftip}
+
+\p{Fix the recipient specification, task family, reveal schedule,
+interaction permissions and resource accounting. Abstract a contributor
+#{v} by a causal interaction law, written as budget-indexed kernels}
+##{K_v^b(\mathrm dh\mid H).}
+\p{Here #{H} is the history available to the contributor, #{b} is its
+remaining contribution budget, and #{h} includes the next message or
+failure/stop output with its joint resource record. The kernels arise from
+one consistent causal process under stopping: different budgets cannot be
+assigned unrelated ideal answers. No access to unrevealed test instances
+or their answers is permitted.}
+
+\p{Two internal realizations are equivalent for this abstraction when
+they induce the same joint laws of transcripts, costs and stopping for
+every admitted recipient protocol and budget. Mathematically equivalent
+message contents need not be equivalent interactions: the recipient may
+find one encoding much easier to interpret or verify. A useful contribution
+may develop through several exchanges. Producing, interpreting, rejecting,
+correcting and learning from suggestions all consume resources.}
+
+\p{Conditional theorems may assume properties of this interface without
+simulating a brain or reconstructing a civilization. An unconditional
+existence result additionally requires a realizable member of the assumed
+class, for example an executable source with disclosed initial state and
+costs. A controlled human protocol instead supplies empirical estimates.
+An arbitrary answer kernel or assumed success probability proves neither.}
+
+\p{The target statements, truth contract, checker and reveal schedule stay
+fixed. Contributors may have different broad backgrounds or search biases;
+these endowment differences are disclosed. Relevant prior results must be
+justified under the target checker. A hidden target parameter or precomputed
+answer table is a different mechanism from conceptual insight. Equalizing
+all background material is an optional stronger comparison. Giving the
+recipient textual access to the relevant material can test whether acquiring
+and using the connection remains costly. Historical preparation follows
+the symmetric accounting convention in \ref{ftip-00MK}.}

--- a/trees/ftip-00MV.tree
+++ b/trees/ftip-00MV.tree
@@ -1,0 +1,40 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Definition}
+\title{Structural quality and good contributor classes}
+\tag{ftip}
+
+\p{Fix a development law and recipient interaction protocol #{\Pi}
+before final evaluation. For development input #{D} and resulting contribution
+transcript #{H_v}, choose an independently specified structural predicate
+#{S(D,H_v)}. Define}
+##{q_v=\Pr_{\Pi,v}\bigl(S(D,H_v)\bigr).}
+\p{A possible property is a sound reduction to a declared tractable class
+with bounded translation and certificate-expansion costs. A reusable
+invariant with a proved consequence or a curriculum satisfying a separate
+learning condition are other possibilities. A fallible analogy may require
+charged recipient completion before the property holds. The predicate is
+not simply that the final score improved; soundness, scope and checking
+costs require their own arguments. Quality is relative to this task,
+protocol and budget, not a universal ranking of minds.}
+
+\p{For #{0<q_0\leq1}, the restricted class}
+##{\mathcal G(q_0)=\{v\in\mathfrak V:q_v\geq q_0\}}
+\p{is legitimate. An existence theorem about a member of this class need
+not help every contributor outside it. Nonemptiness remains a separate
+obligation; choosing sources on final test outcomes does not establish
+pre-evaluation availability. Recruitment and screening costs are necessary
+when claiming an affordable procedure to find a good contributor, but mere
+existence does not require a population recruitment theorem.}
+
+\p{To discuss a median, additionally declare a population law #{\mu}
+on admissible contributors with measurable quality #{v\mapsto q_v}.
+Let #{q_{50}} satisfy
+#{\mu(q_v\leq q_{50})\geq\frac12} and #{\mu(q_v\geq q_{50})\geq\frac12}.
+Then define}
+##{\mathcal G_\mu(q_0)=\{v:q_v\geq\max(q_0,q_{50})\}.}
+\p{If #{q_0\leq q_{50}}, this class has at least half the population
+mass. If #{q_0>q_{50}}, even nonemptiness needs evidence. The median can
+be zero, so belonging to the upper half alone does not guarantee useful
+assistance. There is no default uniform law over all possible contributors,
+and an unattained quality supremum need not have a best contributor.}

--- a/trees/ftip-00MW.tree
+++ b/trees/ftip-00MW.tree
@@ -1,0 +1,31 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{proposition}
+\title{From structural quality to acquired capability}
+\tag{ftip}
+
+\p{Fix one contributor and one recipient protocol with almost-sure total
+resource caps, including failed consultations. Let #{Z\in[0,1]} be the
+realized fresh-task score of its frozen artifact with contributor access
+removed. Suppose, for the same joint process and remaining resources,}
+##{\Pr(S)\geq q_0>0,\qquad\mathbb E[Z\mid S]\geq\beta\geq0.}
+\p{Then #{Q_{\mathrm{acq}}=\mathbb E Z\geq q_0\beta}.}
+
+\proof{
+\p{Nonnegativity and conditional expectation give}
+##{\mathbb E Z\geq\mathbb E[Z\mathbf1_S]
+=\Pr(S)\mathbb E[Z\mid S]\geq q_0\beta.}
+}
+
+\p{No independence assumption is used. A uniform recipient guarantee
+for qualified transcripts and compatible development histories can establish
+the transfer premise, including interpretation, verification and acquisition
+costs. A guarantee for a different, easier message distribution cannot.}
+
+\p{Together with a universal closed bound
+#{Q_{\mathrm{acq}}(P)\leq\tau^-} and an admissible member of
+#{\mathcal G(q_0)}, the strict inequality
+#{q_0\beta\geq\tau^+>\tau^-} yields the assisted crossing in
+\ref{ftip-00MN}. The substantive obligations are affordable source quality,
+recipient transfer and the bound over every admitted unaided alternative.
+The elementary expectation inequality alone establishes none of these.}

--- a/trees/ftip-00MX.tree
+++ b/trees/ftip-00MX.tree
@@ -1,0 +1,31 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{proposition}
+\title{Simulation can erase an apparent contribution advantage}
+\tag{ftip}
+
+\p{Fix a scalar accounting model with the other constraints declared.
+Suppose an admitted assisted campaign #{(R,v)} at total budget #{B}
+has an admitted closed simulator at budget #{g(B)}. Require that the
+simulator can reproduce the contributor's endowment, observations and
+causal interaction, together with the recipient's allowed final artifact
+and evaluation law. All simulation work and initialization count.
+Then, for #{j\in\{\mathrm{disc},\mathrm{acq}\}},}
+##{\sup_{P\in\mathcal L(g(B))}Q_j(P)\geq Q_j(R,v).}
+
+\proof{
+\p{Couple the initial states and each successive conditional interaction
+using the stipulated simulator. Induction gives the same joint law of
+observable transcripts, final artifact and evaluated outcomes. The closed
+simulator therefore has the same score, and its admission places that
+score below the displayed supremum.}
+}
+
+\p{If the simulation is uniform across instance sizes with
+#{g(B)\leq cB} for a fixed constant #{c}, an actual assisted procedure
+reaching #{\tau} at work #{U(n)} implies
+#{B_{\mathrm{closed}}(n,\tau)\leq cU(n)}. This excludes a lower bound
+#{L(n)} with #{U(n)/L(n)\to0}. Unavailable background state, observations,
+hardware or large simulation overhead can invalidate the premise; different
+origin alone does not. The argument does not assume that a language model
+already has an affordable simulation of a human contributor.}

--- a/trees/ftip-00MY.tree
+++ b/trees/ftip-00MY.tree
@@ -1,0 +1,47 @@
+\import{macros}
+\meta{agent-authored}{true}
+\taxon{Example}
+\title{A human–model exchange about conceptual discovery}
+\tag{ftip}
+
+\p{In a discussion on 10 September 2026, Kepler, a language-model
+assistant, was the recipient and utensil the human contributor. The
+assistant's proposals below arose within an already human-directed
+conversation; they were not outputs of a separate unaided experiment.}
+
+\ol{
+\li{Kepler proposed a resource-bounded formulation and a finite
+missing-evidence construction. Utensil rejected missing facts as the
+intended mechanism and described conceptual leaps across model generations:
+new perspectives, paradigms and connections between domains. Kepler revised
+the target to conceptual discovery and separated prohibitive finite work
+from permanent unreachability using the enumeration countercheck.}
+\li{Kepler specified an executable source with bounded observations.
+Utensil challenged an oracle-like abstraction, pointed to diverse cultural
+backgrounds and developed representations, and asked for an abstract account
+of what the source contributes. Kepler formulated the causal contribution
+interface, with background differences disclosed rather than a mandatory
+model of a brain or lifetime.}
+\li{Utensil emphasized that existence of good contributors need not imply
+usefulness of all contributors, and suggested an upper-median restriction.
+Kepler separated independent structural quality, class nonemptiness and
+recipient transfer, while showing why a median requires a population and
+need not have positive quality.}
+\li{Utensil suggested studying recursive self-improvement papers for the
+gap between the problems they diagnose and the portions their methods
+repair. Kepler examined contemporary work and checked a revised primary
+source that narrowed stronger self-imitation claims. The resulting thesis
+distinguishes affordable quality, recipient acquisition and a universal
+unaided bound, with proof, refutation and precise obstacles all possible.}
+}
+
+\p{In \ref{ftip-00MU}, #{H} corresponds to the exchange so far and
+#{h} to the contributor's next criticism, analogy or research direction.
+The recipient's retained conversation and revised artifacts form its evolving
+state; reasoning, literature search and checking are its processing actions.
+The human did not supply a completed theorem: the assistance changed the
+problem representation and choice of inquiry. The observed outcome was a
+revised conjecture, before any fixed-target acquisition experiment.
+No structural-quality probability, cost advantage, held-out
+acquisition score or universal unaided bound was measured, so it does not
+establish the separation conjecture.}


### PR DESCRIPTION
Complementary help needs an account of what a source can affordably contribute and what a recipient can learn from it. This extends the conceptual-discovery section with a causal contributor process, independently specified structural quality, restricted good classes and precise median qualifications.

Two conditional results separate source quality from acquired capability and show when an affordable closed simulation rules out the proposed asymptotic advantage. A concise four-round example maps the actual human–model discussion to contributions and recipient processing, without treating formulation improvement as measured acquisition or a proved separation.

Validation: independent mathematics, prose and rendered review; source/prose checks; full site build and 2,297 XML/HTML pairs; a fresh focused 261-page PDF; browser checks of the six new notes. The candidate is based on the actual PR #184 merge. The focused PDF is local validation evidence.
