### PR TITLE
docs: connect conceptual discovery to contemporary research [AGENT]

### DIFF
--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -27,3 +27,5 @@ illustrates an upper-bound method for a fully specified action class.}
 \transclude{ftip-00MN}
 \transclude{ftip-00MO}
 \transclude{ftip-00MQ}
+
+\transclude{ftip-00MZ}

--- a/trees/ftip-00MZ.tree
+++ b/trees/ftip-00MZ.tree
@@ -1,0 +1,16 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Where contemporary self-improvement meets conceptual discovery}
+\tag{ftip}
+
+\p{Recent work supplies mechanisms for finding and using new structure,
+as well as examples of improvements generated inside a model's own workflow.
+A paper's motivating problem often extends beyond the part its method repairs.
+That difference identifies something to investigate; it does not establish an
+obstruction to every possible repair. The following studies connect these
+mechanisms to the [conceptual-discovery conjecture](ftip-00MN), using the indicated primary versions.}
+\transclude{ftip-00N0}
+\transclude{ftip-00N1}
+\transclude{ftip-00N2}
+\transclude{ftip-00N3}
+\transclude{ftip-00N4}

--- a/trees/ftip-00N0.tree
+++ b/trees/ftip-00N0.tree
@@ -1,0 +1,45 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Background structure and realized complementarity}
+\tag{ftip}
+
+\p{[Hemmer and colleagues](https://arxiv.org/html/2404.00029v2)
+distinguish available complementarity from benefit actually realized by a
+human–AI team. They also distinguish differences in information from
+differences in capability, and choosing an individual's answer from producing
+an answer neither individual supplied alone. This motivates the separation
+between \ref{ftip-00MV} and \ref{ftip-00MW}: a source can expose useful
+structure while the joint procedure fails to exploit it. Their decision-making
+experiments do not establish learning into successor models.}
+
+\p{In [Semantic knowledge guides innovation and drives cultural
+evolution](https://arxiv.org/abs/2510.12837v4), Yaman, Tian and Lindström
+combine an agent-based model with a 1,243-participant experiment. Meaningful
+item depictions let participants use semantic knowledge; abstract symbols
+obscure it while preserving combination rules. Semantic knowledge and social
+learning support cumulative innovation. The model gives a concrete mechanism:
+learned representations direct exploration, and socially transmitted examples
+improve those representations across generations. The evidence comes from a
+closed-world recipe task. The authors also warn that strong priors may hide counterintuitive
+combinations. Cultural background is therefore a possible source of directed
+search, with relevance and flexibility still to be established.}
+
+\p{[Unlocking LLM Creativity in Science through Analogical
+Reasoning](https://arxiv.org/html/2605.11258v1) makes cross-domain
+object and relation mappings explicit, then searches for candidate solutions.
+It reports diversity and judged-novelty gains and four biomedical implementation
+case studies. Its cross-domain baseline also uses two model calls; its unconstrained
+baseline uses one. These counts help interpret the comparison without
+establishing matched total cost. Feasibility
+and later acquisition remain separate questions. Because the model itself
+constructs analogies, this method also belongs among the closed lineage's
+possible substitutes for an external contributor.}
+
+\p{A testable hypothesis is that assistance helps when it supplies a
+relevant relation the recipient can verify more cheaply than it can discover.
+Compare a supplied relation with internally generated analogies at matched
+total cost. Give both arms the relevant background texts in a further
+comparison, charging retrieval and interpretation. If the advantage persists,
+access to texts alone has not explained it; if it disappears, this instance
+supports a background-access explanation. Neither outcome by itself bounds
+all admitted internal search procedures.}

--- a/trees/ftip-00N1.tree
+++ b/trees/ftip-00N1.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Choosing what is worth learning next}
+\tag{ftip}
+
+\p{A contributor may offer a promising question or a direction of inquiry
+without knowing its final answer. The difficulty is prospective: the learner
+must choose where to spend effort before observing how much that effort will
+teach it. Surprise can prioritize noise, while measured learning progress
+arrives after the investment.}
+
+\p{[Herrmann and Schmidhuber](https://arxiv.org/html/2605.14831v1)
+model interestingness through complexity–runtime profiles and future
+compression progress under specified Length, Algorithmic and Speed priors.
+Their analysis and finite enumeration experiments study when present structure
+predicts further compressibility. Section 4.4 limits the formal correspondence
+through Busy Beaver time scales; a long plateau does not exclude a later
+breakthrough. The analysis supplies neither an affordable selector for frontier
+models nor a lower bound over their possible research strategies.}
+
+\p{For the contribution model, a direction's quality needs an independent
+property: for example, a reduction exposing a learnable subproblem with bounded
+translation cost. Calling a direction “interesting” cannot supply that property
+for free. An informative experiment would compare equal-cost choices by the
+recipient, a contributor and a shuffled-direction control, then measure verified
+progress and fresh-task performance after a fixed learning budget. A plausible
+prediction is that a useful structural selector outperforms mere surprise when
+high-surprise distractors are present. A successful internal selector weakens
+the proposed external advantage for that specification.}

--- a/trees/ftip-00N2.tree
+++ b/trees/ftip-00N2.tree
@@ -1,0 +1,42 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Improving workflows and learning from comparisons}
+\tag{ftip}
+
+\p{[Recursive Harness Self-Improvement](https://arxiv.org/html/2607.15524v1)
+addresses the cost of maintaining effective agent workflows and the need for
+useful execution traces in model–workflow co-evolution. It revises prompt-level
+workflows from pairwise evaluation history while holding the foundation model
+fixed. Experiments on 30 synthetic machine-learning research tasks show gains
+over the tested configurations. The proposed information-theoretic explanation
+is a hypothesis. Its conclusion leaves internalizing the resulting traces into
+future foundation models for future work. The improved workflow is evidence
+of better system behavior; successor-model acquisition needs a further result.}
+
+\p{[Mendel Gödel Machine](https://arxiv.org/html/2608.07645v1)
+diagnoses a different missed opportunity: editing from a single failed
+trajectory underuses comparisons across tasks and lineages. Its operators
+extract evidence from both kinds of comparison to edit agent scaffold code.
+The diagnostic theory assumes informative comparisons and an editor able to
+use them. Its simulations vary the comparative fixing advantage, including a
+null setting with no advantage, and its coding-agent experiments test bounded
+benchmark subsets. This is a concrete internal remedy, not evidence that every
+archive automatically yields useful structure.}
+
+\p{These methods suggest an acquisition experiment with declared artifact
+types. First measure the improved workflow with its persistent instructions
+and memory. Then train a successor on the resulting traces and evaluate that
+frozen successor under the same declared deployment wrapper, with contributor
+access removed. An unchanged-weights comparison and a successor trained from
+baseline traces distinguish workflow effects from learning effects. All trace
+generation, evaluation, selection and training consume the lineage budget.
+A gain that survives the second comparison supports acquisition under that
+contract; a workflow-only gain still counts when workflows are among the
+allowed final artifacts in \ref{ftip-00MM}.}
+
+\p{A second prediction concerns archive quality: comparisons should help
+most when failures share an identifiable cause and the archive contains a
+relevant contrast. Vary those conditions while matching archive-building and
+editing costs. Successful internally generated comparisons must enter the
+closed baseline before attributing an affordable advantage to an external
+source.}

--- a/trees/ftip-00N3.tree
+++ b/trees/ftip-00N3.tree
@@ -1,0 +1,38 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Retained experience and the limits of self-imitation}
+\tag{ftip}
+
+\p{[Beyond Final Scores](https://arxiv.org/html/2608.13417v1)
+studies seven models on 36 long-horizon AI research and development tasks. Its process diagnostics
+separate framing, execution and feedback; its experience comparisons include
+continuations with retained versus erased experience and lessons transferred
+to held-out tasks. Reuse can help or mislead. Under its particular novelty
+review, three of 252 best-seed solutions qualify as novel approaches. This
+finite observation identifies a problem in the tested setting, without proving
+a ceiling over alternative learning lineages.}
+
+\p{The mechanism worth testing is whether a learner can extract a reusable
+principle while discarding task-specific tactics. Compare raw experience,
+verified abstractions, deliberately mismatched lessons and no retained
+experience, with extraction and verification charged. Predict that matched
+abstractions help across the declared structural family and that harmful reuse
+increases when applicability conditions are violated. Improved internal
+experience revision is a possible remedy and belongs in the baseline.}
+
+\p{Version differences matter for the stronger claim that a closed loop
+must deteriorate. The September revision of the [RSI survey by Chen, Wang
+and Qu](https://arxiv.org/html/2607.07663v2) describes an unvanishing
+external-signal requirement. [Zenil's August
+revision](https://arxiv.org/html/2601.05280v3) explicitly narrows that
+formulation: a per-generation correction fraction may vanish while cumulative
+correction remains sufficient. It distinguishes exact self-imitation,
+replacement, retention and correction, and does not assert universal collapse.}
+
+\p{Zenil also distinguishes total information from the consequences an
+affordable procedure can make accessible. This is compatible with the role of
+computation in \ref{ftip-00MJ}: a new representation can expose a consequence
+without adding a hidden fact. Neither the information distinction nor the
+narrow resampling calculations show that an autonomous lineage lacks every
+useful representation change. A conceptual-discovery lower bound must constrain
+those alternatives explicitly.}

--- a/trees/ftip-00N4.tree
+++ b/trees/ftip-00N4.tree
@@ -1,0 +1,31 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Three obligations and outcomes that would change the thesis}
+\tag{ftip}
+
+\p{The [conditional transfer result](ftip-00MW) separates three substantive obligations.
+First establish an affordably available contribution with independently
+meaningful structural quality. Then establish recipient interpretation,
+verification and acquisition within the remaining resources. Finally bound
+every admitted closed alternative, including internal analogy search,
+comparative archives, revised experience, task selection and changes across
+model generations. Existing studies motivate the first two and offer useful
+counterchecks to the third. They do not jointly prove the conjecture.}
+
+\p{An admitted procedure whose expected score is proved to exceed a
+proposed threshold refutes that bound. A finite experiment can supply
+counterevidence with an appropriate uncertainty analysis; one unusually
+successful run alone does not refute an expected-score bound. Failure of
+the tested menu cannot certify a bound over all admitted procedures. Mathematical progress
+could instead identify a necessary-event premise valid across every update,
+construct an affordable qualified contributor, or prove a simulation result
+that rules out the proposed asymptotic advantage. An inaccessible ideal source
+or a contribution the recipient cannot acquire exposes a failed premise.}
+
+\p{The research therefore permits a separation theorem, a counterexample,
+or a precise obstacle to either. Successful internal remedies change which
+specifications remain plausible; they are part of the object being studied.
+For any retained candidate, freeze the target, checker, endowments, resource
+limits and evaluation law before the decisive comparison. The outcome should
+say what was discovered, what the final artifact acquired, and at what total
+cost.}


### PR DESCRIPTION
Conceptual-discovery claims need to account for successful internal remedies and distinguish improved workflows from acquired model capability. This adds connected sections on relational complementarity, cultural and analogical structure, prospective interestingness, recursive harnesses, comparative evolution, and experience transfer, grounded in nine version-pinned primary works.

The synthesis corrects the survey-level self-imitation claim against Zenil v3 and derives testable comparisons involving background equalization, internal analogy, artifact type, and prospective usefulness. It separates contribution quality, recipient acquisition, and a bound over all admitted closed alternatives; proof, refutation, and a precise obstruction remain possible outcomes.

Validation: source/prose checks, full site build, 2,303 XML/HTML pairs, a fresh focused 265-page PDF, and browser inspection of the six new sections. The focused PDF is local validation evidence. Independent Sol/high review approved the exact candidate on the actual PR #185 merge base, including primary passages, PDF pages, desktop/mobile rendering and all 810 locally served FTIP payload hashes.
