### PR TITLE
Clarify conceptual discovery without hindsight

### DIFF
--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -25,6 +25,7 @@ illustrates an upper-bound method for a fully specified action class.}
 \transclude{ftip-00ML}
 \transclude{ftip-00MT}
 \transclude{ftip-00MN}
+\transclude{ftip-00N5}
 \transclude{ftip-00MO}
 \transclude{ftip-00MQ}
 

--- a/trees/ftip-00MJ.tree
+++ b/trees/ftip-00MJ.tree
@@ -11,8 +11,10 @@
 }
 \p{Here #{I_0} contains the initial models, corpora, libraries, prompts,
 optimizers, evaluators, software and cached results. The nonempty class
-#{\mathcal C_0} specifies available initial controller programs and their
-constants. The semantics #{\Gamma} specifies executable operations and
+#{\mathcal C_0} specifies controller programs and constants available from #{I_0};
+it does not grant an arbitrary program chosen after a discovery. An
+initial generator of additional controllers is allowed, with its generation
+and selection work charged as explained in \ref{ftip-00N6}. The semantics #{\Gamma} specifies executable operations and
 costs; #{\mathcal E_0} specifies baseline observations and tool-response
 laws. The checker #{V}, task law and reveal schedule #{\mathcal D}, allowed
 final artifacts #{\mathcal F}, campaign cap #{\mathbf B} and deployment cap

--- a/trees/ftip-00MN.tree
+++ b/trees/ftip-00MN.tree
@@ -49,5 +49,6 @@ B_{\mathrm{assisted}}(n,\tau)\leq U(n),\qquad
 \p{An operational crossing additionally requires an actual assisted
 procedure achieving #{\tau} at work at most #{U(n)} and a realistic cap
 #{U(n)\leq B_{\mathrm{real}}(n)<L(n)}. Suprema and infima alone need not
-be attained. Proving these inequalities, refuting one, or identifying a
-precise obstacle to either proof are distinct possible research outcomes.}
+be attained. Both inequalities remain conjectural for the intended mechanism. The
+proof-directed formulation in \ref{ftip-00N5} asks how developmental
+experience could yield the assisted construction and the closed lower bound.}

--- a/trees/ftip-00MX.tree
+++ b/trees/ftip-00MX.tree
@@ -29,3 +29,12 @@ reaching #{\tau} at work #{U(n)} implies
 hardware or large simulation overhead can invalidate the premise; different
 origin alone does not. The argument does not assume that a language model
 already has an affordable simulation of a human contributor.}
+
+\p{Admission includes discovery of any required reconstruction program
+from the declared initial state. A simulator written with advance knowledge
+of the useful representation does not satisfy this premise merely because
+its later execution is cheap. If the program is generated during the
+campaign, its generation law, failed attempts and selection costs belong in
+the simulation. This conditional proposition supplies no lower bound on
+that discovery cost; \ref{ftip-00N6} distinguishes program existence from
+its availability to the lineage.}

--- a/trees/ftip-00N4.tree
+++ b/trees/ftip-00N4.tree
@@ -1,6 +1,6 @@
 \import{macros}
 \meta{agent-authored}{true}
-\title{Three obligations and outcomes that would change the thesis}
+\title{Three obligations for a separation proof}
 \tag{ftip}
 
 \p{The [conditional transfer result](ftip-00MW) separates three substantive obligations.
@@ -12,20 +12,18 @@ comparative archives, revised experience, task selection and changes across
 model generations. Existing studies motivate the first two and offer useful
 counterchecks to the third. They do not jointly prove the conjecture.}
 
-\p{An admitted procedure whose expected score is proved to exceed a
-proposed threshold refutes that bound. A finite experiment can supply
-counterevidence with an appropriate uncertainty analysis; one unusually
-successful run alone does not refute an expected-score bound. Failure of
-the tested menu cannot certify a bound over all admitted procedures. Mathematical progress
-could instead identify a necessary-event premise valid across every update,
-construct an affordable qualified contributor, or prove a simulation result
-that rules out the proposed asymptotic advantage. An inaccessible ideal source
-or a contribution the recipient cannot acquire exposes a failed premise.}
+\p{The central objective is to prove the separation. The developmental
+formulation in \ref{ftip-00N8} begins with absent experience and asks what
+family-specific argument makes every equally useful closed route expensive.
+An affordable qualified contributor and a recipient learning guarantee
+provide the constructive side; a necessary-event premise is insufficient
+unless its necessity and bound are derived for the admitted process.}
 
-\p{The research therefore permits a separation theorem, a counterexample,
-or a precise obstacle to either. Successful internal remedies change which
-specifications remain plausible; they are part of the object being studied.
-For any retained candidate, freeze the target, checker, endowments, resource
-limits and evaluation law before the decisive comparison. The outcome should
-say what was discovered, what the final artifact acquired, and at what total
-cost.}
+\p{Evidence can revise the setting while this proof is sought. A proved
+admitted procedure whose expected score exceeds the proposed ceiling
+invalidates that ceiling. One unusually successful run does not establish
+such an expectation, and failure of a tested menu does not establish a
+universal lower bound. Internal improvements belong in the closed process;
+a contribution the recipient cannot acquire leaves the constructive claim
+unproved. Fix the target, checker, endowments, resource limits and evaluation
+law before the decisive comparison.}

--- a/trees/ftip-00N5.tree
+++ b/trees/ftip-00N5.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Discovery without advance knowledge of the useful pattern}
+\tag{ftip}
+
+\p{Knowing how to construct a representation after someone identifies it
+is different from finding it during research. The relevant cost includes
+reaching a useful idea, recognizing enough of its value to act on it, and
+acquiring a capability that survives fresh evaluation. Each step may occur
+implicitly through learning; an explicit name for the idea is unnecessary.}
+
+\transclude{ftip-00N6}
+\transclude{ftip-00N7}
+\transclude{ftip-00N8}

--- a/trees/ftip-00N6.tree
+++ b/trees/ftip-00N6.tree
@@ -1,0 +1,37 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Which discovery procedures are initially available?}
+\tag{ftip}
+
+\p{The initial controller class in \ref{ftip-00MJ} is part of the
+endowment. It is not enlarged after an assisted discovery by inserting a
+program tailored to that discovery. A concrete specification can supply a
+finite collection of initial controllers, or an executable procedure that
+generates further controllers. In the latter case, generation, execution,
+comparison and selection occur within the campaign and consume its budget.
+The generator's fixed code and constants are themselves initial resources.}
+
+\p{For example, let a campaign generate a program #{A_Z} using a random
+variable #{Z}, and let its later interaction depend on the observed results.
+Its score averages over that declared generation and subsequent execution.
+Showing that one realization #{A_z} constructs a useful representation
+cheaply does not show that the campaign finds that realization cheaply.
+Replacing the campaign by this selected program changes the initial
+endowment unless a legal route to its availability has been supplied.}
+
+\p{This distinction does not forbid an ingenious algorithm. A procedure
+already admitted from the public task-family description is a legitimate
+closed alternative even if nobody has tested it. A lower bound must cover
+it. Conversely, a proof quantifying over all programs with arbitrary
+family-specific constants grants more advice than a fixed model lineage
+possesses. Uniformity across input sizes does not alone remove that advice:
+a single finite program can already contain the decisive family-wide idea.
+The theorem must state which controller access it grants.}
+
+\p{An existential mathematical upper bound may describe a particular
+admitted program without proving that a person will discover its proof.
+The operational claim that a fixed lineage can acquire that program is
+stronger. It requires an available initial program or a charged causal
+construction from its accessible state. Keeping these claims distinct
+prevents both free advance knowledge and the exclusion of legitimate
+internal discoveries.}

--- a/trees/ftip-00N7.tree
+++ b/trees/ftip-00N7.tree
@@ -1,0 +1,38 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Every equally useful acquired solution}
+\tag{ftip}
+
+\p{Fix a difficulty #{n} and task-family parameter, the truth contract,
+fresh evaluation law and
+deployment cap of \ref{ftip-00MM}. For an allowed frozen artifact #{f}, including the failure artifact
+#{\bot}, let
+#{q_n(f)} be its expected fresh-task score under that evaluation. The
+expectation includes fresh tasks and deployment randomness; set #{q_n(\bot)=0}.
+Evaluation begins with
+exactly the retained state permitted by the specification. Define}
+##{\mathcal U_{n,\tau}=\{f\in\mathcal F_n\cup\{\bot\}:q_n(f)\geq\tau\}.}
+\p{If the comparison randomizes a shared family parameter, apply this
+definition conditionally on that parameter and then average the resulting
+scores. This class is defined for mathematical analysis; membership need not
+be decidable or cheaply recognizable during research. It includes any
+artifact with the required performance: explicit lemmas, learned libraries,
+new architectures, implicit weights, and methods that avoid the contributor's
+representation entirely, whenever those artifacts are allowed.}
+
+\p{For a random final artifact #{F_P}, the acquisition score is
+#{Q_{\mathrm{acq}}(P)=\mathbb E[q_n(F_P)]}. The desired lower bound must
+control this expectation for every admitted closed campaign. It cannot
+merely show that one named representation is unlikely to appear. Nor is a
+bound on reaching #{\mathcal U_{n,\tau}} automatically a bound below
+#{\tau}: many outcomes just below the threshold can still have high mean
+score. A proposed proof must connect its event or structural quantity to
+the complete score distribution, as the explicit hypotheses of
+\ref{ftip-00MP} illustrate.}
+
+\p{The contributor need not transmit an entire solution. A question,
+analogy or example may change which experiments the recipient attempts.
+The resulting interpretation, validation and learning remain charged.
+Acquisition is established only by the frozen recipient's performance on
+fresh instances; an insightful exchange by itself establishes neither that
+performance nor a lower bound on unaided discovery.}

--- a/trees/ftip-00N8.tree
+++ b/trees/ftip-00N8.tree
@@ -1,0 +1,40 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{From absent experience to a discovery lower bound}
+\tag{ftip}
+
+\p{The proof direction is to begin with a concrete developmental
+asymmetry: some task-relevant experience available to a contributor is
+absent from the lineage's initial data and observed traces. From a specified
+family and computational model, derive that acquiring any equally useful
+capability exceeds the closed budget. The absence of that experience is
+a premise. The absence of every affordable substitute is the desired
+conclusion, and must not be included as another premise.}
+
+\p{Three arguments are needed. A bounded developmental process must
+produce reusable structure with a stated probability before fresh target
+instances are revealed. A charged interaction and learning procedure must
+turn that structure into recipient capability. A lower-bound argument must
+cover all closed histories admitted by the initial endowment and execution
+semantics, including adaptive tools, simulations, generated programs,
+training, changed architectures and alternative representations. The first
+two arguments describe a constructive assisted procedure; the third
+establishes why the closed lineage cannot match it at the chosen resources.}
+
+\p{A necessary-event estimate becomes useful only after the family and
+operations justify both its necessity and its probability bound. Assuming
+that every successful route requires a rare conceptual event simply moves
+the central difficulty into an assumption. Likewise, absence from a corpus
+does not imply computational inaccessibility: affordable experiments or
+derivations may supply a substitute. A proof must explain what the
+particular environment makes accessible and why the admitted closed
+operations cannot obtain an equally useful substitute within budget.}
+
+\p{Both inequalities in \ref{ftip-00MN} remain open for the intended
+conceptual-discovery mechanism. The conditional transfer estimate in
+\ref{ftip-00MW} and simulation proposition in \ref{ftip-00MX} do not prove
+them. The research objective is a positive separation proof, beginning with
+a sufficiently concrete account of development, access and cost. Any
+restriction used to make the mathematics tractable must be visible in the
+claim; a result for a narrow action class does not establish a ceiling for
+all model lineages.}


### PR DESCRIPTION
A cheap reconstruction program can silently assume knowledge of the useful representation it is meant to discover. This change makes initial controller availability and charged program generation explicit, and defines useful acquisition by fresh-task performance across all allowed artifacts, including alternative representations and implicit weights.

The conjecture now states the proof-directed task: derive a discovery lower bound from absent developmental experience. Both central claims remain open; the existing transfer estimate and simulation proposition remain conditional supporting results. Four addressed pages extend the existing section without changing the six chapter roots.

Validation: `just chk`, the full site build, and `just verify-render` passed for 2,307 XML/HTML page pairs. The 268-page full PDF and three-page focused section were inspected, together with desktop/mobile HTML and mathematical rendering. Fresh independent review passed exact head `64ef8e8d858bf51d68143c58393372f49bbe0199` with no corrections. The full-note mobile width behavior reproduces on the existing public baseline; new standalone pages render correctly. No CSS, build, test, or CI files changed.
