### PR TITLE
docs: develop representation discovery through developmental curricula

### DIFF
--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -27,6 +27,7 @@ illustrates an upper-bound method for a fully specified action class.}
 \transclude{ftip-00MN}
 \transclude{ftip-00N5}
 \transclude{ftip-00N9}
+\transclude{ftip-00NF}
 \transclude{ftip-00MO}
 \transclude{ftip-00MQ}
 

--- a/trees/ftip-00NE.tree
+++ b/trees/ftip-00NE.tree
@@ -61,3 +61,8 @@ lower bound covering every equally useful acquired method as in
 \ref{ftip-00N7}. Keep the model's own discovery, simulations and learning
 inside this argument. Neither the construction alone nor a failed search
 for substitutes proves the prohibitive closed cost.}
+
+\p{\ref{ftip-00NF} develops the first direction as a representation learner
+whose developmental experience also teaches it to construct a useful
+curriculum for another recipient. The concrete objects are the grounded
+representation, the learned teaching policy and their fresh-task effects.}

--- a/trees/ftip-00NF.tree
+++ b/trees/ftip-00NF.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Representation discovery through developmental curricula}
+\p{A useful contribution can change how a learner represents a problem
+and how it learns to reason in that representation. The contributor may
+recognize a conserved quantity, a compositional structure or a distinction
+missing from the learner's present vocabulary. Its curriculum then makes
+that structure usable by another system. This combines two acquisition
+problems: discovering a grounded representation and discovering experiences
+that teach it.}
+
+\p{The proposed construction uses related tasks with public transformation
+rules. A bounded developmental learner acquires representations and teaching
+procedures on earlier tasks; an initially separate recipient learns from
+its contribution and faces fresh certified tasks. The intended gain is
+less total acquisition work at a fixed success threshold. The construction
+below specifies the mechanisms to establish that gain. A successful
+learning process and a lower bound over every affordable closed alternative
+remain mathematical obligations, not consequences of specifying the setting.}
+
+\transclude{ftip-00NG}
+\transclude{ftip-00NH}
+\transclude{ftip-00NI}
+\transclude{ftip-00NJ}

--- a/trees/ftip-00NG.tree
+++ b/trees/ftip-00NG.tree
@@ -1,0 +1,52 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Public transformations and learned representations}
+\p{Consider finite expressions built from a public grammar. A family
+parameter #{\theta} specifies local rewrite rules and a distribution of
+problem sizes and compositions. The description of #{\theta}, the grammar
+and the rules are available to both campaigns. A target instance asks
+whether one expression can be transformed into another. An accepted answer
+contains either a legal rewrite sequence or a proof of impossibility in a
+fixed sound proof system. The generator produces instances with certificates
+of bounded size, retains those certificates for evaluation, and reveals
+only the instance to the learner. The checker, allowed proof rules and
+certificate-size cap are identical for assisted and closed campaigns.}
+
+\p{Public rules make the intended difficulty computational. Earlier
+experience may teach consequences of the rules that are expensive to find
+from their description. It supplies no secret governing future answers.
+The family parameter, development law, evaluation distribution and resource
+caps are fixed before final seeds are sampled. Developmental and final
+seeds are independent conditional on #{\theta}. Intermediate learning tasks
+may be simpler than final tasks, but their relation to the final distribution
+must be specified by the generator rather than chosen after observing a
+favorable test result.}
+
+\p{One possible learned representation consists of a map #{\phi} from
+concrete expressions to abstract states, abstract operations, and procedures
+connecting abstract reasoning to checked concrete certificates. For example,
+a learner may discover that several rewrites preserve a quantity, or that
+large expressions decompose into components with a small interface. A
+soundness proof for the invariant or decomposition is part of the acquired
+method when it is used to certify an answer. Recognizing a pattern in a
+few examples is insufficient. Grounding here means computing the abstract
+description from the supplied expression and justifying the concrete
+consequences used by the solver.}
+
+\p{The map may discard distinctions. If two expressions have the same
+abstract description but require different choices, a successful learner
+can refine the representation, retain a concrete side condition, or use
+another level of description. The cost of discovering the counterexample
+and implementing the revision counts. The task family should admit several
+sufficient methods: another invariant, a different decomposition, a compiled
+solver or direct search may succeed without reconstructing #{\phi}.
+Success is measured by checked answers, so equally useful implicit
+representations in model parameters also qualify.}
+
+\p{This is a parameterized family design, not a claimed hard rewrite
+system. An explicit instance of the construction must give the grammar,
+rules, certified generator and learning procedures, then prove their
+performance. Families reducible to a cheap canonical form or direct search
+may demonstrate learning and transfer while offering no discovery-cost
+separation. That possibility is a substantive test of the proposed mechanism.}

--- a/trees/ftip-00NH.tree
+++ b/trees/ftip-00NH.tree
@@ -1,0 +1,50 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Learning to discover and teach a representation}
+\p{The contributor begins with the disclosed state and bounded development
+of \ref{ftip-00NA}. On related rewrite tasks it can propose predicates,
+execute public rules, test conjectures, build examples and revise its
+representation. Neither a completed invariant nor a successful curriculum
+is placed in its initial state unless that preparation is explicitly counted
+as an inherited endowment. A constructive success argument must describe
+how the development process produces useful structure with a stated
+probability, including failed attempts.}
+
+\p{Teaching is a further learned action. Let #{Z_t} be the contributor's
+retained state, #{h_t} the observed interaction history and #{q_t} an
+intermediate task or demonstration. A teaching policy chooses #{q_t} from
+#{Z_t} and #{h_t}; the recipient's response and checked learning progress
+supply feedback for later choices. The policy may first teach a distinction
+on small expressions, then ask for a general invariant, and finally require
+composition on larger expressions. These stages describe a possible
+mechanism. Their usefulness must be established for the specified learner,
+rather than assumed from the apparent pedagogical order.}
+
+\p{During development, the contributor can practice with bounded copies
+of a declared recipient population. It learns which examples correct
+particular failures and when a new abstraction is worth introducing. The
+student updates used to evaluate a teaching proposal are real work: cloning,
+training, progress evaluation, rejected curricula and teacher updates all
+count. A progress set drawn from the development distribution can provide
+a verified reward. Final evaluation instances remain unavailable for
+curriculum selection. Any guarantee must connect development progress to
+fresh-task success, since a curriculum may overfit either the practiced
+recipient or its progress measure.}
+
+\p{At assistance time, a fresh recipient starts from the declared model
+endowment. The contributor supplies an explanation, programs, examples or
+an adaptive sequence of tasks, within communication and interaction caps.
+The recipient must interpret the contribution, check the relevant claims
+and learn to use the representation. Evaluation occurs after the contributor
+is removed. A retained contributed program is allowed when it fits the
+common deployment interface and cap; merely consulting an uncharged external
+solver during evaluation is a different experiment.}
+
+\p{Useful teaching need not require the teacher to solve the final tasks
+itself. Conversely, a source that can solve them may still fail to teach
+the recipient. Measuring the contributor's discovery, its teaching skill
+and the recipient's later capability separately makes these possibilities
+visible. A short explanation or a short successful curriculum measures
+transmission after discovery; its length does not establish that finding
+it was cheap or expensive.}

--- a/trees/ftip-00NI.tree
+++ b/trees/ftip-00NI.tree
@@ -1,0 +1,50 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Contemporary representation and curriculum learners}
+\p{Current agents already implement substantial parts of this construction.
+[TheoryCoder-2](https://arxiv.org/html/2602.00929v1) synthesizes PDDL
+abstractions alongside a learned Python dynamics model and hierarchical
+planning. Its discussion nevertheless identifies supplied object-oriented
+states and brittle predicate grounding as limitations. In its tested
+environments, an initial observation sufficed for adequate abstractions;
+learning to revise a representation through unfamiliar interventions remains
+a further problem. This motivates learning the concrete-to-abstract map,
+without implying that generated predicates are beyond model capabilities.}
+
+\p{[ProPlay](https://arxiv.org/html/2606.12780v1) learns a procedural graph
+with transition reliability to guide later action. Its failure analysis
+shows why reusable structure alone is insufficient: a coarse procedure can
+lose necessary quantitative detail, and a generally reliable transition
+can be unhelpful for the present task. Its plan is produced once per episode.
+The representation learner above must therefore be compared with agents
+allowed to revise plans and abstraction levels, not just with the particular
+implementation evaluated in that paper.}
+
+\p{[SOAR](https://arxiv.org/html/2601.18778v3), especially its method,
+ablations and limitations, provides an automated teaching mechanism: teacher
+tasks receive reward through a student's improvement on a separate hard
+training set, without the teacher seeing those hard questions. Its
+substantial bilevel training cost and dependence on a ground-truth progress
+signal belong in the comparison. Failure on an initial finite sample does
+not prove that direct discovery is impossible.}
+
+\p{[Vocabulary Dropout for Curriculum Diversity](https://arxiv.org/html/2604.03472v4)
+shows that modifying proposal generation can sustain curriculum diversity,
+while its asymmetric proposer/solver experiment and verification analysis
+show that diversity and stronger teachers need not yield better learning.
+[ANCORA](https://arxiv.org/html/2604.27644v2) combines supervised
+initialization, proposer/solver training and a filtered curriculum graph
+for verifier-based learning. Its limitations include diversity collapse
+within valid outputs and longer-run plateaus. Its Proposition 4.1 assumes
+continued positive probability of admitting new specifications; that premise
+does not establish the cost of discovering useful new concepts.}
+
+\p{These results motivate a combined comparison with representation
+synthesis, curriculum generation, active experiments, persistent memory,
+search and model updates. Their reported benchmarks do not instantiate the
+rewrite construction or establish its separation. A contributor defined
+only as a supplier of abstractions, diverse exercises or a curriculum graph
+would duplicate mechanisms already available to the closed campaign. The
+remaining question concerns how much work any adequate combination needs
+to acquire useful structure from the specified starting state.}

--- a/trees/ftip-00NJ.tree
+++ b/trees/ftip-00NJ.tree
@@ -1,0 +1,54 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Fresh transfer and the discovery-cost argument}
+\p{Fix a final success threshold and a resource vector before comparing
+methods. The assisted upper-bound problem is constructive: specify bounded
+development, a prospective source-selection procedure, contribution
+production and recipient learning, and establish their joint probability
+of reaching the threshold. Charge failed development and teaching runs
+where selection uses them. The marginal comparison discloses earlier
+contributor development separately; a lifetime claim includes that work
+under \ref{ftip-00ND}. Communication length, token count, accelerator work
+and elapsed time are distinct quantities unless an explicit conversion
+relates them.}
+
+\p{Several controlled comparisons can locate the benefit. Giving the
+recipient a completed grounded representation measures acquisition after
+discovery. Replaying a successful curriculum measures learning after its
+selection. Replacing adaptive teaching with fixed examples tests the value
+of recipient feedback; varying the final expression size and composition
+tests reuse. A closed campaign that builds its own curricula, revises
+representations and updates its models tests affordable reconstruction.
+The supplied-representation and replay experiments are positive controls,
+not estimates of unaided discovery cost.}
+
+\p{The mechanism predicts that a useful developmental curriculum reduces
+recipient work on unseen compositions, and that failures caused by lost
+abstract distinctions decrease after grounded refinement. If gains vanish
+when the source is removed, depend on near-duplicate evaluation instances,
+or disappear under a cheap alternative solver, the proposed explanation
+must change. Measuring these outcomes can reject a candidate construction.
+An observed advantage over the implemented comparison agents still leaves
+the all-campaign claim open.}
+
+\p{For that claim, start with an arbitrary successful closed campaign in
+\ref{ftip-00MJ}. Its code search, implicit representations, retrieval,
+synthetic tasks, self-play, active interventions, training updates,
+heterogeneous models and resource-allocation choices are all admissible
+when allowed by the declared endowment and caps. The lower-bound argument
+must connect its checked fresh-task success to work that every such route
+incurs. It cannot require the campaign to discover the contributor's
+particular invariant or follow its curriculum. Direct solving is an
+alternative to conceptual reconstruction.}
+
+\p{A family-specific reduction could show that any successful closed
+campaign solves an independently hard computational problem, while the
+bounded developmental process and assistance yield an affordable upper
+bound under the disclosed prior endowments. A restricted representation
+language or response interface may admit a first, narrower theorem. Neither
+case permits assuming that every useful curriculum or
+representation is negligibly likely under arbitrary adaptive search:
+that would assume the desired discovery barrier. The absence of the
+contributor's experience in \ref{ftip-00N8} supplies the starting condition;
+the prohibitive cost of every equivalent capability is still to be derived.}


### PR DESCRIPTION
A developmental contribution may need to discover a grounded representation and learn how to teach it. This change develops that mechanism using public rewrite rules, a certified task generator, bounded contributor development, an adaptive teaching policy and a fresh recipient evaluated after the source is removed.

The section distinguishes discovery from replay or acquisition, specifies controls and predictions, and compares against contemporary representation synthesis and curriculum learners. Direct search, alternative abstractions, implicit representations and model updates remain covered by the intended closed lower bound. This is a research construction, with the success proof and all-campaign separation still open.

Validation: `just chk` (22 prose tests), full site build and `just verify-render` (2,318 page pairs) pass. The full 278-page PDF, focused six-page PDF, new-section pagination and desktop/mobile HTML were inspected. Frozen evidence covers 14 affected pages and all 825 FTIP HTML payloads. Fresh independent Sol/high review: PASS with no actionable findings, independently checking source, artifact hashes, the five primary papers, responsive pages and full-PDF pages 162–168. Exact base `bd9913a2bb64559f34e488f33d75b3ae5898e9a0`, head `58b4ef6da3744acf3e1159c3c8b915ad876242c9`, tree `2f6b2a4152ca3e6134681e395ff4b812b88537b6`. Five new stable addressed sections and two integration links; six chapter roots are unchanged. Exact-head CI build and lint both pass.
