### PR TITLE
docs: develop prospective abstraction under changing demands [AGENT]

### DIFF
--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -28,6 +28,7 @@ illustrates an upper-bound method for a fully specified action class.}
 \transclude{ftip-00N5}
 \transclude{ftip-00N9}
 \transclude{ftip-00NF}
+\transclude{ftip-00NK}
 \transclude{ftip-00MO}
 \transclude{ftip-00MQ}
 

--- a/trees/ftip-00NF.tree
+++ b/trees/ftip-00NF.tree
@@ -19,6 +19,10 @@ below specifies the mechanisms to establish that gain. A successful
 learning process and a lower bound over every affordable closed alternative
 remain mathematical obligations, not consequences of specifying the setting.}
 
+\p{A complementary acquisition problem is deciding which representations
+will matter before future demands are apparent. \ref{ftip-00NK} studies
+that prospective choice through a changing public task process.}
+
 \transclude{ftip-00NG}
 \transclude{ftip-00NH}
 \transclude{ftip-00NI}

--- a/trees/ftip-00NK.tree
+++ b/trees/ftip-00NK.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Prospective abstraction in evolving task families}
+\p{Some concepts become valuable because they prepare a learner for tasks
+that have not yet arrived. A contributor may learn how research demands
+evolve and invest in structure whose utility is poorly reflected by
+compression of past solutions. The acquired capability is a way to forecast,
+choose and revise abstractions under limited resources.}
+
+\p{This differs from constructing a teaching curriculum in
+\ref{ftip-00NF}. There the source chooses experiences that help a recipient
+learn useful structure. Here the source learns about the process producing
+future demands, and uses that understanding to decide which structure is
+worth acquiring. Teaching can transmit the resulting capability, but does
+not define its prospective value. Informative experiments, cumulative
+culture and research judgment can support either process.}
+
+\transclude{ftip-00NL}
+\transclude{ftip-00NM}
+\transclude{ftip-00NN}
+\transclude{ftip-00NO}
+\transclude{ftip-00NP}

--- a/trees/ftip-00NL.tree
+++ b/trees/ftip-00NL.tree
@@ -1,0 +1,44 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{A public process for changing task demands}
+\p{Extend the public rewrite setting of \ref{ftip-00NG} by a sequence
+of demand states #{X_t}, with a declared initial distribution. A fixed
+transition law #{K_\theta} governs how
+the demand state changes. Conditional on #{X_t}, a fixed generator
+#{G_\theta} samples a certified task. The parameter #{\theta}, both
+laws and the rewrite rules are available to both campaigns. A demand state
+may favor particular compositions, expression sizes or interfaces, so an
+abstraction useful in one period need not remain useful in the next. The
+future random seeds are unrevealed, and the laws are fixed independently
+of either learner's decisions. The laws are given as computable programs;
+their execution and any derived approximation are charged.}
+
+\p{For example, demand may move between tasks dominated by local
+cancellation, tasks requiring repeated composition, and tasks coupling
+several components through a shared boundary. This describes possible
+structure in the generator, not established difficulty of those tasks.
+The change law could make a local regularity predictive of later coupling,
+so acquiring a compositional representation has value before that coupling
+becomes common. An actual construction must specify the expressions,
+rules and transition probabilities, and show that its proposed investment
+really reduces later work.}
+
+\p{A state #{X_t} can be observed directly or inferred from the common
+history of revealed tasks and responses. Fix which case applies. If the
+state is latent, both campaigns receive the same observations; the source
+has no private reading of the current state or future seed. In the
+computational version, their problem is to process the available history
+and public laws cheaply enough. Uncertainty remaining even for an unlimited
+observer is common to both. Giving only the contributor an informative
+sensor or an undisclosed generator defines a separate information-access
+comparison.}
+
+\p{Development uses earlier independently seeded episodes from the
+declared process family. It may teach a learner to recognize which histories
+predict useful future structure, but cannot supply the final episode's
+hidden state. Selection of the source and its retained state precedes
+final seeds. During evaluation, tasks arrive in order; any feedback and
+adaptation available after an answer follow the same specified schedule
+on both sides. The final correctness predicate, proof rules and
+certificate cap stay fixed throughout the changing demand distribution.}

--- a/trees/ftip-00NM.tree
+++ b/trees/ftip-00NM.tree
@@ -1,0 +1,41 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Joint acquisition of a forecast and a library}
+\p{A developmental learner retains a predictive state #{b_t} and a
+library #{L_t} of representations, subroutines or reusable reasoning
+procedures. From the observed history it updates its forecast of future
+tasks and decides whether to extend, refine or discard library elements.
+The forecast need not be an explicit Bayesian posterior, and the library
+may be encoded in parameters. The defining feature is that the learner
+uses anticipated downstream utility in deciding what to acquire.}
+
+\p{The two learning problems interact. A new representation can make a
+previously obscure regularity in the task process easier to recognize;
+a revised forecast can change which representation is worth learning.
+Consequently, a predictor operating over a fixed, human-supplied list of
+perfect abstractions removes part of the proposed acquisition problem.
+A bounded construction should describe how candidate structure is generated,
+how its consequences are grounded, and how experience updates both
+prediction and selection. Initial program libraries, pretrained predictors
+and demonstration histories remain disclosed endowments.}
+
+\p{One possible developmental procedure generates candidate decompositions
+from earlier solved tasks, predicts their usefulness over a finite future
+horizon, and spends a capped amount of work testing the most promising
+candidates on independently sampled continuations. Failed predictions
+supply feedback. This is an explicit algorithmic pattern, not a free
+forecast oracle: generating continuations, constructing a simulator,
+evaluating candidates and revising the predictor all cost work. With public
+computable laws, the closed campaign may implement this procedure too.
+The intended advantage must come from the cost of acquiring a sufficiently
+useful procedure from the specified endowments.}
+
+\p{A developed contributor can teach the recipient its selection method,
+transmit a grounded library with its conditions of use, or help initialize
+a predictor. The recipient must acquire and apply the contribution within
+the assistance cap. Later library selection and task solving are performed
+without further uncharged source access. A one-time selection for a revealed
+history is a weaker form of help than learning a reusable prospective
+policy; transfer to fresh episodes distinguishes them. Neither form
+requires matching the source's internal concepts.}

--- a/trees/ftip-00NN.tree
+++ b/trees/ftip-00NN.tree
@@ -1,0 +1,40 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Prospective selection and contemporary agent alternatives}
+\p{[Prospective Compression in Human Abstraction Learning](https://arxiv.org/html/2605.09985v1)
+studies reusable-helper choices while a latent curriculum changes. Its
+two controlled Pattern Builder experiments involve 60 participants in total
+and six computational comparison models. The results support sensitivity
+to future reusable structure beyond the tested retrospective and LLM-based
+accounts. They motivate studying prospective acquisition rather than only
+compression of earlier solutions.}
+
+\p{The paper's limitations are decisive for the comparison here. It does
+not implement a full learner that infers the latent task-generating process,
+and individual tasks can be solved without reproducing human helper choices.
+Its restricted helper-optimization hardness result does not bound arbitrary
+learning agents. The proposed construction therefore evaluates checked
+future performance and total work, rather than similarity to human-selected
+helpers, and admits agents that jointly learn a process model and a library.}
+
+\p{Such agents may forecast by Bayesian inference, learned world models,
+sequence prediction or simulation; select structure by search, expected
+utility or learned value estimates; and retain experience in memory or
+model updates. [ProPlay](https://arxiv.org/html/2606.12780v1) supplies one
+contemporary procedural-memory mechanism, while
+[BREW](https://arxiv.org/html/2511.20297v2) constructs reusable recipes
+from trajectories and optimizes their correctness and retrieval usefulness.
+These particular systems do not establish prospective learning for the
+public rewrite process, but their mechanisms are available components of
+an alternative campaign.}
+
+\p{Theoretical active-inference guarantees also require attention to
+what is already supplied. [Curiosity is Knowledge](https://arxiv.org/html/2602.06029v1)
+proves results under stated identifiability and regularity conditions;
+its discussion identifies idealizations including a discrete hypothesis
+setting and exact mutual-information computation. Providing an adequate
+hypothesis class or an exact acquisition calculation can remove work that
+the developmental construction is meant to explain. Conversely, these
+restrictions do not establish that a more general agent cannot find an
+affordable approximation or a different sufficient method.}

--- a/trees/ftip-00NO.tree
+++ b/trees/ftip-00NO.tree
@@ -1,0 +1,48 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Experiments, cultural preparation and research judgment}
+\p{Informative experiments can improve either representation discovery
+or forecasts of future demand. A contributor may learn which intervention
+distinguishes plausible decompositions or exposes a misleading progress
+measure. In the public-rule setting, both campaigns can execute the same
+permitted experiments; the question is the cost of choosing and interpreting
+them. [Criticality-guided learning](https://arxiv.org/html/2607.28251v1)
+learns to target failure-prone conditions from execution outcomes, showing
+why rarity under random sampling is too weak an argument. Its predefined
+state representations remain a relevant limitation of that implementation.
+A physical experiment with unequal access may support a different, explicitly
+informational or interaction-rate result.}
+
+\p{Cultural preparation can supply earlier exploration, tested concepts
+and teaching practices. Model it as a bounded population that generates,
+selects and transmits methods, or disclose its products as inherited
+endowments. Failed discoveries, selection and transmission count; so do
+analogous shared data, model populations and libraries on the closed side.
+The [study of AI-discovered strategies in human culture](https://www.nature.com/articles/s41467-026-76113-2)
+separates difficulty of discovery, ease of transmission and recognizable
+advantage. Its AI-to-human direction supports an origin-neutral contribution.
+Neither that experiment nor its population simulations establish a general
+discovery lower bound. Prior cultural work can explain a marginal benefit,
+while lifetime and amortized claims require the accounting in \ref{ftip-00ND}.}
+
+\p{Research judgment can help choose a fruitful subproblem, recognize
+when an abstraction loses an essential distinction, or improve an
+intermediate progress measure. Such choices affect how computation is spent;
+they do not change the final mathematical task or checker. The
+[study of divergence and negation in scientific ideas](https://arxiv.org/html/2606.08251v3)
+reports differences between expert ratings and several automated evaluations,
+while also showing benefits from learning a reward model on human ratings.
+This motivates acquired judgment without treating it as a human monopoly.
+Expert ratings of ideas do not directly certify mathematical discovery.
+For this construction, any learned progress measure must justify its value
+through fresh checked outcomes, with its own training and validation charged.}
+
+\p{These three contributions have distinct roles: experiments produce
+useful evidence, culture explains how prior useful structure was generated
+and transmitted, and judgment guides selection and evaluation. They can
+support both major constructions, but their benefits do not automatically
+add. A curriculum learned from cultural demonstrations and selected by an
+experimental progress measure may share preparation across all three.
+Ablations should vary one mechanism at a time, and total accounting should
+charge shared work once.}

--- a/trees/ftip-00NP.tree
+++ b/trees/ftip-00NP.tree
@@ -1,0 +1,54 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Future utility, investment cost and proof scope}
+\p{Fix a horizon #{H}, a success threshold and a common adaptation
+schedule. In an additive work measure, let #{A_t} charge forecasting,
+experiments and library construction before task #{t}, and let #{S_t}
+charge solving, checking and permitted learning from that task. Let #{I}
+charge assistance production, communication and recipient acquisition.
+The assisted marginal work is}
+##{W_1=I+\sum_{t=1}^{H}(A_t+S_t).}
+\p{The closed total charges its corresponding acquisition and task work
+under the same convention. Forecasts may optimize expected future work,
+but a hard budget claim must also bound realized resource use and include
+runs that exhaust the cap in the success probability. Memory, peak hardware
+and elapsed time retain their separate operational constraints. Earlier
+development and any portfolio amortization follow \ref{ftip-00ND}.}
+
+\p{A useful prospective policy should reduce later acquisition and solving
+work enough to repay its earlier investment at the fixed success threshold.
+Compare it with retrospective compression, a learned generative-model
+policy, direct solving without a reusable library, and a campaign that
+constructs its own predictor and representations. Equalize current
+observations and disclose earlier preparation. An oracle given the future
+sequence can diagnose the maximum possible value of anticipation, but its
+performance does not establish that either real learner can obtain it.}
+
+\p{The mechanism predicts a larger benefit when demand changes have
+learnable structure and the right abstractions require substantial advance
+investment. It predicts a smaller benefit when demand is uninformative,
+useful libraries are cheap to build on arrival, or direct solving already
+fits the cap. A predictor can be accurate yet unhelpful if its forecast
+does not change an affordable decision. Measure fresh-task success, realized
+work and the effect of forecast-guided investment together. These are
+testable predictions for the specified process, not reported experiments.}
+
+\p{The constructive proof problem is to produce a bounded developmental
+learner and establish its later performance without hindsight selection
+or privileged final-episode information. The closed lower-bound problem
+must cover every equally useful selection or solving method in
+\ref{ftip-00N7}, including implicit forecasts, alternate abstractions,
+heterogeneous learners and internally generated curricula. A lower bound
+only against retrospective compression would explain that restricted
+comparison, not the conjecture about contemporary closed campaigns.}
+
+\p{For a computational separation with public laws, a reduction must
+connect fresh checked success to an independently hard inference or
+computation problem under the declared endowment and resource cap. It must
+also explain why direct solving and alternative investment policies cannot
+avoid that work. Withholding the future law from one side, choosing future
+tasks after seeing its library, or assuming every useful forecast is rare
+would establish a different claim or assume the desired conclusion. The
+prospective construction supplies a distinct acquisition problem; the
+all-campaign cost inequality remains open.}


### PR DESCRIPTION
A contributor may learn how research demands evolve and acquire useful structure before it is needed. This change develops prospective abstraction as a separate acquisition problem from teaching a grounded representation: a public computable process produces changing task demands, both campaigns receive the same current observations, and independently seeded development precedes unrevealed final tasks.

The construction specifies joint forecast and library learning, charges anticipation and recipient acquisition, and measures future checked success and realized work. It explains how informative experiments, cultural transmission and learned research judgment can support either construction, with contemporary mechanisms and limits grounded in seven primary papers. An explicit hard family, constructive success theorem and all-campaign cost lower bound remain open.

Validation: `just chk` (22 prose tests), full site build and `just verify-render` (2,324 page pairs) pass. The full 284-page PDF, focused six-page PDF, new-section pages 167–173 and desktop/mobile HTML were inspected. Frozen evidence covers 15 affected pages and all 831 FTIP payloads. Independent Sol/high review: PASS with no actionable findings, bound to the actual predecessor merge after independent verification of unchanged source and artifacts. Exact base `2b4c6bb1544b030f36edde25999f71855c39e1c3`, head `faed260b998d9aca131acc793afb521bf1705f21`, tree `e6de4cc6f2ac5f9b670a09c4359001a0d0033ad5`. Six new stable addressed sections and two integration links preserve the six chapter roots.

Exact-head CI build and lint both pass.
