### PR TITLE
docs(ftip): define mathematical research beyond initial ability [AGENT]

### DIFF
--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -29,6 +29,7 @@ illustrates an upper-bound method for a fully specified action class.}
 \transclude{ftip-00N9}
 \transclude{ftip-00NF}
 \transclude{ftip-00NK}
+\transclude{ftip-00NQ}
 \transclude{ftip-00MO}
 \transclude{ftip-00MQ}
 

--- a/trees/ftip-00NQ.tree
+++ b/trees/ftip-00NQ.tree
@@ -1,0 +1,19 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Mathematical research beyond initial ability}
+\p{A mathematical agent can develop a method for a problem whose solution
+is already known to its evaluators. What matters for acquisition is the
+agent's starting ability, the research it performs, and the new problems
+it can solve afterward. Novel mathematics strengthens the discovery outcome,
+but withholding a known solution can make the development of a method
+observable under a precise standard of correctness.}
+
+\p{This setting makes the developmental construction of \ref{ftip-00NF}
+concrete through mathematical research. A candidate concept is tested against
+objects and counterexamples, useful lemmas are retained, and a recipient
+acquires an artifact before fresh problems are revealed. The prospective
+question in \ref{ftip-00NK} concerns which such concepts are worth developing
+for future demands. Both questions admit successful autonomous discovery.}
+
+\transclude{ftip-00NR}

--- a/trees/ftip-00NR.tree
+++ b/trees/ftip-00NR.tree
@@ -1,0 +1,105 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Initial difficulty, discovery and retained capability}
+\p{Fix an initial agent, its available mathematical material and tools,
+a correctness standard, and a budget for an initial attempt. A problem
+is initially unresolved by this agent when the declared attempt procedure
+returns no accepted solution. A family-level measurement reports the initial
+success rate and its sampling uncertainty. Failure under this procedure
+neither proves that the solution is absent from pretrained weights nor
+establishes failure under every affordable procedure.}
+
+\p{This operational condition permits three settings. In controlled
+rediscovery, evaluators know a useful mathematical concept and withhold its
+explicit construction. In withheld research problems, evaluators possess
+proofs that the agent cannot retrieve through its permitted interfaces.
+In open mathematical research, a result may also be new to the community.
+The initial agent can have relevant background knowledge in all three.
+Novelty, correctness and improvement over initial ability are different
+measurements.}
+
+\p{The [First Proof second batch](https://arxiv.org/html/2606.18119v1)
+provides a concrete withheld-research protocol: human-proved research lemmas
+were evaluated before their proofs were published, with organizer-run agents,
+a time limit and expert assessment. Its released statements and logs are
+now public, so a new experiment must use fresh withheld material or state
+which reconstruction of earlier access is being tested. An agent's accepted
+alternative proof can be a substantive discovery even if the theorem has
+an existing human proof.}
+
+\p{The research campaign has three observable products. A discovery is an
+accepted mathematical result or method obtained during development. An
+acquired artifact is the state retained for subsequent work: parameters,
+a checked library, an executable representation, a search procedure, or an
+explicitly specified combination. Transfer is the performance of that frozen
+artifact on new problems under a common deployment budget. A successful
+answer to the current problem alone does not establish transfer. Continuing
+to consult the contributor during evaluation changes the system being
+measured and must be a separate condition.}
+
+\p{[DreamProver](https://arxiv.org/html/2604.26311v1) (sections 3--5)
+illustrates how research produces a reusable library. Failed training goals
+are decomposed into helper results; a later phase clusters, generalizes,
+verifies and prunes candidate lemmas. Libraries are then evaluated on
+separate theorems. The learned lemmas may be well-known mathematics, and
+the retained artifact is available in context rather than necessarily
+encoded by a parameter update. This is evidence for a particular acquisition
+mechanism, with discovery and library-construction costs still relevant
+to a complete comparison.}
+
+\p{[ProofEvolve](https://arxiv.org/html/2608.26334v1) (section 5.6)
+separates two useful reuse experiments. Synthetic compositional families
+compare a growing library against resetting it. A separate held-out theorem
+study supplies relevant self-generated, verified proofs as examples and
+compares them with no examples and random retrieval. That second experiment
+disables proof-graph search, decomposition and repair, so its measured gain
+isolates contextual reuse rather than the entire evolving prover. This
+suggests testing the contribution of an acquired library independently
+of changes to the surrounding search algorithm.}
+
+\p{The [multi-agent concept-discovery study](https://arxiv.org/html/2603.04528v2)
+provides a complementary mechanism. A conjecturing process guides symbolic
+regression, a skeptical process challenges regularities by reweighting
+examples, and provability feedback helps select candidates. Experiments
+reconstruct expressions related to Euler characteristic and Betti numbers.
+The provided incidence matrices, dimensions, ranks and nullities already
+encode mathematical insight. Discovering an expression from those features
+and inventing the underlying representation are distinct acquisition tasks.
+A concrete experiment must state which one it measures.}
+
+\p{[SOAR](https://arxiv.org/html/2601.18778v3) makes useful teaching an
+executable development process: a teacher proposes intermediate exercises
+and is rewarded by measured student progress on difficult training questions.
+Its initial filtering by repeated failed attempts is an operational
+criterion, not an impossibility claim. Teacher development and recipient
+training are separately charged, including unsuccessful curricula. A
+contributor can therefore be a learned mathematical teacher rather than
+an unexplained source of ideal hints.}
+
+\p{The autonomous comparator must also admit learning during search.
+[TTT-Discover](https://arxiv.org/html/2601.16175v2) (section 3) updates a
+model while seeking an excellent solution to the current problem; later
+generalization is outside that stated objective.
+[ThetaEvolve](https://arxiv.org/html/2511.23473v1) (section 4.3.1) includes
+an experiment freezing a checkpoint trained on one mathematical search
+task and applying it to unseen tasks. These mechanisms distinguish current
+search progress from retained parameter acquisition. Checkpoint selection
+and learning costs accompany the latter comparison.}
+
+\p{The proposed FTIP experiment combines concept testing, verified lemma
+accumulation and recipient transfer. This combination is a research proposal,
+not a result reported jointly by the cited papers. Both campaigns retain
+the fixed mathematical rules and checker of \ref{ftip-00ML}; an external
+contribution may provide a representation, connection or curriculum developed
+from permitted related experience. Its producer does not receive the
+withheld evaluation answers. The recipient may reject it, improve it or
+find an alternative. All of that work belongs to the process being compared.}
+
+\p{The finite comparison can show that one developed artifact is useful
+or affordable relative to tested alternatives. It cannot establish the
+all-lineage lower bound in \ref{ftip-00MN}. If an admitted classical solver,
+a self-generated library or a learned autonomous procedure reaches the
+same capability more cheaply, that finding is evidence against the proposed
+advantage for this setting. The correctness criterion does not privilege
+reconstruction of the evaluator's preferred concept.}


### PR DESCRIPTION
The FTIP research setting previously left community-open mathematics as the apparent starting point. This adds a precise setting for problems beyond an agent's initial demonstrated ability, including withheld research lemmas and controlled conceptual rediscovery.

The new section distinguishes discovery, retained artifacts and fresh-task transfer, and grounds the proposed workflow in First Proof, DreamProver, ProofEvolve, concept discovery, SOAR, TTT-Discover and ThetaEvolve. It preserves the open status of the all-lineage cost claim and admits successful autonomous alternatives.

Validation: source lint passes, including 22 prose regression tests. Final full build, HTML/PDF inspection and independent review are in progress; this draft starts CI while those checks complete. The change touches three tree files, preserves the six chapter roots and adds no tests or build-system changes.
