### PR TITLE
FTIP: invariant rediscovery and contributor development

### DIFF
--- a/trees/ftip-00NQ.tree
+++ b/trees/ftip-00NQ.tree
@@ -17,3 +17,5 @@ question in \ref{ftip-00NK} concerns which such concepts are worth developing
 for future demands. Both questions admit successful autonomous discovery.}
 
 \transclude{ftip-00NR}
+\transclude{ftip-00NS}
+\transclude{ftip-00NT}

--- a/trees/ftip-00NS.tree
+++ b/trees/ftip-00NS.tree
@@ -35,8 +35,10 @@ rediscovery is being measured. They are not new mathematical results.}
 \p{Allowed changes include invertible changes of basis #{P_i} in each
 space. They replace the matrices by}
 \eqnotag{
-  D'_1=P_0D_1P_1^{-1},\qquad
-  D'_2=P_1D_2P_2^{-1}.
+  \begin{aligned}
+  D'_1&=P_0D_1P_1^{-1},\\
+  D'_2&=P_1D_2P_2^{-1}.
+  \end{aligned}
 }
 \p{The product remains zero and the ranks remain unchanged. Another allowed
 change adjoins or removes a direct summand consisting of an identity map
@@ -63,7 +65,11 @@ mathematical checker.}
 nonnegative integer tuples #{(h_0,h_1,h_2,r_1,r_2)} satisfying the declared
 dimension cap, where}
 \eqnotag{
- n_0=h_0+r_1,\quad n_1=h_1+r_1+r_2,\quad n_2=h_2+r_2.
+ \begin{aligned}
+ n_0&=h_0+r_1,\\
+ n_1&=h_1+r_1+r_2,\\
+ n_2&=h_2+r_2.
+ \end{aligned}
 }
 \p{It builds a direct sum of zero-differential spaces of dimensions
 #{h_i} in degree #{i}, #{r_1} identity pairs in degrees one and zero,

--- a/trees/ftip-00NS.tree
+++ b/trees/ftip-00NS.tree
@@ -1,0 +1,104 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{A finite setting for invariant rediscovery}
+\p{A first concrete family can use linear chain complexes over the two-element
+field #{\mathbb F_2}. This adapts the incidence-matrix concept-discovery
+setting of [Aggarwal et al.](https://arxiv.org/html/2603.04528v2) into an
+exact finite experiment. The chosen field, transformations and certificate
+tasks below are part of this proposal, not a reproduction of that paper.}
+
+\p{An object consists of vector spaces of dimensions #{n_0,n_1,n_2} and
+matrices #{D_1:\mathbb F_2^{n_1}\to\mathbb F_2^{n_0}} and
+#{D_2:\mathbb F_2^{n_2}\to\mathbb F_2^{n_1}} satisfying #{D_1D_2=0}.
+All entries, dimensions and allowed operations are public. Arithmetic is
+exact. Zero-dimensional spaces and zero maps are included. The experiment
+can provide only matrices and arithmetic, or additionally ranks and
+nullities; these are different initial endowments and receive separate
+results. Neither regime establishes discovery of the entire mathematical
+representation from unstructured observations.}
+
+\p{The middle cycles and boundaries are #{Z_1=\ker D_1} and
+#{B_1=\operatorname{im}D_2}. The chain identity gives #{B_1\subseteq Z_1},
+so the quotient #{H_1=Z_1/B_1} is defined. Rank-nullity yields}
+\eqnotag{
+  \beta_1=\dim H_1
+  =n_1-\operatorname{rank}D_1-\operatorname{rank}D_2.
+}
+\p{Indeed, #{\dim Z_1=n_1-\operatorname{rank}D_1} and
+#{\dim B_1=\operatorname{rank}D_2}; taking the quotient subtracts these
+dimensions. At the ends, #{\beta_0=n_0-\operatorname{rank}D_1} and
+#{\beta_2=n_2-\operatorname{rank}D_2}. These elementary identities explain
+the evaluator's target and remain withheld as explicit answers where
+rediscovery is being measured. They are not new mathematical results.}
+
+\p{Allowed changes include invertible changes of basis #{P_i} in each
+space. They replace the matrices by}
+\eqnotag{
+  D'_1=P_0D_1P_1^{-1},\qquad
+  D'_2=P_1D_2P_2^{-1}.
+}
+\p{The product remains zero and the ranks remain unchanged. Another allowed
+change adjoins or removes a direct summand consisting of an identity map
+between two adjacent one-dimensional spaces, with zero maps elsewhere.
+That summand has zero homology in every degree. Direct sums add dimensions
+of homology, so these moves preserve all three #{\beta_i}. A candidate
+invariant can be challenged with new valid objects, basis changes and
+such elementary additions.}
+
+\p{A target asks whether two presented objects are related by a sequence
+of these allowed moves. A positive certificate lists legal moves and their
+exact matrices, including inverses for basis changes and the displayed
+summand for a removal. A negative certificate supplies unequal homology
+dimensions with checked rank witnesses. A rank witness can give invertible
+row and column transformations, their inverses and a diagonal normal form
+with an identity block and zeros elsewhere; the checker verifies these
+matrix identities and counts the block size. Agreement of a proposed invariant
+on a few examples is insufficient, and equality of the dimensions alone
+is not accepted as a positive certificate. The agent must construct the
+required transformation or another certificate justified by the fixed
+mathematical checker.}
+
+\p{A concrete sampler first draws uniformly from the finite set of
+nonnegative integer tuples #{(h_0,h_1,h_2,r_1,r_2)} satisfying the declared
+dimension cap, where}
+\eqnotag{
+ n_0=h_0+r_1,\quad n_1=h_1+r_1+r_2,\quad n_2=h_2+r_2.
+}
+\p{It builds a direct sum of zero-differential spaces of dimensions
+#{h_i} in degree #{i}, #{r_1} identity pairs in degrees one and zero,
+and #{r_2} identity pairs in degrees two and one. Independently sampled
+invertible binary basis matrices scramble this presentation; uniform
+sampling by rejection from all binary square matrices is one exact choice.
+The resulting #{\beta_i=h_i} are evaluator facts, not additional observations
+supplied to either agent. The distribution and sampling algorithm themselves
+are public, so reconstructing this decomposition is an admitted strategy.}
+
+\p{Positive instances apply a sampled legal move sequence to an object,
+retaining that sequence privately. At each step the sampler chooses
+uniformly among the declared finite encodings of dimension-bounded legal
+moves; the identity move permits padding to the specified length. Negative
+instances draw two canonical tuples with different homology vectors and
+randomize their presentations independently. Their dimensions are matched
+where the chosen profile permits, and results are also stratified by
+dimension differences to detect easy size cues. Retained rank witnesses
+certify the labels. The mixture, move count, dimension profile and
+certificate limits are fixed before final seeds are sampled.}
+
+\p{A single middle invariant is not complete even for this family.
+Objects concentrated in degree zero can have identical #{\beta_1=0}
+and different #{\beta_0}, and hence cannot be related by the allowed moves.
+This provides a concrete counterexample to premature abstraction. A learner
+may retain the whole homology vector, refine its proposal or use direct
+algebraic reasoning; successful certification, rather than one preferred
+formula, determines the outcome.}
+
+\p{This initial family has an efficient classical alternative. Gaussian
+elimination computes bases for cycles and boundaries and decomposes a
+finite complex over a field into homology summands and adjacent identity
+summands. It therefore supplies both the invariants and constructive
+transformations when appropriate. Its arithmetic and certificate costs
+must be measured as an admitted baseline. The setting can reveal how an
+agent develops and transfers a method, but cannot support a claim that
+all autonomous methods face a prohibitive search barrier merely because
+one language model initially fails it.}

--- a/trees/ftip-00NT.tree
+++ b/trees/ftip-00NT.tree
@@ -1,0 +1,78 @@
+\import{macros}
+\meta{agent-authored}{true}
+\tag{ftip}
+\title{Developing a method and teaching a recipient}
+\p{The finite family in \ref{ftip-00NS} permits a complete account of what
+a contributor learns and what a recipient acquires. Development takes
+place on earlier instances with independently sampled seeds. The final
+instance distribution, allowed observations and resource caps are specified
+before development; target instances and their certificates remain
+unrevealed. Broad mathematical preparation is disclosed separately from
+work performed during this experiment.}
+
+\p{An autonomous research process alternates candidate generation,
+experiments and proof attempts. It can propose expressions involving the
+available matrix features, search for transformations, generate helper
+lemmas or invent code. A skeptical process selects valid chains that
+challenge a proposal. Exact counterexamples return a failed instance;
+a finite test pass only advances a conjecture to a proof attempt.
+A general lemma enters the verified library only after justification in
+the fixed proof system. Special-case facts carry their assumptions and
+are not silently promoted to universal laws.}
+
+\p{The library-development loop follows the mechanism of
+[DreamProver](https://arxiv.org/html/2604.26311v1): use failed goals to
+identify helper results, group related discoveries, propose generalizations,
+verify them and discard redundant material. Suitable discoveries here
+include behavior under direct sums, invariance under changes of basis,
+and the need to account for all relevant degrees. Generalization may fail;
+its attempts, counterexamples and proof costs are part of development.
+No rule confines the process to discovering the evaluator's homology
+formula if another certified method is useful.}
+
+\p{One executable contributor begins with related finite linear-algebra
+episodes: solving systems, studying kernels and images, and comparing
+quotients of nested subspaces. A bounded learner selects useful exercises
+and retains procedures and justified claims. It subsequently encounters
+the chain-complex development family and can propose a connection,
+a proof-producing solver, or exercises that teach the connection to the
+recipient. Its prior lessons, their solutions and its development work
+are recorded. It does not receive final target answers, an ideal hint for
+each instance, or an uncharged completed representation.}
+
+\p{A second contribution type is a learned teaching curriculum. Following
+the progress-based idea in [SOAR](https://arxiv.org/html/2601.18778v3),
+a teacher chooses intermediate tasks and is evaluated by improvement of
+a provisional student on a separate development set. Teacher selection
+never uses final evaluation outcomes. Useful exercises need not solve the
+ultimate task directly. Producing and testing them, training provisional
+students and selecting a curriculum all consume resources. The recipient
+may receive incorrect suggestions, provided their verification and
+rejection are included rather than scored as free work.}
+
+\p{Separate recipient conditions identify what was acquired. A library
+condition retains checked statements, proofs and an executable retriever.
+A procedural condition retains a certified transformation algorithm.
+A parameter condition updates a declared trainable model using the
+permitted development material. A combined condition retains an explicitly
+listed combination. These are different systems, not interchangeable
+evidence that the same capability has entered model weights. Imported
+proof macros must expand or be justified under the unchanged checker.}
+
+\p{After acquisition, freeze the retained artifact, remove access to the
+contributor and reveal fresh instances. Measure accepted certificates
+under a common deployment budget. Test new random presentations within
+the development size range first, then a separately specified larger-size
+or composition regime. Success on one does not imply success on the other.
+A further assessment asks for general laws about direct sums and allowed
+transformations, with formal proof or independently assessed mathematical
+arguments as declared in advance. Benchmark prompts and theorem families
+are held out by mathematical content, not merely renamed variables.}
+
+\p{The contributor may itself be an agent, a human or another bounded
+learning process. What matters is its endowment, development, transmitted
+artifact and the recipient's resulting capability. Supplying a previously
+published human proof is a legitimate retrieval condition, but its effect
+does not by itself demonstrate that a newly developed contributor discovered
+or taught the method. This distinction permits successful autonomous
+research to revise the proposed complementarity claim.}


### PR DESCRIPTION
The mathematical-agent discussion needs a concrete family on which discovery, teaching and retained capability can be distinguished. This adds finite binary chain complexes, exact equivalence certificates, a public sampler, a counterexample to an incomplete invariant, and an admitted Gaussian-elimination baseline. It then specifies contributor preparation, reusable lemma development, curricula and frozen-recipient transfer.

This is a proposed adaptation of the cited research mechanisms. It reports no agent campaign or discovery-cost separation. Three addressed source files change; the six chapter roots remain stable.

Validation: source lint (22 checks), full build and 2,328 XML/HTML render pairs pass. A separate finite check agrees with the quotient formula on 15,744 small complexes. Fresh independent review passes at the exact final head after correcting a mobile equation overflow. NS, NT and their parent fit 390 pixels; desktop layout, the 290-page full PDF and seven-page focused PDF were inspected. Required exact-head build and lint CI pass. Production deployment and live payload verification follow the merge.
