### PR TITLE
Refresh FTIP opening, chapter organization and reading guide

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -14,68 +14,95 @@
 \author{utensil}
 \date{2026-08-27}
 
-\p{These are research notes for \strong{Formalized Theoretical Intelligence
-Potential} (FTIP). The project asks how much reliable capability a
-post-training procedure can obtain from a specified pretrained language model
-when its information, resources, and evaluation are fixed.}
+\p{\strong{Formalized Theoretical Intelligence Potential} (FTIP) studies
+how much reliable capability can be developed from a specified pretrained
+model through post-training and agent interaction, given its starting
+information, available feedback and resources. The system may search, use
+tools, retain experience, generate training problems and train successor
+models. Its capability is measured under an independently specified
+evaluation procedure and deployment budget.}
 
-\p{The question is comparative. It does not assign an intrinsic intelligence
-number to a model, and it does not assume that a larger training reward implies
-a broader capability. A claim must name the base artifact, training procedure,
-feedback source, resource budget, inference procedure, and independent
-evaluation law.}
+\p{A central question concerns [conceptual discovery across model
+generations](ftip-00MH). Can a model lineage affordably discover and acquire
+a reusable representation, method or connection through its own research
+and training? When can a contribution from a separately developed human or
+agent make the same capability cheaper to acquire? This comparison includes
+the cost of developing, communicating, checking and learning from the
+contribution. A claimed separation must also account for alternative
+autonomous routes, including internally generated curricula and changes to
+the search procedure.}
 
-\p{FTIP treats capability as a conditional question
-about behavior under a named intervention and evaluation law. Four parts of
-the setup can change independently: represented weights, optimizer and feedback
-protocol, inference harness and retained state, and the evaluation interface.
-A benchmark gain or successful rollout therefore witnesses behavior under its
-declared setup; it does not by itself establish a new latent capability or
-capability acquisition. A stronger claim requires an explicit intervention,
-invariant evaluation law, comparison controls, and a transfer argument. The
-sections below distinguish empirical observations, finite mathematical
-consequences, and open transfer questions.}
+\p{The analysis distinguishes changes to model parameters, optimizer and
+feedback, agent procedures and retained state, and the evaluation interface.
+These changes can interact: a learned library may improve search, and the
+resulting traces may train a successor model. [Discovery and acquired
+capability](ftip-00ML) are separate outcomes. Solving a current problem
+establishes discovery under that procedure; acquisition concerns the
+retained system's performance on fresh problems. Each comparison states
+whether that system consists of model weights, an agent with a library,
+or a specified combination.}
 
-\p{The analysis begins with text probabilities and decoder-only Transformer
-architecture, then introduces pretraining and the task--environment interface.
-Fine-tuning and instruction tuning receive separate sections. Preference
-modeling and reinforcement learning (RL) describe different parts of a training
-procedure; alignment training names a declared role. Concrete routes include
-reinforcement learning from human feedback (RLHF), Direct Preference
-Optimization (DPO), and reinforcement learning with verifiable rewards (RLVR).
-The final sections study costed evaluation, finite counterexamples, and finite
-mathematical consequences.}
+\p{Mathematical research provides tasks in which useful structure and
+correctness can be examined closely. [Problems beyond an agent's initial
+ability](ftip-00NQ) include controlled rediscovery and withheld research
+problems. They need not be new to the mathematical community. These settings
+serve the study of model capability, agents and post-training; an initial
+failed attempt alone establishes neither ignorance nor a capability ceiling.}
 
-\p{The RLVR route begins with DeepSeekMath
-\citef{shao2024deepseekmath} and DeepSeek-R1
-\citef{guo2025deepseek}. Decoupled Clip and Dynamic sAmpling Policy
-Optimization (DAPO) \citef{yu2025dapo} supplies later changes to sampling,
-clipping, and reward design.}
+\p{The notes combine published empirical observations, specified learning
+mechanisms, conditional mathematical results and proposed research settings.
+The [discovery-cost separation](ftip-00MN) remains a conjecture. Finite
+probability bounds and constructive examples establish only their stated
+claims; applying them to an evolving learning system requires justifying
+their assumptions for that system.}
 
 \section{How to read these notes}{
-\p{The motivating question is conditional: under a declared task, evaluation
-law, intervention, and scalar resource budget, what reliable capability can a
-specified model instance support, and which changes are attributable to the
-intervention? The note does not assign a context-free intelligence number.}
+\p{The six chapters connect the learning system to the evidence and
+mathematics needed to assess its capability:}
+\ol{
+  \li{[Foundations and interfaces](ftip-00J9) defines capability claims,
+  language models, pretraining, tasks and environments.}
+  \li{[Post-training, alignment, and feedback](ftip-00JA) develops
+  fine-tuning, preference learning, RLHF, DPO, RLVR and agentic training,
+  with concrete objectives, feedback mechanisms and update procedures.}
+  \li{[Evaluation, evidence, and finite limits](ftip-00JB) studies
+  discovery, feedback and the interpretation of measured gains. Its
+  conceptual-discovery section extends the comparison to complete model
+  lineages, developed contributors, representation learning, curricula
+  and mathematical research campaigns.}
+  \li{[Architecture-conditioned potential and computation](ftip-00JC)
+  examines how architecture, optimization and computation affect the
+  attainable capability and its cost.}
+  \li{[Harness state, failure modes, and reliability](ftip-00JD) studies
+  persistent agent state, recursive execution, replay, recovery and
+  reliability, including improvements possible with fixed model weights.}
+  \li{[Finite consequences and counterexamples](ftip-00JE) collects
+  mathematical results about discovery probability, feedback information
+  and execution, together with the restrictions on their interpretation.}
+}
 
-\p{Read Chapter 1 for the shared model, task, environment, intervention, and
-evaluation interfaces. Chapter 2 fixes the training, post-training,
-alignment, preference, and feedback routes. Chapter 3 develops identification,
-finite limits, and evidence transport. Chapter 5 treats retained state,
-replay, lifecycle, recovery, and reliability. Chapter 6 summarizes finite
-probability results, counterexamples, and the assumptions on which they depend.}
+\p{For the central research question, begin with [research question and
+scope](ftip-0002), then read [conceptual discovery across model
+generations](ftip-00MH). That section proceeds from the complete lineage
+and acquisition criterion to contributions, developmental experience,
+learned representations, future task demands and a concrete research
+setting. Its obstruction and simulation arguments explain what a
+separation proof would need to establish and what could defeat it.}
 
-\p{Chapter 4 is an optional refinement. Enter it only when a claim names an
-architecture or a computation method: it starts from the decoder-only
-autoregressive reference, then adds only the architecture, optimizer, and
-systems fields needed by the comparison. Its comparisons among model instances
-and cost frontiers are interpreted through the evaluation and reliability rules
-from Chapters 3 and 5; they do not replace the architecture-neutral route.}
+\p{For the learning mechanisms, read the foundations and post-training
+chapters, then the harness chapter alongside the conceptual-discovery
+section. Track both parameter updates and retained agent artifacts when
+following an improvement across generations. Enter the architecture
+chapter when a claim depends on a particular model architecture,
+optimization method or computation strategy.}
 
-\p{A practical reading order is therefore Chapters 1--3, then Chapter 5, and
-finally Chapter 6. For an architecture comparison, insert Chapter 4 between
-Chapters 1 and 3 and carry its declared budgets, task families, and evaluation
-assumptions into the later comparison.}
+\p{For a claimed capability gain or limit, use the evaluation chapter and
+finite consequences to identify the starting system, admitted procedures,
+feedback, task law and resource bounds. Training, search, contributor
+development and deployment costs have distinct roles; quantities with
+different units require an explicit conversion or a comparison that keeps
+those units separate. Follow the result's stated assumptions before
+applying it to another model or agent.}
 }
 
 \transclude{ftip-00J9}

--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -56,9 +56,47 @@ probability bounds and constructive examples establish only their stated
 claims; applying them to an evolving learning system requires justifying
 their assumptions for that system.}
 
-\section{How to read these notes}{
+\section{\title{How to read these notes}}{
 \p{The six chapters connect the learning system to the evidence and
-mathematics needed to assess its capability:}
+mathematics needed to assess its capability. The diagram shows their main
+logical relationships. Arrows indicate that a chapter supplies assumptions
+or mechanisms for the analysis below it; they do not prescribe a mandatory
+reading order.}
+
+\tikzfig{\begin{tikzpicture}[
+  box/.style={draw,rounded corners=2pt,align=center,font=\small,
+    text width=27mm,minimum height=17mm,inner sep=4pt},
+  wide/.style={box,text width=46mm},
+  flow/.style={-{Stealth[length=2mm]},semithick}
+]
+\node[wide] (foundation) at (0,0)
+  {1. Foundations\\models, tasks and interfaces};
+\node[box] (training) at (-3.2,-2.4)
+  {2. Post-training\\objectives and feedback};
+\node[box] (architecture) at (0,-2.4)
+  {4. Architecture\\computation and cost};
+\node[box] (harness) at (3.2,-2.4)
+  {5. Agent harness\\state and reliability};
+\node[wide,text width=56mm] (evaluation) at (0,-5)
+  {3. Evaluation and finite limits\\including model lineages and conceptual discovery};
+\node[wide] (consequences) at (0,-7.3)
+  {6. Finite consequences\\and counterexamples};
+\draw[flow] (foundation.south) -- (architecture.north);
+\draw[flow] (foundation.south) -- (0,-1.2) -| (training.north);
+\draw[flow] (foundation.south) -- (0,-1.2) -| (harness.north);
+\draw[flow] (training.south) -- (-3.2,-3.6)
+  -| ([xshift=-20mm]evaluation.north);
+\draw[flow] (architecture.south) -- (evaluation.north);
+\draw[flow] (harness.south) -- (3.2,-3.6)
+  -| ([xshift=20mm]evaluation.north);
+\draw[flow] (evaluation.south) -- (consequences.north);
+\end{tikzpicture}}
+
+\p{Post-training, architecture and harness state are complementary views of
+the learning system. Their interactions matter for the evaluation of an
+evolving lineage. The finite consequences make particular assumptions and
+counterexamples explicit; they do not establish the general
+conceptual-discovery conjecture.}
 \ol{
   \li{[Foundations and interfaces](ftip-00J9) defines capability claims,
   language models, pretraining, tasks and environments.}

--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -56,96 +56,15 @@ probability bounds and constructive examples establish only their stated
 claims; applying them to an evolving learning system requires justifying
 their assumptions for that system.}
 
-\section{\title{How to read these notes}}{
-\p{The six chapters connect the learning system to the evidence and
-mathematics needed to assess its capability. The diagram shows their main
-logical relationships. Arrows indicate that a chapter supplies assumptions
-or mechanisms for the analysis below it; they do not prescribe a mandatory
-reading order.}
-
-\tikzfig{\begin{tikzpicture}[
-  box/.style={draw,rounded corners=2pt,align=center,font=\small,
-    text width=27mm,minimum height=17mm,inner sep=4pt},
-  wide/.style={box,text width=46mm},
-  flow/.style={-{Stealth[length=2mm]},semithick}
-]
-\node[wide] (foundation) at (0,0)
-  {1. Foundations\\models, tasks and interfaces};
-\node[box] (training) at (-3.2,-2.4)
-  {2. Post-training\\objectives and feedback};
-\node[box] (architecture) at (0,-2.4)
-  {4. Architecture\\computation and cost};
-\node[box] (harness) at (3.2,-2.4)
-  {5. Agent harness\\state and reliability};
-\node[wide,text width=56mm] (evaluation) at (0,-5)
-  {3. Evaluation and finite limits\\including model lineages and conceptual discovery};
-\node[wide] (consequences) at (0,-7.3)
-  {6. Finite consequences\\and counterexamples};
-\draw[flow] (foundation.south) -- (architecture.north);
-\draw[flow] (foundation.south) -- (0,-1.2) -| (training.north);
-\draw[flow] (foundation.south) -- (0,-1.2) -| (harness.north);
-\draw[flow] (training.south) -- (-3.2,-3.6)
-  -| ([xshift=-20mm]evaluation.north);
-\draw[flow] (architecture.south) -- (evaluation.north);
-\draw[flow] (harness.south) -- (3.2,-3.6)
-  -| ([xshift=20mm]evaluation.north);
-\draw[flow] (evaluation.south) -- (consequences.north);
-\end{tikzpicture}}
-
-\p{Post-training, architecture and harness state are complementary views of
-the learning system. Their interactions matter for the evaluation of an
-evolving lineage. The finite consequences make particular assumptions and
-counterexamples explicit; they do not establish the general
-conceptual-discovery conjecture.}
-\ol{
-  \li{[Foundations and interfaces](ftip-00J9) defines capability claims,
-  language models, pretraining, tasks and environments.}
-  \li{[Post-training, alignment, and feedback](ftip-00JA) develops
-  fine-tuning, preference learning, RLHF, DPO, RLVR and agentic training,
-  with concrete objectives, feedback mechanisms and update procedures.}
-  \li{[Evaluation, evidence, and finite limits](ftip-00JB) studies
-  discovery, feedback and the interpretation of measured gains. Its
-  conceptual-discovery section extends the comparison to complete model
-  lineages, developed contributors, representation learning, curricula
-  and mathematical research campaigns.}
-  \li{[Architecture-conditioned potential and computation](ftip-00JC)
-  examines how architecture, optimization and computation affect the
-  attainable capability and its cost.}
-  \li{[Harness state, failure modes, and reliability](ftip-00JD) studies
-  persistent agent state, recursive execution, replay, recovery and
-  reliability, including improvements possible with fixed model weights.}
-  \li{[Finite consequences and counterexamples](ftip-00JE) collects
-  mathematical results about discovery probability, feedback information
-  and execution, together with the restrictions on their interpretation.}
-}
-
-\p{For the central research question, begin with [research question and
-scope](ftip-0002), then read [conceptual discovery across model
-generations](ftip-00MH). That section proceeds from the complete lineage
-and acquisition criterion to contributions, developmental experience,
-learned representations, future task demands and a concrete research
-setting. Its obstruction and simulation arguments explain what a
-separation proof would need to establish and what could defeat it.}
-
-\p{For the learning mechanisms, read the foundations and post-training
-chapters, then the harness chapter alongside the conceptual-discovery
-section. Track both parameter updates and retained agent artifacts when
-following an improvement across generations. Enter the architecture
-chapter when a claim depends on a particular model architecture,
-optimization method or computation strategy.}
-
-\p{For a claimed capability gain or limit, use the evaluation chapter and
-finite consequences to identify the starting system, admitted procedures,
-feedback, task law and resource bounds. Training, search, contributor
-development and deployment costs have distinct roles; quantities with
-different units require an explicit conversion or a comparison that keeps
-those units separate. Follow the result's stated assumptions before
-applying it to another model or agent.}
+\scope{
+  \put\transclude/toc{false}
+  \put\transclude/numbered{false}
+  \transclude{ftip-00NW}
 }
 
 \transclude{ftip-00J9}
 \transclude{ftip-00JA}
+\transclude{ftip-00JD}
 \transclude{ftip-00JB}
 \transclude{ftip-00JC}
-\transclude{ftip-00JD}
-\transclude{ftip-00JE}
+\transclude{ftip-00MH}

--- a/trees/ftip-0002.tree
+++ b/trees/ftip-0002.tree
@@ -5,18 +5,46 @@
 \tag{ftip}
 \tag{notes}
 
-\p{Post-training changes a trained language model by exposing it to new
-examples, comparisons, rewards, or interaction. The question of this note is
-how much independently evaluated capability a specified post-training
-procedure can produce from a specified starting model under stated resource
-bounds.}
+\p{The question is how much independently evaluated capability a specified
+learning system can develop from its starting model, information and tools
+under stated resource bounds. Post-training changes model parameters using
+examples, comparisons, rewards or interaction. An agent also changes its
+contexts, search procedures and retained experience. A complete comparison
+allows these processes to interact across successive learned artifacts.}
 
-\p{The question is comparative. A score increase can come from selecting a
-behaviour the starting model already produced, acquiring a behaviour that the
-declared starting procedure rarely produced, spending more computation at
-evaluation time, or exploiting the evaluator. The following conventions make
-these alternatives explicit before model architecture or training objectives
-are specified.}
+\p{The [conceptual-discovery conjecture](ftip-00MN) asks whether some
+reusable mathematical capability is too costly for a specified autonomous
+lineage to acquire, yet becomes affordable with a contribution developed
+outside that lineage. The contribution may be a representation, lemma,
+connection, procedure or curriculum. Both its production and the recipient's
+learning must be accounted for. Different developmental backgrounds are
+permitted when disclosed; secret evaluation answers are not conceptual
+contributions. The mathematical target and correctness criterion stay fixed.}
+
+\p{This comparison permits the autonomous lineage to learn new
+representations, generate auxiliary tasks, use failed attempts and improve
+its own procedures. A plateau in one training recipe is therefore evidence
+about that recipe, not a bound over the complete lineage. Conversely, an
+affordable autonomous solution can defeat a proposed separation for the
+specified setting. [Simulation](ftip-00MX) and
+[enumeration](ftip-00MQ) provide further
+checks on claims about external advantage and permanent barriers.}
+
+\p{The initial distinctions below remain useful within that broader
+question. [Elicitation](ftip-0005) concerns improved access to behaviour
+already observable under the declared starting procedure.
+[Acquisition](ftip-0007) requires improvement on an independent transfer
+evaluation. For an agent or a lineage, specify the retained artifact before
+that evaluation: weights, a library, executable procedures, or their
+combination. A result retained in a library and one learned into model
+parameters establish different acquisition claims.}
+
+\p{A score increase can also arise from greater deployment computation or
+exploitation of the evaluator. The model, procedure, evaluation and resource
+conventions make these possibilities explicit. The later
+[research-campaign comparison](ftip-00NU) applies them to discovery and
+teaching on concrete mathematical tasks. It is a proposed experiment;
+the general discovery-cost separation remains open.}
 
 \transclude{ftip-0003}
 \transclude{ftip-0004}

--- a/trees/ftip-0003.tree
+++ b/trees/ftip-0003.tree
@@ -9,9 +9,12 @@
 \p{A \newvocab{capability claim} in this note names four objects:}
 
 \ol{
-  \li{a starting model artifact #{M_0};}
-  \li{a procedure #{A} that may train or query it;}
-  \li{an evaluation rule #{E}; and}
+  \li{a starting model artifact #{M_0}, with its accompanying information,
+  libraries, tools and initially available controllers disclosed;}
+  \li{a procedure #{A} that may query models, interact, retain experience
+  and train successor artifacts, with its feedback sources specified;}
+  \li{an evaluation rule #{E}, including the task law, retained artifact
+  and deployment procedure being evaluated; and}
   \li{a resource bound #{b}.}
 }
 
@@ -19,9 +22,18 @@
 judging the result with #{E} while respecting #{b}. It is not a claim about an
 unbounded or unspecified model.}
 
+\p{For a comparison across generations, use the
+[complete lineage specification](ftip-00MI) to make these initial resources
+and permitted operations explicit. Newly generated controllers and learned
+artifacts belong to the charged process. An externally supplied contribution
+has a declared producer and acquisition procedure; it is not silently added
+to the starting model's resources.}
+
 \p{The bound #{b} may contain several coordinates, such as training tokens,
 rollouts, accelerator work, wall-clock time, tool calls, or evaluation-time
-samples. Coordinates with different units remain separate unless a declared
+samples. Distinguish the complete development budget from the deployment
+budget used to compare frozen artifacts on fresh problems. Coordinates with
+different units remain separate unless a declared
 cost model converts them to a common unit.}
 
 \p{This convention follows the experimental separation between training and

--- a/trees/ftip-00J9.tree
+++ b/trees/ftip-00J9.tree
@@ -9,9 +9,14 @@
 evaluation interfaces. These determine the possible interactions and the
 quantities by which their outcomes are compared.}
 
+\p{The interfaces here require a token probability law and a specified
+starting artifact, without fixing the neural computation that implements
+them. The [decoder-only Transformer](ftip-000K) appears with the later
+architecture analysis. Pretraining, tasks and interaction provide the shared
+starting point for both parameter updates and agent adaptation.}
+
 \transclude{ftip-0002}
 \transclude{ftip-0009}
-\transclude{ftip-000K}
 \transclude{ftip-0014}
 \transclude{ftip-001M}
 \transclude{ftip-001W}

--- a/trees/ftip-00JA.tree
+++ b/trees/ftip-00JA.tree
@@ -9,6 +9,12 @@
 updates they permit. Demonstrations, preferences, rewards, verifiers, and
 environment interactions impose different conditions on the resulting policy.}
 
+\p{The chapter moves from demonstrations and preferences to reward-based
+updates, then to training through tool interaction and replay. The
+[agent-state analysis](ftip-00JD) complements these parameter-changing
+procedures by examining the contexts, memories and computation an agent
+retains around its models.}
+
 \transclude{ftip-006P}
 \transclude{ftip-0029}
 \transclude{ftip-002J}

--- a/trees/ftip-00JB.tree
+++ b/trees/ftip-00JB.tree
@@ -5,15 +5,24 @@
 \tag{ftip}
 \tag{chapter}
 
-\p{A training score does not determine an independently evaluated capability.
-Discovery probabilities, support constraints, proxy error, and information
-available through feedback each restrict what a post-training comparison can
-establish.}
+\p{The training and agent mechanisms described earlier produce an artifact
+whose capability must be evaluated under a declared task law, inference
+procedure and resource account. This chapter fixes that comparison, studies
+what survives a change of evaluation, and examines discovery probabilities,
+support, proxy error and the information available through feedback.}
+
+\p{Finite results and counterexamples establish consequences under specific
+probability laws and computational assumptions. They provide tools for the
+[model-lineage question](ftip-00MH), where their assumptions must cover an
+evolving research and training process. The
+[architecture analysis](ftip-00JC) uses the same evaluation framework for
+comparisons that depend on a model implementation or optimizer.}
 
 \transclude{ftip-005C}
+\transclude{ftip-00F9}
 \transclude{ftip-005T}
 \transclude{ftip-0075}
 \transclude{ftip-008E}
 \transclude{ftip-009M}
 
-\transclude{ftip-00MH}
+\transclude{ftip-00JE}

--- a/trees/ftip-00JC.tree
+++ b/trees/ftip-00JC.tree
@@ -5,12 +5,19 @@
 \tag{ftip}
 \tag{chapter}
 
-\p{Capability and cost can depend on architecture, optimization geometry,
-computation, and retained context. Readers whose
-question does not name an architecture may omit this chapter. The reference
-autoregressive Transformer formulation in \ref{ftip-000K} is the comparison
-baseline; each comparison depends on the variables specified in its assumptions.}
+\p{This chapter refines the [evaluation framework](ftip-005C) for claims
+that depend on architecture, optimization geometry or a systems
+implementation. It begins with the decoder-only Transformer, then introduces
+architecture-indexed frontiers and matched-compute comparisons, and studies
+how an optimizer can depend on the representation of its parameters.}
 
+\p{The reference architecture specifies how token probabilities are
+computed; it does not replace the shared task and evaluation interfaces.
+Readers whose question does not depend on an architecture or optimizer can
+continue directly to [conceptual discovery](ftip-00MH). Changes to retained
+context and rollout computation are treated with
+[agent state](ftip-00DA).}
+
+\transclude{ftip-000K}
 \transclude{ftip-00JF}
 \transclude{ftip-00AU}
-\transclude{ftip-00DA}

--- a/trees/ftip-00JD.tree
+++ b/trees/ftip-00JD.tree
@@ -1,17 +1,23 @@
 \import{macros}
 \meta{agent-authored}{true}
 
-\title{Harness state, failure modes, and reliability}
+\title{Agent state, computation, and reliability}
 \tag{ftip}
 \tag{chapter}
 
-\p{An agent's behavior can change through persistent state, recursive
-execution, and retained evidence even when its weights are fixed. Replay,
-evaluation transport, and independent audit constrain what these changes
-establish about reliability.}
+\p{An agent's behavior can change through persistent state, retained
+context and recursive execution even when its model weights are fixed.
+These mechanisms complement [post-training](ftip-00JA), and their costs and
+retained artifacts belong to the same capability comparison.}
+
+\p{The chapter begins with persistent state and lifecycle accounting,
+then examines dynamic computation and recursive harnesses. Failure modes
+and reliability protocols explain when an apparent gain can be trusted.
+[Evaluation transport](ftip-00F9) is developed with the independent
+evaluation framework that follows.}
 
 \transclude{ftip-00C2}
-\transclude{ftip-00DX}
+\transclude{ftip-00DA}
 \transclude{ftip-00EH}
-\transclude{ftip-00F9}
+\transclude{ftip-00DX}
 \transclude{ftip-00GR}

--- a/trees/ftip-00JE.tree
+++ b/trees/ftip-00JE.tree
@@ -3,10 +3,14 @@
 
 \title{Finite consequences and counterexamples}
 \tag{ftip}
-\tag{chapter}
 
 \p{Finite sampling, reward information, and deterministic execution give
 conditional conclusions about post-training. Their counterexamples show why
 the task law, feasible set, and available information cannot be omitted.}
+
+\p{This synthesis brings together the finite results used in the evaluation
+analysis. The [conceptual-discovery chapter](ftip-00MH) asks whether such
+arguments can constrain a complete learning lineage, including changes to
+representations, curricula and research procedures.}
 
 \transclude{ftip-00I1}

--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -2,6 +2,12 @@
 \meta{agent-authored}{true}
 \title{Conceptual discovery across model generations}
 \tag{ftip}
+\tag{chapter}
+
+\p{The preceding chapters specify the model and learning mechanisms,
+retained agent state, evaluation and costs, with architecture-dependent
+refinements when needed. This chapter combines them in a question about
+capability growth across successive learned artifacts.}
 
 \p{A mathematical breakthrough may require a new representation, a useful
 invariant, or a connection to another domain. The question is whether a

--- a/trees/ftip-00NW.tree
+++ b/trees/ftip-00NW.tree
@@ -10,7 +10,7 @@ inputs to the next analysis. The dashed branch adds architecture-specific
 detail when the question requires it. These are dependencies between subjects,
 rather than a requirement to read every chapter in sequence.}
 
-\tikzfig{\begin{tikzpicture}[
+\texfig{\begin{tikzpicture}[
   box/.style={draw,rounded corners=2pt,align=center,font=\small,
     text width=30mm,minimum height=17mm,inner sep=4pt},
   wide/.style={box,text width=47mm},

--- a/trees/ftip-00NW.tree
+++ b/trees/ftip-00NW.tree
@@ -1,0 +1,97 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{How to read these notes}
+\tag{ftip}
+
+\p{The note develops the learning system, the evidence used to evaluate it,
+and the question of capability growth across generations. The diagram shows
+the main logical relationships among its six chapters. Solid arrows indicate
+inputs to the next analysis. The dashed branch adds architecture-specific
+detail when the question requires it. These are dependencies between subjects,
+rather than a requirement to read every chapter in sequence.}
+
+\tikzfig{\begin{tikzpicture}[
+  box/.style={draw,rounded corners=2pt,align=center,font=\small,
+    text width=30mm,minimum height=17mm,inner sep=4pt},
+  wide/.style={box,text width=47mm},
+  flow/.style={-{Stealth[length=2mm]},semithick}
+]
+\node[wide] (foundation) at (0,0)
+  {1. Foundations\\models, tasks and interfaces};
+\node[box] (training) at (-1.9,-2.2)
+  {2. Post-training\\objectives and feedback};
+\node[box] (harness) at (1.9,-2.2)
+  {3. Agent state\\computation and reliability};
+\node[wide,text width=40mm] (evaluation) at (-1.2,-4.6)
+  {4. Evaluation\\evidence and finite limits};
+\node[box] (architecture) at (2.6,-6.1)
+  {5. Architecture\\optimization and capability};
+\node[wide,text width=44mm] (lineage) at (-1.2,-8)
+  {6. Conceptual discovery\\capability across model generations};
+\draw[flow] (foundation.south) -- (0,-1.1) -| (training.north);
+\draw[flow] (foundation.south) -- (0,-1.1) -| (harness.north);
+\draw[flow] (training.south) -- (-1.9,-3.5)
+  -| ([xshift=-12mm]evaluation.north);
+\draw[flow] (harness.south) -- (1.9,-3.5)
+  -| ([xshift=12mm]evaluation.north);
+\draw[flow] (evaluation.south) -- (lineage.north);
+\draw[flow,dashed] (evaluation.east) -| (architecture.north);
+\draw[flow,dashed] (architecture.south) |- (lineage.east);
+\end{tikzpicture}}
+
+\p{Post-training and agent state are complementary parts of the system:
+one changes learned parameters, while the other manages interaction,
+computation and retained artifacts. Evaluation places their results under a
+common task law and cost account. The architecture branch refines that
+comparison for particular model implementations and optimizers. The final
+chapter asks what these systems can discover and acquire across generations.}
+
+\ol{
+  \li{[Foundations and interfaces](ftip-00J9) introduces capability claims,
+  token probabilities, pretraining, tasks and environments. These interfaces
+  allow the later analysis to specify a model without requiring a particular
+  neural architecture.}
+  \li{[Post-training, alignment, and feedback](ftip-00JA) develops
+  fine-tuning, preference learning, RLHF, DPO, RLVR and agentic training,
+  with concrete objectives, feedback mechanisms and update procedures.}
+  \li{[Agent state, computation, and reliability](ftip-00JD) studies
+  persistent state, retained context, recursive execution, failure modes and
+  reliability. It separates changes to agent behavior from changes to model
+  weights while examining their interaction.}
+  \li{[Evaluation, evidence, and finite limits](ftip-00JB) fixes the
+  comparison law and costs, studies transport to other evaluations, and
+  develops finite results about discovery, support, feedback and proxy error.
+  Its closing synthesis collects the consequences and counterexamples.}
+  \li{[Architecture-conditioned potential and computation](ftip-00JC)
+  begins with a decoder-only Transformer, then studies architecture,
+  optimization geometry and matched-compute capability comparisons. This
+  branch uses the evaluation framework to make implementation-specific
+  claims.}
+  \li{[Conceptual discovery across model generations](ftip-00MH) brings
+  the model, training, agent and evaluation machinery together. It develops
+  the complete lineage, independently developed contributions,
+  representation learning, curricula and mathematical research settings,
+  alongside the conjecture and arguments that could establish or defeat it.}
+}
+
+\p{For an overview of the research question, read [research question and
+scope](ftip-0002), then the opening of the conceptual-discovery chapter.
+Follow its [complete lineage](ftip-00MI), [acquisition criterion](ftip-00ML)
+and [conjecture](ftip-00MN) for the comparison being proposed. The subsequent
+sections explain contributor development, learned representations, future
+task demands and a concrete research setting.}
+
+\p{For the mechanisms, read the foundations, post-training and agent
+chapters, followed by evaluation. Then continue to conceptual discovery.
+Insert the architecture chapter before that final step when the claim
+depends on a particular model implementation or optimizer. Track both
+parameter updates and retained agent artifacts when following an improvement
+across generations.}
+
+\p{For a claimed capability gain or limit, begin with
+[independent evaluation and post-training potential](ftip-005C), then follow
+the relevant finite result or counterexample. Training, search, contributor
+development and deployment costs have distinct roles; quantities with
+different units require an explicit conversion or a comparison that keeps
+those units separate. The general discovery-cost separation remains a
+conjecture, and each finite result depends on its stated assumptions.}

--- a/trees/ftip-00NW.tree
+++ b/trees/ftip-00NW.tree
@@ -24,9 +24,9 @@ rather than a requirement to read every chapter in sequence.}
   {3. Agent state\\computation and reliability};
 \node[wide,text width=40mm] (evaluation) at (-1.2,-4.6)
   {4. Evaluation\\evidence and finite limits};
-\node[box] (architecture) at (2.6,-6.1)
+\node[box] (architecture) at (2.6,-6.4)
   {5. Architecture\\optimization and capability};
-\node[wide,text width=44mm] (lineage) at (-1.2,-8)
+\node[wide,text width=44mm] (lineage) at (-1.2,-8.5)
   {6. Conceptual discovery\\capability across model generations};
 \draw[flow] (foundation.south) -- (0,-1.1) -| (training.north);
 \draw[flow] (foundation.south) -- (0,-1.1) -| (harness.north);


### PR DESCRIPTION
FTIP's opening and chapter order still reflected the earlier post-training note. The complete lineage and conceptual-discovery framework was buried in the evaluation chapter, while some evaluation and agent mechanisms appeared in other chapters.

This refreshes the introduction and scope, adds a branching chapter diagram, and reorganizes the existing material into foundations, post-training, agents, evaluation, optional architecture detail, and conceptual discovery. Decoder internals move to architecture, retained-context computation to agents, evaluation transport to evaluation, and the finite-results synthesis joins the evaluation chapter. The guide explains the resulting dependencies and reading routes.

Existing tree addresses and all content occurrences are preserved; the guide receives its own stable address. Chapter introductions describe their revised roles. This changes the exposition and organization without adding a model experiment or claiming a new mathematical result.

Validation: source/prose lint, the complete site build, and rendered-output checks pass (2,331 page pairs). Stable-address/reachability checks preserve every occurrence of the 818 previously reachable FTIP trees. Independent exact-head source, desktop/mobile, and full 296-page PDF review passes. The root title, unnumbered reading guide, six-chapter numbering, and new diagram were inspected in the rendered output.
