### PR TITLE
docs(ftip): balance the opening and clarify the anonymous exchange

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -15,46 +15,45 @@
 \date{2026-08-27}
 
 \p{\strong{Formalized Theoretical Intelligence Potential} (FTIP) studies
-how much reliable capability can be developed from a specified pretrained
-model through post-training and agent interaction, given its starting
-information, available feedback and resources. The system may search, use
-tools, retain experience, generate training problems and train successor
-models. Its capability is measured under an independently specified
-evaluation procedure and deployment budget.}
+how much reliable capability post-training and agent procedures can obtain
+from a specified pretrained model, and how that capability depends on
+information, feedback, computation and evaluation. The question is
+comparative: what improves, through which mechanism, at what cost, and on
+which tasks? It concerns behavior under specified conditions, rather than
+an intrinsic intelligence number assigned to a model.}
 
-\p{A central question concerns [conceptual discovery across model
-generations](ftip-00MH). Can a model lineage affordably discover and acquire
-a reusable representation, method or connection through its own research
-and training? When can a contribution from a separately developed human or
-agent make the same capability cheaper to acquire? This comparison includes
-the cost of developing, communicating, checking and learning from the
-contribution. A claimed separation must also account for alternative
-autonomous routes, including internally generated curricula and changes to
-the search procedure.}
+\p{[Post-training](ftip-00JA) studies how demonstrations, preferences,
+rewards and interaction change a model's policy. Fine-tuning, direct
+preference optimization, and reinforcement learning with human or verifiable
+feedback differ in their objectives, feedback and update procedures.
+[Agent systems](ftip-00JD) add another source of change: tool use, search,
+persistent state and retained context can alter behavior even with fixed
+model weights. Their computation, failure modes and reliability are part of
+the capability being studied.}
 
-\p{The analysis distinguishes changes to model parameters, optimizer and
-feedback, agent procedures and retained state, and the evaluation interface.
-These changes can interact: a learned library may improve search, and the
-resulting traces may train a successor model. [Discovery and acquired
-capability](ftip-00ML) are separate outcomes. Solving a current problem
-establishes discovery under that procedure; acquisition concerns the
-retained system's performance on fresh problems. Each comparison states
-whether that system consists of model weights, an agent with a library,
-or a specified combination.}
+\p{[Evaluation and finite limits](ftip-00JB) ask which improvements survive
+independent testing, what transfers to other task laws, and what follows
+from assumptions about sampling, support, feedback and proxy error.
+[Architecture and optimization](ftip-00JC) ask how the model's computation,
+parameterization and optimizer affect achievable capability and resource
+tradeoffs. Matched comparisons connect these questions without identifying
+a higher training reward, a successful rollout and a transferable capability
+as the same outcome.}
 
-\p{Mathematical research provides tasks in which useful structure and
-correctness can be examined closely. [Problems beyond an agent's initial
-ability](ftip-00NQ) include controlled rediscovery and withheld research
-problems. They need not be new to the mathematical community. These settings
-serve the study of model capability, agents and post-training; an initial
-failed attempt alone establishes neither ignorance nor a capability ceiling.}
+\p{[Conceptual discovery across generations](ftip-00MH) extends the study
+to successive learned artifacts, reusable representations, curricula and
+contributions from independently developed researchers. It asks when a
+system can discover a method and acquire the ability to use it on fresh
+problems, with development and learning costs included. Mathematical
+research supplies concrete settings for that question; the proposed
+[discovery-cost separation](ftip-00MN) remains open.}
 
-\p{The notes combine published empirical observations, specified learning
-mechanisms, conditional mathematical results and proposed research settings.
-The [discovery-cost separation](ftip-00MN) remains a conjecture. Finite
-probability bounds and constructive examples establish only their stated
-claims; applying them to an evolving learning system requires justifying
-their assumptions for that system.}
+\p{The shared [model, task and evaluation interfaces](ftip-00J9) support
+these different lines of inquiry. The notes combine published empirical
+observations, specified mechanisms, finite mathematical results and open
+research questions. Each result has its own assumptions and scope; a
+capability claim depends on the starting artifact, the intervention,
+independent evaluation and resource bounds.}
 
 \scope{
   \put\transclude/toc{false}

--- a/trees/ftip-0002.tree
+++ b/trees/ftip-0002.tree
@@ -39,8 +39,9 @@ procedure.}
 generations](ftip-00MH). An autonomous lineage may change its representations,
 curricula and research procedures; an independently developed contribution
 may change what it can affordably acquire. That comparison includes both
-development and recipient learning. The [mathematical research
-settings](ftip-00NQ) study this direction within the broader capability
+development and learning by the system receiving the contribution. The
+[mathematical research settings](ftip-00NQ) study this direction within the
+broader capability
 question. A plateau in one recipe is evidence about that recipe, and the
 general discovery-cost separation remains a conjecture.}
 

--- a/trees/ftip-0002.tree
+++ b/trees/ftip-0002.tree
@@ -8,43 +8,41 @@
 \p{The question is how much independently evaluated capability a specified
 learning system can develop from its starting model, information and tools
 under stated resource bounds. Post-training changes model parameters using
-examples, comparisons, rewards or interaction. An agent also changes its
-contexts, search procedures and retained experience. A complete comparison
-allows these processes to interact across successive learned artifacts.}
+examples, comparisons, rewards or interaction. Agent procedures also change
+contexts, search and retained experience. Their effects depend on the tasks,
+available feedback, model computation and evaluation procedure.}
 
-\p{The [conceptual-discovery conjecture](ftip-00MN) asks whether some
-reusable mathematical capability is too costly for a specified autonomous
-lineage to acquire, yet becomes affordable with a contribution developed
-outside that lineage. The contribution may be a representation, lemma,
-connection, procedure or curriculum. Both its production and the recipient's
-learning must be accounted for. Different developmental backgrounds are
-permitted when disclosed; secret evaluation answers are not conceptual
-contributions. The mathematical target and correctness criterion stay fixed.}
+\p{A score increase can have several explanations.
+[Elicitation](ftip-0005) improves access to behavior already observable under
+the starting procedure. [Acquisition](ftip-0007) requires improvement on an
+independent transfer evaluation. More deployment computation can improve
+performance through additional search or sampling, while exploitation of an
+evaluator can improve its score without improving the intended capability.
+The conventions below distinguish these possibilities.}
 
-\p{This comparison permits the autonomous lineage to learn new
-representations, generate auxiliary tasks, use failed attempts and improve
-its own procedures. A plateau in one training recipe is therefore evidence
-about that recipe, not a bound over the complete lineage. Conversely, an
-affordable autonomous solution can defeat a proposed separation for the
-specified setting. [Simulation](ftip-00MX) and
-[enumeration](ftip-00MQ) provide further
-checks on claims about external advantage and permanent barriers.}
+\p{The post-training questions concern what different objectives, update
+rules and feedback sources enable a model to learn. The agent questions
+concern what persistent state, tools, interaction and recursive computation
+enable a system to do reliably. A retained library and an updated set of
+model weights can both affect later performance, but they are different
+interventions with different costs.}
 
-\p{The initial distinctions below remain useful within that broader
-question. [Elicitation](ftip-0005) concerns improved access to behaviour
-already observable under the declared starting procedure.
-[Acquisition](ftip-0007) requires improvement on an independent transfer
-evaluation. For an agent or a lineage, specify the retained artifact before
-that evaluation: weights, a library, executable procedures, or their
-combination. A result retained in a library and one learned into model
-parameters establish different acquisition claims.}
+\p{Architecture-dependent questions concern how token probabilities are
+computed, how parameterization interacts with optimization, and how model
+implementations compare under matched resources. Evaluation determines
+which comparisons the evidence supports. Finite probability bounds,
+counterexamples and feedback analyses establish consequences under their
+stated conditions; they do not by themselves bound every possible learning
+procedure.}
 
-\p{A score increase can also arise from greater deployment computation or
-exploitation of the evaluator. The model, procedure, evaluation and resource
-conventions make these possibilities explicit. The later
-[research-campaign comparison](ftip-00NU) applies them to discovery and
-teaching on concrete mathematical tasks. It is a proposed experiment;
-the general discovery-cost separation remains open.}
+\p{The same distinctions extend to [successive model
+generations](ftip-00MH). An autonomous lineage may change its representations,
+curricula and research procedures; an independently developed contribution
+may change what it can affordably acquire. That comparison includes both
+development and recipient learning. The [mathematical research
+settings](ftip-00NQ) study this direction within the broader capability
+question. A plateau in one recipe is evidence about that recipe, and the
+general discovery-cost separation remains a conjecture.}
 
 \transclude{ftip-0003}
 \transclude{ftip-0004}

--- a/trees/ftip-00MT.tree
+++ b/trees/ftip-00MT.tree
@@ -3,6 +3,11 @@
 \title{Affordable complementary contributions}
 \tag{ftip}
 
+\p{The \em{recipient} is the learning system whose capability is being
+evaluated. It receives and processes a contribution through an admitted
+interaction protocol, using its permitted tools, retained state and update
+procedures. The \em{contributor} is the source of that contribution.}
+
 \p{A contributor can make a representation, analogy, criticism, discriminating
 question or research direction affordably available to a recipient. The
 relevant properties are the interaction it can produce and what the recipient

--- a/trees/ftip-00MT.tree
+++ b/trees/ftip-00MT.tree
@@ -13,8 +13,7 @@ question or research direction affordably available to a recipient. The
 relevant properties are the interaction it can produce and what the recipient
 can make of it. Architecture, culture, expertise and developmental history
 can explain these properties without becoming mandatory coordinates of the
-abstract definition. “Contributor” names the technical role; “visitor” is
-its counterpart in a fable.}
+abstract definition.}
 
 \p{Availability, structural quality and realized benefit require different
 arguments. A familiar connection can be novel to a learner's affordable

--- a/trees/ftip-00MT.tree
+++ b/trees/ftip-00MT.tree
@@ -3,10 +3,10 @@
 \title{Affordable complementary contributions}
 \tag{ftip}
 
-\p{The \em{recipient} is the learning system whose capability is being
-evaluated. It receives and processes a contribution through an admitted
-interaction protocol, using its permitted tools, retained state and update
-procedures. The \em{contributor} is the source of that contribution.}
+\p{The \em{recipient} is the learning system that receives and processes
+a contribution. Its interaction protocol specifies the permitted tools,
+retained state and update procedures. The \em{contributor} is the source
+of that contribution.}
 
 \p{A contributor can make a representation, analogy, criticism, discriminating
 question or research direction affordably available to a recipient. The

--- a/trees/ftip-00MU.tree
+++ b/trees/ftip-00MU.tree
@@ -4,7 +4,7 @@
 \title{A causal contribution process}
 \tag{ftip}
 
-\p{Fix the recipient specification, task family, reveal schedule,
+\p{Fix the [recipient](ftip-00MT) specification, task family, reveal schedule,
 interaction permissions and resource accounting. Abstract a contributor
 #{v} by a causal interaction law, written as budget-indexed kernels}
 ##{K_v^b(\mathrm dh\mid H).}

--- a/trees/ftip-00MY.tree
+++ b/trees/ftip-00MY.tree
@@ -1,35 +1,34 @@
 \import{macros}
 \meta{agent-authored}{true}
 \taxon{Example}
-\title{A human–model exchange about conceptual discovery}
+\title{A human–agent exchange about conceptual discovery}
 \tag{ftip}
 
-\p{In a discussion on 10 September 2026, Kepler, a language-model
-assistant, was the recipient and utensil the human contributor. The
-assistant's proposals below arose within an already human-directed
-conversation; they were not outputs of a separate unaided experiment.}
+\p{In a discussion between the human and the agent, the agent's proposals
+arose within an already human-directed conversation; they were not outputs
+of a separate unaided experiment.}
 
 \ol{
-\li{Kepler proposed a resource-bounded formulation and a finite
-missing-evidence construction. Utensil rejected missing facts as the
+\li{The agent proposed a resource-bounded formulation and a finite
+missing-evidence construction. The human rejected missing facts as the
 intended mechanism and described conceptual leaps across model generations:
-new perspectives, paradigms and connections between domains. Kepler revised
+new perspectives, paradigms and connections between domains. The agent revised
 the target to conceptual discovery and separated prohibitive finite work
 from permanent unreachability using the enumeration countercheck.}
-\li{Kepler specified an executable source with bounded observations.
-Utensil challenged an oracle-like abstraction, pointed to diverse cultural
+\li{The agent specified an executable source with bounded observations.
+The human challenged an oracle-like abstraction, pointed to diverse cultural
 backgrounds and developed representations, and asked for an abstract account
-of what the source contributes. Kepler formulated the causal contribution
+of what the source contributes. The agent formulated the causal contribution
 interface, with background differences disclosed rather than a mandatory
 model of a brain or lifetime.}
-\li{Utensil emphasized that existence of good contributors need not imply
+\li{The human emphasized that existence of good contributors need not imply
 usefulness of all contributors, and suggested an upper-median restriction.
-Kepler separated independent structural quality, class nonemptiness and
+The agent separated independent structural quality, class nonemptiness and
 recipient transfer, while showing why a median requires a population and
 need not have positive quality.}
-\li{Utensil suggested studying recursive self-improvement papers for the
+\li{The human suggested studying recursive self-improvement papers for the
 gap between the problems they diagnose and the portions their methods
-repair. Kepler examined contemporary work and checked a revised primary
+repair. The agent examined contemporary work and checked a revised primary
 source that narrowed stronger self-imitation claims. The resulting thesis
 distinguishes affordable quality, recipient acquisition and a universal
 unaided bound, with proof, refutation and precise obstacles all possible.}

--- a/trees/ftip-00MY.tree
+++ b/trees/ftip-00MY.tree
@@ -4,9 +4,10 @@
 \title{A human–agent exchange about conceptual discovery}
 \tag{ftip}
 
-\p{In a discussion between the human and the agent, the agent's proposals
-arose within an already human-directed conversation; they were not outputs
-of a separate unaided experiment.}
+\p{In this exchange, the human is the contributor and the agent is the
+[recipient](ftip-00MT): the system receiving and processing the contribution.
+The agent's proposals arose within an already human-directed conversation;
+they were not outputs of a separate unaided experiment.}
 
 \ol{
 \li{The agent proposed a resource-bounded formulation and a finite
@@ -35,8 +36,8 @@ unaided bound, with proof, refutation and precise obstacles all possible.}
 }
 
 \p{In \ref{ftip-00MU}, #{H} corresponds to the exchange so far and
-#{h} to the contributor's next criticism, analogy or research direction.
-The recipient's retained conversation and revised artifacts form its evolving
+#{h} to the human's next criticism, analogy or research direction.
+The agent's retained conversation and revised artifacts form its evolving
 state; reasoning, literature search and checking are its processing actions.
 The human did not supply a completed theorem: the assistance changed the
 problem representation and choice of inquiry. The observed outcome was a

--- a/trees/ftip-00NW.tree
+++ b/trees/ftip-00NW.tree
@@ -3,12 +3,11 @@
 \title{How to read these notes}
 \tag{ftip}
 
-\p{The note develops the learning system, the evidence used to evaluate it,
-and the question of capability growth across generations. The diagram shows
-the main logical relationships among its six chapters. Solid arrows indicate
-inputs to the next analysis. The dashed branch adds architecture-specific
-detail when the question requires it. These are dependencies between subjects,
-rather than a requirement to read every chapter in sequence.}
+\p{The six chapters connect learning mechanisms, computational constraints,
+agent reliability, evaluation and capability growth. The diagram shows
+their main logical relationships. Solid arrows indicate concepts used by
+another analysis. The dashed branch supplies architecture-specific detail
+for comparisons involving a particular model implementation or optimizer.}
 
 \texfig{\begin{tikzpicture}[
   box/.style={draw,rounded corners=2pt,align=center,font=\small,
@@ -39,12 +38,12 @@ rather than a requirement to read every chapter in sequence.}
 \draw[flow,dashed] (architecture.south) |- (lineage.east);
 \end{tikzpicture}}
 
-\p{Post-training and agent state are complementary parts of the system:
-one changes learned parameters, while the other manages interaction,
-computation and retained artifacts. Evaluation places their results under a
-common task law and cost account. The architecture branch refines that
-comparison for particular model implementations and optimizers. The final
-chapter asks what these systems can discover and acquire across generations.}
+\p{Post-training and agent state are complementary sources of capability
+change: one changes learned parameters, while the other manages interaction,
+computation and retained artifacts. Evaluation studies the evidence for
+those changes and their limits. Architecture analysis connects the
+comparison to the model's computation and optimization. The lineage
+analysis extends it to discovery and learning across generations.}
 
 \ol{
   \li{[Foundations and interfaces](ftip-00J9) introduces capability claims,
@@ -67,31 +66,37 @@ chapter asks what these systems can discover and acquire across generations.}
   optimization geometry and matched-compute capability comparisons. This
   branch uses the evaluation framework to make implementation-specific
   claims.}
-  \li{[Conceptual discovery across model generations](ftip-00MH) brings
-  the model, training, agent and evaluation machinery together. It develops
+  \li{[Conceptual discovery across model generations](ftip-00MH) studies
+  discovery and learning across successive artifacts. It develops
   the complete lineage, independently developed contributions,
   representation learning, curricula and mathematical research settings,
   alongside the conjecture and arguments that could establish or defeat it.}
 }
 
-\p{For an overview of the research question, read [research question and
-scope](ftip-0002), then the opening of the conceptual-discovery chapter.
-Follow its [complete lineage](ftip-00MI), [acquisition criterion](ftip-00ML)
-and [conjecture](ftip-00MN) for the comparison being proposed. The subsequent
-sections explain contributor development, learned representations, future
-task demands and a concrete research setting.}
+\p{The [research question and scope](ftip-0002) introduces the common
+distinctions between elicitation, acquisition, computation and evaluation.
+Questions about fine-tuning, preferences, rewards and interaction lead to
+the [post-training chapter](ftip-00JA). Questions about memory, tools,
+recursive execution and reliability lead to the [agent chapter](ftip-00JD).
+Both use the model, task and environment interfaces in the foundations.}
 
-\p{For the mechanisms, read the foundations, post-training and agent
-chapters, followed by evaluation. Then continue to conceptual discovery.
-Insert the architecture chapter before that final step when the claim
-depends on a particular model implementation or optimizer. Track both
-parameter updates and retained agent artifacts when following an improvement
-across generations.}
+\p{Questions about a particular model implementation or optimizer are
+developed in the [architecture chapter](ftip-00JC). Its decoder-only
+reference, optimization geometry and matched-compute comparisons explain
+how capability claims depend on the computation that implements the model.
+The shared evaluation framework supplies the task laws and resource
+comparisons used in that analysis.}
 
-\p{For a claimed capability gain or limit, begin with
-[independent evaluation and post-training potential](ftip-005C), then follow
-the relevant finite result or counterexample. Training, search, contributor
-development and deployment costs have distinct roles; quantities with
-different units require an explicit conversion or a comparison that keeps
-those units separate. The general discovery-cost separation remains a
-conjecture, and each finite result depends on its stated assumptions.}
+\p{Claims about a capability gain or limit are examined in
+[independent evaluation and post-training potential](ftip-005C) and the
+following finite results and counterexamples. These sections distinguish
+training reward from evaluation evidence, examine transport to other task
+laws, and make the assumptions behind a bound explicit. Training, search
+and deployment costs have distinct roles in those comparisons.}
+
+\p{Questions about reusable concepts and capability growth across
+generations are developed in [conceptual discovery](ftip-00MH). Its
+[complete lineage](ftip-00MI), [acquisition criterion](ftip-00ML) and
+[conjecture](ftip-00MN) specify the autonomous and contributed processes
+being compared. Contributor development, learned representations, curricula
+and mathematical research provide concrete settings for that open question.}


### PR DESCRIPTION
The FTIP opening overemphasized the newest conceptual-discovery material, and the reading guide described an authoring step instead of the architecture chapter's content. Rebalance the opening and scope across post-training, agent behavior, evaluation and finite bounds, architecture and optimization, and conceptual discovery. Describe the guide's routes by their subject matter.

Anonymize the human–agent exchange in `ftip-00MY`, removing the participants' names and discussion date. Define the recipient and contributor roles before the causal contribution model, link to that explanation, and make the example's role mapping explicit without implying that it measured capability. Remove the unexplained visitor/fable aside from the public exposition.

The six-chapter organization, stable addresses, transclusions and chapter diagram are preserved. Changes are limited to six prose trees.

Validation at `5c7173bf38c01f14e2d474a2946c80c6cf0463a7`: build and lint CI pass; local prose checks and 22 checker tests pass; the full build verifies 2,331 XML/HTML page pairs. The final artifact set contains all 838 FTIP HTML pages and the rebuilt 296-page PDF. Independent source and PDF review covers the complete six-file correction. The expanded root's existing mobile overflow remains a baseline limitation.
