### PR TITLE
docs(ftip): condition capability on economic resources

### DIFF
--- a/trees/ftip-00MH.tree
+++ b/trees/ftip-00MH.tree
@@ -40,3 +40,8 @@ illustrates an upper-bound method for a fully specified action class.}
 \transclude{ftip-00MQ}
 
 \transclude{ftip-00MZ}
+
+\p{The [economic extension](ftip-00NX) studies how civilization and
+economic reproduction constrain the resources available to these learning
+lineages. It separates feasible schedules from task-specific discovery
+difficulty.}

--- a/trees/ftip-00NX.tree
+++ b/trees/ftip-00NX.tree
@@ -2,6 +2,7 @@
 \meta{agent-authored}{true}
 \title{Civilization, economic reproduction and capability}
 \tag{ftip}
+\date{2026-09-13}
 \tag{chapter}
 \meta{pdf}{true}
 

--- a/trees/ftip-00NX.tree
+++ b/trees/ftip-00NX.tree
@@ -1,0 +1,21 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Civilization, economic reproduction and capability}
+\tag{ftip}
+\tag{chapter}
+\meta{pdf}{true}
+
+\p{Learning systems depend on productive capacity and on institutions that
+create, transmit and validate knowledge. Their training and deployment can
+change those conditions. This chapter extends the [model-lineage
+framework](ftip-00MJ) by specifying economic trajectories alongside learning
+procedures. It studies the resources attainable before a deadline and the
+cost of acquiring contributions from a maintained knowledge-producing
+population.}
+\p{An economic restriction and a computational difficulty are different
+premises. A resource envelope constrains what can be executed; a learning
+lower bound constrains what a task requires. A capability separation needs
+both, together with a realizable assisted procedure. The results below are
+conditional mathematical statements about specified models.}
+\transclude{ftip-00NY}
+\transclude{ftip-00O1}

--- a/trees/ftip-00NY.tree
+++ b/trees/ftip-00NY.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Economic conditions on a learning campaign}
+\tag{ftip}
+
+\p{The [architecture refinement](ftip-00JF) makes a model implementation
+explicit when it affects a comparison. Economic conditions play an analogous
+role: they determine which resource schedules can be supplied, while the
+original checker, task law and acquisition criterion remain fixed.}
+\transclude{ftip-00NZ}
+\transclude{ftip-00O0}

--- a/trees/ftip-00NZ.tree
+++ b/trees/ftip-00NZ.tree
@@ -1,0 +1,38 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Economic state and admissible joint execution}
+\tag{ftip}
+\taxon{Definition}
+
+\p{Fix a horizon #{T>0} and a [lineage specification](ftip-00MJ) #{\Xi}.
+An economic specification #{\Omega} consists of an initial state #{x_0},
+causal transition laws, a class of policies, physical and financial
+constraints, and a measurable viability region #{\mathcal V}. A state may
+contain productive capital #{K}, maintained expertise #{H}, accessible
+knowledge #{D}, energy and hardware capacity #{E}, and institutional
+capacity #{J}. These coordinates name declared state variables; no
+production function or substitutability assumption follows from their names.}
+\p{A joint execution #{z=(P,\pi,x,r)} comprises a permitted lineage
+procedure #{P}, a causal economic policy #{\pi}, its state trajectory #{x},
+and an actual resource schedule #{r}. Transitions may depend on admitted
+learning outcomes and deployment decisions. Feasibility requires that
+#{r} supplies every operation of #{P} and every charged economic activity
+at the time and place used, under the [hard resource conventions](ftip-00MK).
+All work on search, synthetic generation, evaluation and controller changes
+is included. Missing output scores zero.}
+\p{Let #{\mathcal Z_{\rm phys}} contain physically feasible joint
+executions. Financeable executions additionally satisfy specified balance
+sheets and funding constraints; viable executions also remain in
+#{\mathcal V} almost surely. Thus}
+##{\mathcal Z_{\rm viable}\subseteq\mathcal Z_{\rm fin}
+\subseteq\mathcal Z_{\rm phys}.}
+\p{An equilibrium class is an additional restriction, not a synonym for
+all financeable choices. Welfare floors in #{\mathcal V} impose normative
+or institutional constraints unless physical necessity independently
+justifies them. Autonomy may maintain schools, public knowledge and power
+infrastructure; its access to new target-specific contributions remains
+controlled by #{\Xi}.}
+\p{Both arms disclose their endowments and use the same external accounting
+boundary. Currency outlays and physical resource coordinates remain
+separate. Buying electricity spends money and uses energy; these are two
+constraints on one transaction, not two independent monetary costs.}

--- a/trees/ftip-00NZ.tree
+++ b/trees/ftip-00NZ.tree
@@ -19,7 +19,10 @@ learning outcomes and deployment decisions. Feasibility requires that
 #{r} supplies every operation of #{P} and every charged economic activity
 at the time and place used, under the [hard resource conventions](ftip-00MK).
 All work on search, synthetic generation, evaluation and controller changes
-is included. Missing output scores zero.}
+is included. Missing output scores zero. The procedure #{P} includes the stopping and
+evaluation decisions induced by its resource schedule. Economic policies
+preserve the observation laws and information access permitted by #{\Xi};
+they supply no undeclared channel for target answers.}
 \p{Let #{\mathcal Z_{\rm phys}} contain physically feasible joint
 executions. Financeable executions additionally satisfy specified balance
 sheets and funding constraints; viable executions also remain in

--- a/trees/ftip-00O0.tree
+++ b/trees/ftip-00O0.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Economically conditioned potential}
+\tag{ftip}
+\taxon{Definition}
+
+\p{For any admitted class #{\mathcal Z} of joint executions and acquisition
+score #{Q_{\rm acq}(P)\in[0,1]}, define}
+##{\Phi(\Xi,\Omega,T;\mathcal Z)=
+\sup_{z\in\mathcal Z}Q_{\rm acq}(P_z).}
+\p{Take the supremum of an empty class to be zero in the ordered interval
+#{[0,1]}. For a nonnegative counted compute rate #{u_z}, define the hard
+resource envelope}
+##{\overline B(T;\mathcal Z)=
+\sup_{z\in\mathcal Z}\operatorname*{ess\,sup}
+\int_0^T u_z(t)\,dt,}
+\p{with zero for an empty class. The essential supremum is over the
+execution's declared randomness. A claim about expected expenditure alone
+does not bound this quantity. The compute unit is fixed by the operational
+semantics and must agree with any subsequent learning lower bound.}
+\p{Class inclusion gives #{\Phi(\mathcal Z_1)\leq\Phi(\mathcal Z_2)}
+and #{\overline B(\mathcal Z_1)\leq\overline B(\mathcal Z_2)} whenever
+#{\mathcal Z_1\subseteq\mathcal Z_2}, with other arguments fixed.
+Indeed every value in the first supremum also occurs in the second.
+A supremum need not be attained: #{\Phi\geq\tau} does not by itself
+provide a procedure with score at least #{\tau}.}

--- a/trees/ftip-00O1.tree
+++ b/trees/ftip-00O1.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Finite-horizon resources and discovery difficulty}
+\tag{ftip}
+
+\p{Financing, hardware throughput and power supply constrain different
+coordinates of a learning schedule. Their uniform bounds can be combined
+without asserting that any bound is attainable. Infrastructure investment
+and algorithmic improvements belong among the policies being bounded.}
+\transclude{ftip-00O2}
+\transclude{ftip-00O3}

--- a/trees/ftip-00O2.tree
+++ b/trees/ftip-00O2.tree
@@ -2,7 +2,7 @@
 \meta{agent-authored}{true}
 \title{A uniform finite-horizon compute envelope}
 \tag{ftip}
-\taxon{Proposition}
+\taxon{proposition}
 
 \p{Suppose for every #{z\in\mathcal Z}, almost surely, its nonnegative
 compute service rate #{u_z(t)} has monetary price #{p_z(t)\geq p_*>0},
@@ -10,7 +10,7 @@ and}
 ##{\int_0^T p_z(t)u_z(t)\,dt\leq F_T,\qquad
 u_z(t)\leq q(t),\qquad u_z(t)\leq e(t)P(t).}
 \p{The deterministic functions are measurable and nonnegative;
-#{F_T<\infty}, #{q} and #{eP} are integrable. Here #{q} bounds usable
+#{0\leq F_T<\infty}, #{q} and #{eP} are integrable. Here #{q} bounds usable
 hardware throughput, #{P} available power, and #{e} compute per unit
 energy. These bounds hold over all admitted investments, prices,
 implementations and efficiency changes. Then}

--- a/trees/ftip-00O2.tree
+++ b/trees/ftip-00O2.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A uniform finite-horizon compute envelope}
+\tag{ftip}
+\taxon{Proposition}
+
+\p{Suppose for every #{z\in\mathcal Z}, almost surely, its nonnegative
+compute service rate #{u_z(t)} has monetary price #{p_z(t)\geq p_*>0},
+and}
+##{\int_0^T p_z(t)u_z(t)\,dt\leq F_T,\qquad
+u_z(t)\leq q(t),\qquad u_z(t)\leq e(t)P(t).}
+\p{The deterministic functions are measurable and nonnegative;
+#{F_T<\infty}, #{q} and #{eP} are integrable. Here #{q} bounds usable
+hardware throughput, #{P} available power, and #{e} compute per unit
+energy. These bounds hold over all admitted investments, prices,
+implementations and efficiency changes. Then}
+##{\overline B(T;\mathcal Z)\leq
+\min\left\{F_T/p_*,\int_0^T q(t)\,dt,
+\int_0^T e(t)P(t)\,dt\right\}.}
+\proof{\p{For each execution integrate the two rate inequalities.
+The expenditure inequality gives
+#{p_*\int_0^T u_z(t)\,dt\leq F_T} almost surely.
+Taking the essential supremum for each execution and then the supremum
+over executions preserves all three bounds.}}
+\p{This is a necessary envelope. It does not establish that its minimum
+can be spent on an arbitrary schedule or that its inputs describe a
+particular economy. An excluded financing source or a permitted efficiency
+improvement that violates the displayed premises invalidates that
+application of the bound.}

--- a/trees/ftip-00O3.tree
+++ b/trees/ftip-00O3.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Economic exclusion from an independent work lower bound}
+\tag{ftip}
+\taxon{Proposition}
+
+\p{Fix #{0<\tau\leq1} and the autonomous procedure class admitted by
+#{\Xi}. Suppose every such procedure attaining #{Q_{\rm acq}\geq\tau}
+requires a hard compute cap at least #{L>0}: no implementation with a
+smaller almost-sure cap attains that score. If a uniform economic envelope
+#{b} satisfies #{\overline B(T;\mathcal Z_{\rm aut})\leq b<L},
+then no admitted autonomous execution reaches score #{\tau} by #{T}.}
+\proof{\p{An admitted successful execution would implement an autonomous
+procedure with hard cap at most #{b<L}, contradicting the work lower
+bound.}}
+\p{An economically feasible separation additionally requires an actual
+assisted execution achieving the same score and satisfying the shared
+external constraints. The scalar relation #{U\leq b} alone does not
+provide one: resource timing, memory, communication, contributor formation
+and evaluation must fit a supplied schedule.}
+\p{The lower-bound premise must cover permitted representations, search,
+training and controller development. It is stronger than failure of a
+particular recipe. For the intended conceptual-discovery tasks, establishing
+such a lower bound remains part of the [conjecture](ftip-00MN). The
+proposition makes a finite work lower bound operationally decisive when
+a separately justified economic envelope lies below it.}

--- a/trees/ftip-00O3.tree
+++ b/trees/ftip-00O3.tree
@@ -2,7 +2,7 @@
 \meta{agent-authored}{true}
 \title{Economic exclusion from an independent work lower bound}
 \tag{ftip}
-\taxon{Proposition}
+\taxon{proposition}
 
 \p{Fix #{0<\tau\leq1} and the autonomous procedure class admitted by
 #{\Xi}. Suppose every such procedure attaining #{Q_{\rm acq}\geq\tau}


### PR DESCRIPTION
FTIP currently treats the campaign resource cap as a supplied parameter. This change adds an explicit economic state and resource schedule, so capability can be conditioned on physical feasibility, financing and maintenance of productive knowledge.

The new chapter defines pathwise resource envelopes, proves a uniform finite-horizon compute bound, and states precisely how an independent autonomous work lower bound can make that envelope decisive. Actual assisted schedules and attained scores remain necessary; no general discovery lower bound or lifetime training ceiling is claimed. The chapter is linked from conceptual discovery; the final PR in this series will integrate the completed chapter into the opening and reader guide.

This is the first of five dependent PRs: economic conditions; knowledge renewal and finance; distributed contributions; alternative mathematical models; opening and reader navigation.

Validation: source prose check, full site build, and `just verify-render` passed (2,338 XML/HTML pairs). The standalone chapter PDF compiles to four pages. Independent mathematical, terminology and rendered review passed at `4e1f4f787c13cf321301c4f3da4e83610a5e9ea2`, including all four PDF pages and the exact source/artifact hashes.
