### PR TITLE
feat(ftip): model knowledge renewal and training finance

### DIFF
--- a/justfile
+++ b/justfile
@@ -152,11 +152,11 @@ verify-render:
 verify-pdf-fixtures:
     #!/usr/bin/env bash
     set -euo pipefail
-    for tree_id in spin-0001 hopf-0001 ca-0001 fgap-0001 fgap-001F fgap-001G fcap-0001 connes-0001 tt-0001 uts-000C; do
+    for tree_id in spin-0001 hopf-0001 ca-0001 fgap-0001 fgap-001F fgap-001G fcap-0001 connes-0001 tt-0001 uts-000C ftip-0001 ftip-00NX; do
         ./lize.sh "$tree_id" > "build/forester-pdf-$tree_id.log" 2>&1
         ./verify-forester-output.sh output/forest "$tree_id"
     done
-    bash ./verify-pdf-dates.sh spin-0001 hopf-0001 ca-0001 fgap-0001 fgap-001F fgap-001G fcap-0001 connes-0001 tt-0001 uts-000C
+    bash ./verify-pdf-dates.sh spin-0001 hopf-0001 ca-0001 fgap-0001 fgap-001F fgap-001G fcap-0001 connes-0001 tt-0001 uts-000C ftip-0001 ftip-00NX
 
 pre-push:
     just chk

--- a/trees/ftip-00NX.tree
+++ b/trees/ftip-00NX.tree
@@ -1,8 +1,8 @@
 \import{macros}
 \meta{agent-authored}{true}
+\date{2026-09-13}
 \title{Civilization, economic reproduction and capability}
 \tag{ftip}
-\date{2026-09-13}
 \tag{chapter}
 \meta{pdf}{true}
 
@@ -20,3 +20,9 @@ both, together with a realizable assisted procedure. The results below are
 conditional mathematical statements about specified models.}
 \transclude{ftip-00NY}
 \transclude{ftip-00O1}
+
+\transclude{ftip-00O4}
+
+\transclude{ftip-00O7}
+
+\transclude{ftip-00OA}

--- a/trees/ftip-00O4.tree
+++ b/trees/ftip-00O4.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Knowledge reproduction and viable expenditure}
+\tag{ftip}
+
+\p{A learning campaign can divert resources from the productive knowledge
+stock that supports later learning. The following model gives a bound over
+all permitted allocations, including allocations that deliberately maintain
+that stock. It describes effective capacity to produce useful knowledge;
+copying a nonrival dataset does not consume its bytes. The distinction
+between use and access incentives is developed in
+[Jones and Tonetti's economics of data](https://www.nber.org/papers/w26260).}
+\transclude{ftip-00O5}
+\transclude{ftip-00O6}

--- a/trees/ftip-00O5.tree
+++ b/trees/ftip-00O5.tree
@@ -1,0 +1,23 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A maintained productive knowledge stock}
+\tag{ftip}
+\taxon{Definition}
+
+\p{Fix #{A,\eta,\delta>0} with #{g=\eta A-\delta>0}, and initial
+stock #{h_0\geq h_{\min}>0}. Productive output is #{Ah(t)} per unit time,
+measured in a fixed consumption numeraire. Learning expenditure #{v(t)}
+and maintenance #{m(t)} exhaust output. Assume}
+##{v(t)+m(t)=Ah(t),\qquad
+\dot h(t)=\eta m(t)-\delta h(t)=gh(t)-\eta v(t).}
+\p{An allocation on #{[0,T]} is admissible when #{h} is absolutely
+continuous, #{v} is measurable, #{h(0)=h_0}, and almost everywhere
+#{0\leq v(t)\leq Ah(t)}, while #{h(t)\geq h_{\min}} at every time.
+Randomized allocations must satisfy these conditions almost surely.
+The conversion #{\eta} and depreciation #{\delta} are model assumptions;
+no causal estimate of human deskilling is asserted.}
+\p{The variable #{v} measures expenditure, not compute. To connect it to
+#{u} in the [compute envelope](ftip-00O2), specify the service price and
+require #{p(t)u(t)\leq v(t)}. The model excludes other productive assets
+and outside output. Applications that admit them must enlarge its state
+and recompute the bound.}

--- a/trees/ftip-00O6.tree
+++ b/trees/ftip-00O6.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A renewal bound valid for every admissible allocation}
+\tag{ftip}
+\taxon{proposition}
+
+\p{Every allocation in \ref{ftip-00O5} satisfies}
+##{\int_0^T v(t)\,dt\leq
+\min\left\{\frac{Ah_0(e^{gT}-1)}{g},
+\frac{h_0e^{gT}-h_{\min}}{\eta}\right\}.}
+\proof{\p{The stock equation gives
+#{(e^{-gt}h(t))'=-\eta e^{-gt}v(t)\leq0} almost everywhere.
+Hence #{h(t)\leq h_0e^{gt}}. Integrating #{v\leq Ah} gives the first
+bound. Integrating the discounted stock equation gives}
+##{\eta\int_0^T e^{-gt}v(t)\,dt
+=h_0-e^{-gT}h(T)\leq h_0-e^{-gT}h_{\min}.}
+\p{Since #{v\geq0} and #{e^{-gt}\geq e^{-gT}}, multiplication by
+#{e^{gT}} gives the second bound. The argument is pathwise, so it also
+covers randomized causal allocations satisfying the hypotheses.}}
+\p{The bound is necessary and need not be attained. With a positive
+service-price lower bound #{p_*}, division by #{p_*} supplies a compute
+envelope and can be used in \ref{ftip-00O3}. The relevant autonomous
+lower bound is still independent of this stock calculation. The bound
+increases with #{T}; it makes no finite lifetime claim.}

--- a/trees/ftip-00O7.tree
+++ b/trees/ftip-00O7.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Financing as a constrained balance sheet}
+\tag{ftip}
+
+\p{Expenditure must be financed even when hardware and power are physically
+available. Conversely, a fall in household income need not imply a fall in
+funds available for training. The following accounting model states exactly
+which funds enter the resource envelope.}
+\transclude{ftip-00O8}
+\transclude{ftip-00O9}

--- a/trees/ftip-00O8.tree
+++ b/trees/ftip-00O8.tree
@@ -1,0 +1,22 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A finite-horizon learning account}
+\tag{ftip}
+\taxon{Definition}
+
+\p{Let #{b(t)} be an absolutely continuous liquid balance with
+#{b(0)=b_0\geq0}. Let #{f(t)\geq0} be admitted inflows, #{o(t)\geq0}
+other outlays, #{u(t)\geq0} the counted compute rate, and #{p(t)>0} its
+price. Assume these flows are measurable and integrable, and the balance equation holds almost everywhere. The account satisfies}
+##{\dot b(t)=f(t)-p(t)u(t)-o(t),\qquad b(T)\geq0.}
+\p{All quantities are measured over the same institutional boundary and
+time interval. Inflows include operating receipts, equity, grants and debt
+proceeds whenever admitted; debt service and terminal obligations enter
+outlays or a stronger terminal-balance condition. Receipts recycled within
+this account are not counted again as external funding. A restriction to
+retained earnings is a special financing model, not a property of AI.}
+\p{For a resource envelope, require a uniform bound
+#{\int_0^T f(t)\,dt\leq F} over the admitted policies, with
+#{0\leq F<\infty}. Expected inflows alone do not impose this almost-sure
+bound. Unlimited refinancing violates this premise unless some separate
+constraint bounds its cumulative proceeds.}

--- a/trees/ftip-00O9.tree
+++ b/trees/ftip-00O9.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A compute bound from financed expenditure}
+\tag{ftip}
+\taxon{proposition}
+
+\p{If \ref{ftip-00O8} holds and #{p(t)\geq p_*>0}, then}
+##{\int_0^T u(t)\,dt\leq\frac{b_0+F}{p_*}.}
+\proof{\p{Integration of the balance sheet gives}
+##{\int_0^T p(t)u(t)\,dt
+=b_0-b(T)+\int_0^T f(t)\,dt-\int_0^T o(t)\,dt
+\leq b_0+F.}
+\p{Apply the price lower bound. If the premises hold uniformly almost
+surely, the same bound holds for the hard envelope over all executions.}}
+\p{This establishes the financing term in \ref{ftip-00O2} from an
+explicit account. It does not derive #{F} from aggregate output or welfare.
+A concrete model must establish the inflow bound while admitting its actual
+investment, borrowing and redistribution mechanisms.}

--- a/trees/ftip-00OA.tree
+++ b/trees/ftip-00OA.tree
@@ -1,0 +1,14 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Competitive automation and retained training finance}
+\tag{ftip}
+
+\p{[The AI Layoff Trap](https://arxiv.org/html/2603.20617v3),
+Proposition 1, gives a static model in which firms internalize their own
+cost savings but only part of a demand loss. The calculation below
+reproduces its interior game and derives a conditional financing consequence.
+Cooperation here means maximizing joint firm profits; it is not a general
+social optimum. Appendix A of the paper leaves saving, investment and
+interest-rate closure outside the baseline model.}
+\transclude{ftip-00OB}
+\transclude{ftip-00OC}

--- a/trees/ftip-00OB.tree
+++ b/trees/ftip-00OB.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{An interior automation game}
+\tag{ftip}
+\taxon{Definition}
+
+\p{Fix an integer #{N>1}, #{L,k>0}, and #{0<\ell<s<k+\ell/N}.
+Firm #{i} chooses #{\alpha_i\in[0,1]}, average automation is
+#{\bar\alpha=N^{-1}\sum_i\alpha_i}, and its profit is}
+##{\pi_i=\Pi_0+L\left(s\alpha_i-\ell\bar\alpha
+-\frac{k}{2}\alpha_i^2\right).}
+\p{The saving #{s} and demand leakage #{\ell} are fixed parameters.
+In the seed model #{s=w-c} and #{\ell=\lambda(1-\eta)w}, with wage
+#{w}, automation cost #{c}, spending propensity #{\lambda} and
+replacement-income fraction #{\eta}. These are static parameters; they do
+not specify training expenditure or a law of economic development.}
+\p{Strict concavity gives the unique Nash choice and the unique
+joint-profit maximizing choice, both interior:}
+##{\alpha^{\rm NE}=\frac{s-\ell/N}{k},\qquad
+\alpha^{\rm CO}=\frac{s-\ell}{k}.}
+\proof{\p{Differentiate individual profit in #{\alpha_i} to obtain
+#{L(s-\ell/N-k\alpha_i)}. Differentiate total profit in each choice
+to obtain #{L(s-\ell-k\alpha_i)}. The stated inequalities put both
+stationary choices strictly between zero and one; negative second
+derivatives establish the maxima.}}

--- a/trees/ftip-00OC.tree
+++ b/trees/ftip-00OC.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Retained-finance loss under the competitive allocation}
+\tag{ftip}
+\taxon{proposition}
+
+\p{In \ref{ftip-00OB}, write total profit at a common choice #{a} as
+#{\Pi(a)=N\Pi_0+NL((s-\ell)a-ka^2/2)}. Then}
+##{\Delta\Pi=\Pi(\alpha^{\rm CO})-\Pi(\alpha^{\rm NE})
+=\frac{NLk}{2}(\alpha^{\rm NE}-\alpha^{\rm CO})^2>0.}
+\proof{\p{Complete the square around
+#{a=(s-\ell)/k}. The difference of the choices is
+#{\ell(1-1/N)/k>0}.}}
+\p{Suppose both total profits are nonnegative, a fixed fraction
+#{\rho\in[0,1]} funds the next training round, outside finance is
+unavailable, and its compute price is a fixed #{p>0}. The difference
+between the monetary training allocations is #{\rho\Delta\Pi},
+and the difference between their financially purchasable compute
+quantities is #{\rho\Delta\Pi/p}. This follows directly from the
+stipulated rule #{C(a)=\rho\Pi(a)/p}; other physical constraints can
+prevent those quantities from being realized.}
+\p{The result compares two allocations. It does not bound all autonomous
+policies, which may coordinate, borrow or maintain demand when permitted.
+For #{\rho=0} the financing difference vanishes. Changing institutions or
+adding productive investment changes the model rather than contradicting
+the displayed algebra.}


### PR DESCRIPTION
This adds three mathematical routes connecting economic reproduction to learning resources: a maintained knowledge-stock model with a uniform expenditure bound, an explicit balance-sheet compute bound, and an interior automation game with a proved profit gap and conditional retained-finance consequence.

All-policy bounds are distinguished from equilibrium comparisons. Outside financing, productive investment and indefinite horizons remain explicit limits of the assumptions. The results do not assert a universal training ceiling or prove a conceptual-discovery lower bound.

Part 2 of five, dependent on #196. Validation: source prose, full site build, 2,347 XML/HTML pairs and the eight-page chapter PDF passed. Independent mathematical, terminology and rendered review passed at `ec65dc3933148f5616377e6e6fcab567eb133cf7`, including all new PDF pages and exact source/artifact hashes.

The PDF buttons previously linked to files omitted from the publication build. The existing PDF fixture loop now generates and verifies both the full FTIP suite and economic chapter, and checks their publication dates before Pages upload. This also restores the existing full-suite PDF download.

The mathematical source is unchanged from its reviewed head. The two-line justfile repair is appended at `5821e5a4f4f68b7234798bee02c080aab4370cfe`; both added PDF targets passed local builds, date checks and rendered-output checks. Exact-head CI and production download verification are required before landing closeout.
