### PR TITLE
feat(ftip): derive reliable contribution and portfolio cost bounds

### DIFF
--- a/trees/ftip-00NX.tree
+++ b/trees/ftip-00NX.tree
@@ -26,3 +26,7 @@ conditional mathematical statements about specified models.}
 \transclude{ftip-00O7}
 
 \transclude{ftip-00OA}
+
+\transclude{ftip-00OD}
+
+\transclude{ftip-00OG}

--- a/trees/ftip-00OD.tree
+++ b/trees/ftip-00OD.tree
@@ -1,0 +1,13 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Distributed expertise and reliable acquisition}
+\tag{ftip}
+
+\p{A maintained population can preserve distinct lines of experience and
+produce useful representations, criticism and proofs. The mathematical
+question is whether a recipient can find, validate and acquire useful
+structure at a lower total cost. Diversity alone supplies no probability
+bound. The following protocol strengthens the [single-consultation
+result](ftip-00MW) with explicit conditions for repeated acquisition.}
+\transclude{ftip-00OE}
+\transclude{ftip-00OF}

--- a/trees/ftip-00OE.tree
+++ b/trees/ftip-00OE.tree
@@ -1,0 +1,35 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Costed consultation with observable certification}
+\tag{ftip}
+\taxon{Definition}
+
+\p{Fix the shared task, checker, evaluation law and endowments from
+[the lineage specification](ftip-00MJ). Preparation of the contributor
+population and recipient costs at most #{S\geq0} in one declared additive
+resource unit. For a fixed integer #{k\geq1}, a causal protocol makes at
+most #{k} attempts, each with hard cost at most #{c\geq0}. Each attempt
+includes selection of a contributor, communication, recipient learning,
+validation, and any reset. Retention, final selection and evaluation are
+also charged within these caps. All remaining resource coordinates require
+a feasible schedule.}
+\p{An attempt either returns an observable certificate with a frozen
+recipient artifact or reports failure. The protocol returns the first
+certified artifact, continuing after each failure until certification or
+#{k} failures; in the latter case it returns a declared fallback.
+Contributor access is removed for fresh evaluation. Let #{Z\in[0,1]}
+be the resulting score. Assume #{q\in(0,1]} and #{\beta\in(0,1]} such that:}
+\ol{
+\li{At every prior failure history reached with positive probability, the
+conditional probability of certification on the next attempt is at least
+#{q}. For general history spaces this condition holds almost surely.}
+\li{For every possible selected certificate history, the conditional
+expected fresh-evaluation score of that retained artifact is at least
+#{\beta}, again almost surely.}
+}
+\p{The second premise is a soundness requirement for acquired capability,
+including any effect of selection. A proof checked on an observed task or
+a finite validation score need not imply it. Establishing such soundness,
+affordable contributor access and the first probability bound remains a
+substantive obligation for an application. Independent attempts are not
+required.}

--- a/trees/ftip-00OE.tree
+++ b/trees/ftip-00OE.tree
@@ -18,7 +18,7 @@ recipient artifact or reports failure. The protocol returns the first
 certified artifact, continuing after each failure until certification or
 #{k} failures; in the latter case it returns a declared fallback.
 Contributor access is removed for fresh evaluation. Let #{Z\in[0,1]}
-be the resulting score. Assume #{q\in(0,1]} and #{\beta\in(0,1]} such that:}
+be the resulting score. Assume #{0<q\leq1} and #{0<\beta\leq1} such that:}
 \ol{
 \li{At every prior failure history reached with positive probability, the
 conditional probability of certification on the next attempt is at least

--- a/trees/ftip-00OF.tree
+++ b/trees/ftip-00OF.tree
@@ -16,7 +16,7 @@ certificate and nonnegativity on failure imply
 #{\mathbb E Z\geq\beta\Pr(F_k^c)}. Summing the preparation and attempt
 caps proves the cost claim, including early stopping.}}
 \p{If #{0<q<1} and #{0<\tau<\beta}, the choice}
-##{k=\left\lceil\frac{\log(1-\tau/\beta)}{\log(1-q)}\right\rceil}
+##{k=\left\lceil\frac{\log(1-\frac{\tau}{\beta})}{\log(1-q)}\right\rceil}
 \p{ensures #{Q_{\rm acq}\geq\tau}. If #{q=1}, one attempt suffices
 for #{\tau\leq\beta}. For example, #{q=1/4}, #{\beta=0.9} and
 #{k=8} give #{Q_{\rm acq}\geq0.9(1-(3/4)^8)>0.8}; this is an

--- a/trees/ftip-00OF.tree
+++ b/trees/ftip-00OF.tree
@@ -1,0 +1,30 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A reliable acquisition bound}
+\tag{ftip}
+\taxon{proposition}
+
+\p{The protocol in \ref{ftip-00OE} has hard additive cost at most
+#{U=S+kc} and attains}
+##{Q_{\rm acq}=\mathbb E Z\geq
+\beta\bigl(1-(1-q)^k\bigr).}
+\proof{\p{Let #{F_j} denote failure of the first #{j} attempts, with
+#{F_0} certain. Conditional certification gives
+#{\Pr(F_j)\leq(1-q)\Pr(F_{j-1})}, hence
+#{\Pr(F_k)\leq(1-q)^k}. Conditional soundness at the first selected
+certificate and nonnegativity on failure imply
+#{\mathbb E Z\geq\beta\Pr(F_k^c)}. Summing the preparation and attempt
+caps proves the cost claim, including early stopping.}}
+\p{If #{0<q<1} and #{0<\tau<\beta}, the choice}
+##{k=\left\lceil\frac{\log(1-\tau/\beta)}{\log(1-q)}\right\rceil}
+\p{ensures #{Q_{\rm acq}\geq\tau}. If #{q=1}, one attempt suffices
+for #{\tau\leq\beta}. For example, #{q=1/4}, #{\beta=0.9} and
+#{k=8} give #{Q_{\rm acq}\geq0.9(1-(3/4)^8)>0.8}; this is an
+illustration of the assumptions, not an empirical estimate.}
+\p{Together with an actual economically viable schedule for this protocol
+and an independent autonomous hard-work lower bound #{L>U}, this supplies
+the assisted construction needed in \ref{ftip-00O3}, whenever the
+autonomous economic envelope is below #{L}. Here #{U}, #{L} and that
+envelope must use the same counted resource unit, with any conversion
+explicitly justified. A low scalar cost does not
+establish the schedule or the lower bound.}

--- a/trees/ftip-00OG.tree
+++ b/trees/ftip-00OG.tree
@@ -1,0 +1,11 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Civilizational preparation and shared costs}
+\tag{ftip}
+
+\p{A contributor population can serve many campaigns. Economies from
+sharing its preparation are meaningful only for an actual portfolio and
+under the same accounting treatment given to shared model pretraining.
+The following comparison makes the amortization and its quantifiers explicit.}
+\transclude{ftip-00OH}
+\transclude{ftip-00OI}

--- a/trees/ftip-00OH.tree
+++ b/trees/ftip-00OH.tree
@@ -1,0 +1,25 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A portfolio with charged preparation}
+\tag{ftip}
+\taxon{Definition}
+
+\p{For difficulty #{n}, fix #{R\geq1} specified tasks, their common
+evaluation convention and a portfolio success condition: each task's
+recipient attains expected fresh-task score at least #{\tau}. An admitted
+assisted construction pays preparation #{S(n)} once and at most #{c(n)}
+per task, including failed consultations and acquisition. Its actual joint
+schedule therefore has additive work at most}
+##{U_R(n)=S(n)+R c(n),\qquad
+\frac{U_R(n)}{R}=\frac{S(n)}{R}+c(n).}
+\p{This charges the whole preparation cost to the portfolio. A single
+campaign does not gain extra cash from anticipated future users. Count
+maintenance over the service interval and capacity needed for all tasks
+in #{S} or #{c}; peak resources and time come from the actual schedule,
+not this sum.}
+\p{Let #{L_R(n)>0} be a lower bound on the total hard additive work of
+every admitted autonomous portfolio meeting the same success condition,
+including permitted shared training and development. One cannot obtain
+#{L_R} by adding isolated-task lower bounds without proving that sharing
+does not invalidate the result. Marginal comparisons may disclose sunk
+preparation on both sides; lifecycle comparisons must charge both.}

--- a/trees/ftip-00OI.tree
+++ b/trees/ftip-00OI.tree
@@ -1,0 +1,24 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A conditional asymptotic portfolio advantage}
+\tag{ftip}
+\taxon{proposition}
+
+\p{Under \ref{ftip-00OH}, suppose actual assisted schedules exist and,
+for integers #{n\geq1}, constants #{C_s,C_c,c_0>0}, exponents
+#{a,b,d\geq0} and #{r>0},}
+##{S(n)\leq C_s n^a,\qquad c(n)\leq C_c n^b,\qquad
+R(n)=\lceil n^r\rceil,\qquad
+L_{R(n)}(n)\geq R(n)c_0 n^d.}
+\p{If #{\max\{a-r,b\}<d}, then}
+##{\frac{U_{R(n)}(n)}{L_{R(n)}(n)}\longrightarrow0.}
+\proof{\p{Since #{R(n)\geq n^r},}
+##{0\leq\frac{U_{R(n)}(n)}{L_{R(n)}(n)}
+\leq\frac{C_s}{c_0}n^{a-r-d}
++\frac{C_c}{c_0}n^{b-d}\longrightarrow0.}}
+\p{For instance, #{a=2,b=0,r=2,d=1} obeys the exponent condition.
+The displayed lower bound on autonomous portfolios is still a hypothesis;
+the calculation does not establish it for conceptual discovery. The result
+identifies a possible macroeconomic route: sustained expertise serves many
+tasks while each recipient acquires a comparatively inexpensive contribution.
+If autonomous preparation is equally reusable, the proposed #{L_R} may fail.}


### PR DESCRIPTION
This gives two conditional routes from maintained expertise to lower acquisition cost. A consultation protocol with observable, sound certification attains an explicit finite-attempt score bound, charging failed attempts, selection, validation and recipient learning. A portfolio calculation proves a vanishing assisted/autonomous cost ratio under explicit scaling assumptions.

Preparation is charged across actual tasks on both sides. The autonomous portfolio lower bound must cover shared development; the note does not infer it by summing isolated-task bounds. Economic feasibility additionally requires an actual schedule and a common resource unit.

Part 3 of five, dependent on #197. Validation passed: source prose, full site build, 2,353 XML/HTML pairs and the eleven-page chapter PDF. Independent mathematical, terminology and rendered review passed at `3030de98be494ad41d6b5418d04e28b3360d5a87`, checking all new PDF pages and 26 source/artifact hashes. Exact-head PR lint passed; the Pages build workflow only runs for PRs targeting main.
