### PR TITLE
feat(ftip): formulate alternative economic learning models

### DIFF
--- a/trees/ftip-00NX.tree
+++ b/trees/ftip-00NX.tree
@@ -30,3 +30,5 @@ conditional mathematical statements about specified models.}
 \transclude{ftip-00OD}
 
 \transclude{ftip-00OG}
+
+\transclude{ftip-00OJ}

--- a/trees/ftip-00OJ.tree
+++ b/trees/ftip-00OJ.tree
@@ -1,0 +1,18 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Alternative mathematical models and failure conditions}
+\tag{ftip}
+
+\p{Economic dependence does not fix the sign or magnitude of feedback.
+The models below isolate assumptions under which continued learning is
+sustainable, expertise is replenished or a machine can reconstruct the
+assisted process. Each is a mathematical alternative with stated premises,
+not a fitted description of the economy. The equations are elementary
+illustrations; links identify related research rather than attributing these
+particular equations to those papers.}
+\transclude{ftip-00OK}
+\transclude{ftip-00OL}
+\transclude{ftip-00OM}
+\transclude{ftip-00ON}
+\transclude{ftip-00OO}
+\transclude{ftip-00OP}

--- a/trees/ftip-00OK.tree
+++ b/trees/ftip-00OK.tree
@@ -1,0 +1,17 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{A maintained stock can finance training forever}
+\tag{ftip}
+\taxon{Example}
+
+\p{In \ref{ftip-00O5}, choose constant expenditure
+#{v(t)=gh_0/\eta} and maintenance #{m(t)=\delta h_0/\eta}.
+Since #{g=\eta A-\delta>0}, these are nonnegative and sum to #{Ah_0}.
+The stock equation gives #{h(t)=h_0\geq h_{\min}} for all #{t\geq0},
+so the allocation is admissible on every finite interval and}
+##{\int_0^T v(t)\,dt=\frac{gh_0}{\eta}T\longrightarrow\infty.}
+\p{At a fixed compute price #{p>0}, a service with constant physical
+capacity at least #{gh_0/(\eta p)} can supply that positive compute rate
+indefinitely. Thus maintenance dependence and a finite bound for each
+deadline are compatible with infinite lifetime compute. No conclusion
+about unbounded capability follows without a learning model.}

--- a/trees/ftip-00OL.tree
+++ b/trees/ftip-00OL.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Productive investment expands the envelope}
+\tag{ftip}
+\taxon{Example}
+
+\p{Consider a single productive capital stock #{K_0>0}, output #{AK},
+depreciation #{\delta_K>0} and allocation fractions #{s,\theta>0}
+with #{s+\theta\leq1}. Invest #{sAK}, spend #{\theta AK} on training,
+and allocate the remainder to other uses. If #{A>0} and
+#{\gamma=sA-\delta_K>0}, then}
+##{\dot K=\gamma K,\qquad K(t)=K_0e^{\gamma t},\qquad
+\int_0^T\theta AK(t)\,dt
+=\frac{\theta AK_0}{\gamma}(e^{\gamma T}-1).}
+\p{These identities follow by solving the linear stock equation and
+integrating output. With service price #{p>0} and sufficient installed
+service capacity, division by #{p} gives affordable compute. For #{T>0}, this
+expenditure exceeds the frozen-capital estimate #{\theta AK_0T}, since
+#{e^{\gamma T}-1>\gamma T}. That estimate cannot bound this policy. The
+model assumes investment converts into usable capital without delay;
+construction lags and essential complements require additional states.}
+\p{[Aghion, Jones and Jones](https://www.nber.org/papers/w23928)
+study AI and economic growth with production and idea-generation mechanisms.
+[Caballero](https://www.nber.org/papers/w34722) analyzes a richer financing
+and capital-installation mechanism with alternative long-run outcomes.
+Neither citation makes the exponential path here an empirical forecast.}

--- a/trees/ftip-00OM.tree
+++ b/trees/ftip-00OM.tree
@@ -1,0 +1,29 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Knowledge renewal depends on useful yield}
+\tag{ftip}
+\taxon{Example}
+
+\p{Let #{D(t)} denote effective task-relevant coverage, rather than raw
+token count. Suppose useful new human input arrives at rate #{h\geq0},
+synthetic generation at rate #{v\geq0} has effective yield #{a\geq0},
+and coverage depreciates at rate #{\delta_D>0}. Under the stipulated law}
+##{\dot D=h+av-\delta_DD,\qquad
+D(t)=D_*+(D_0-D_*)e^{-\delta_Dt},\qquad
+D_*=(h+av)/\delta_D.}
+\p{Direct differentiation verifies the solution. For a required coverage
+#{D_{\min}>0}, if #{D_0\geq D_{\min}} and
+#{h+av\geq\delta_DD_{\min}}, then #{D(t)\geq D_{\min}}
+at every time. If #{h+av<\delta_DD_{\min}} and #{D_0} is finite,
+the path eventually falls below the threshold. The necessary synthetic
+contribution is exactly #{av\geq\max\{0,\delta_DD_{\min}-h\}}.
+Positive synthetic yield is necessary when human inflow leaves a deficit;
+an affordable schedule must also produce and check the generated material.}
+\p{The scalar law omits distributional coverage and estimation error.
+The contrast between recursive replacement in
+[Shumailov et al.](https://www.nature.com/articles/s41586-024-07566-y),
+accumulation in [Gerstgrasser et al.](https://arxiv.org/abs/2404.01413),
+and consistency conditions in
+[Barzilai and Shamir](https://arxiv.org/abs/2505.19046v3)
+is a reason to specify #{a} and the learning process, not to assume that
+every generated token has fixed positive knowledge value.}

--- a/trees/ftip-00ON.tree
+++ b/trees/ftip-00ON.tree
@@ -1,0 +1,20 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Essential and substitutable expertise give different restrictions}
+\tag{ftip}
+\taxon{Example}
+
+\p{Let #{H,M\geq0} denote usable human and machine expertise. Under
+perfect substitution, effective expertise is #{E=H+\chi M} with
+#{\chi>0}. The productive requirement #{E\geq E_{\min}>0} is
+satisfied with #{H=0} whenever #{M\geq E_{\min}/\chi}. Under
+essential complementarity, take #{E=\min\{H,\chi M\}} instead.
+Then #{E\geq E_{\min}} implies #{H\geq E_{\min}}. Both claims
+follow directly from the definitions.}
+\p{A human-stock floor can therefore represent either an explicit social
+constraint or an indispensable productive input. The latter interpretation
+requires a complementarity premise. An economic model does not prove
+biological exclusivity merely by naming one coordinate human expertise.
+The organization and substitution of knowledge also depend on communication
+and access, as modeled by
+[Ide and Talamàs](https://doi.org/10.1086/737233).}

--- a/trees/ftip-00OO.tree
+++ b/trees/ftip-00OO.tree
@@ -1,0 +1,27 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Assistance can maintain or erode expertise}
+\tag{ftip}
+\taxon{Example}
+
+\p{Fix maintenance #{m\geq0}, assistance intensity #{a\geq0}, and
+parameters #{\eta,\delta_0>0}, #{\xi,\delta_1\geq0}. Consider}
+##{\dot H=\eta m+\xi a-(\delta_0+\delta_1a)H,\qquad
+H_* =\frac{\eta m+\xi a}{\delta_0+\delta_1a}.}
+\p{Here #{\xi a} models learning produced by assistance and
+#{\delta_1aH} models lost practice. The solution is
+#{H(t)=H_*+(H_0-H_*)e^{-(\delta_0+\delta_1a)t}}. If
+#{H_0\geq H_{\min}}, the stock stays above that floor for every
+#{t\geq0} exactly when
+#{H_*\geq H_{\min}}; if the stationary stock is smaller, it
+eventually crosses below. For a finite deadline #{T}, monotonicity instead
+makes viability equivalent to #{H(T)\geq H_{\min}}, which may hold
+even when the stationary stock is smaller. Moreover,}
+##{\frac{dH_*}{da}=
+\frac{\xi\delta_0-\delta_1\eta m}{(\delta_0+\delta_1a)^2}.}
+\p{Differentiation shows that the sign depends on the stated parameters.
+Neither automatic deskilling nor automatic skill improvement follows from
+assistance alone. [Bastani et al.](https://pmc.ncbi.nlm.nih.gov/articles/PMC12232635/)
+study learning outcomes under different assistance designs; their particular
+experiment does not identify universal coefficients for this stock law.
+Assistance and maintenance costs must also fit the resource account.}

--- a/trees/ftip-00OP.tree
+++ b/trees/ftip-00OP.tree
@@ -1,0 +1,26 @@
+\import{macros}
+\meta{agent-authored}{true}
+\title{Affordable autonomous reconstruction removes the gap}
+\tag{ftip}
+\taxon{proposition}
+
+\p{Fix one admitted assisted campaign with final score #{Z\in[0,1]}.
+Suppose an autonomous campaign is admitted under the same external
+resource caps and evaluation convention, with simulation, development and
+recipient learning fully charged. If its joint law of transcript, retained
+artifact and fresh evaluation agrees with that of the assisted campaign,
+then its expected acquisition score is identical.}
+\proof{\p{The acquisition score is the expectation of the same bounded
+measurable score function under equal laws.}}
+\p{More generally, if these laws have total variation distance at most
+#{\varepsilon}, where #{\operatorname{TV}(P,Q)=\sup_A|P(A)-Q(A)|},
+then #{|\mathbb E_PZ-\mathbb E_QZ|\leq\varepsilon}. Indeed,
+#{\mathbb E_PZ=\int_0^1P(Z>t)\,dt}, and the probability difference
+in each integrand is at most #{\varepsilon}. Thus the autonomous score
+is at least #{Q_{\rm acq}^{\rm assisted}-\varepsilon}.}
+\p{Approximate agreement of output laws does not establish an almost-sure
+resource cap: admission of the autonomous implementation is a separate
+premise. Nor does computability establish affordable reconstruction of the
+contributor's development and observations. This is the economic version
+of [the reconstruction boundary](ftip-00MX); a claimed separation must
+exclude such an affordable implementation by an actual lower bound.}


### PR DESCRIPTION
This adds a separate section of six mathematical alternatives: sustainable training, productive investment, useful knowledge replenishment, expertise substitution, assistance-dependent skill dynamics, and affordable autonomous reconstruction. Each model states its assumptions and derives the condition under which a proposed constraint or contributor advantage fails.

The examples distinguish finite-deadline feasibility from lifetime limits, and effective knowledge yield from raw token count. The reconstruction result includes a total-variation score bound while keeping hard resource admission separate. Related literature is attributed without presenting the illustrative equations as empirical estimates.

Part 4 of five, dependent on #198. Validation passed: source prose, full site build, 2,360 XML/HTML pairs and the fifteen-page chapter PDF. Independent mathematical, terminology and rendered review passed at `b0774ace7126f82eadd64f89e2ef1a85afa783c9`, including every new PDF page and all 29 source/artifact hashes. Exact-head PR lint passed; the existing Pages build only runs for main-targeted PRs.
