### PR TITLE
docs(ftip): refresh the seven-chapter opening and reader guide

### DIFF
--- a/trees/ftip-0001.tree
+++ b/trees/ftip-0001.tree
@@ -48,6 +48,15 @@ problems, with development and learning costs included. Mathematical
 research supplies concrete settings for that question; the proposed
 [discovery-cost separation](ftip-00MN) remains open.}
 
+\p{[Civilization and economic reproduction](ftip-00NX) ask how learning
+resources arise from productive capacity, finance and the renewal of
+knowledge. Economic development can constrain a campaign or expand its
+future resources. The chapter proves conditional bounds for specified
+models and studies reliable contributions and shared preparation costs,
+alongside alternative models that sustain continued learning. These
+results make the budget part of the mathematical question; the general
+discovery lower bound remains open.}
+
 \p{The shared [model, task and evaluation interfaces](ftip-00J9) support
 these different lines of inquiry. The notes combine published empirical
 observations, specified mechanisms, finite mathematical results and open
@@ -67,3 +76,5 @@ independent evaluation and resource bounds.}
 \transclude{ftip-00JB}
 \transclude{ftip-00JC}
 \transclude{ftip-00MH}
+
+\transclude{ftip-00NX}

--- a/trees/ftip-0002.tree
+++ b/trees/ftip-0002.tree
@@ -45,6 +45,15 @@ broader capability
 question. A plateau in one recipe is evidence about that recipe, and the
 general discovery-cost separation remains a conjecture.}
 
+\p{[Economic conditions](ftip-00NX) extend resource accounting to the
+productive stocks, institutions and allocations that sustain learning.
+Physical feasibility, financing, knowledge maintenance and competitive
+equilibrium impose different restrictions. A bound on attainable resources
+must cover the admitted development policies, including investment and
+deliberate maintenance. Such a bound becomes decisive for capability only
+when combined with an independent work lower bound; a contributor advantage
+also needs a realizable acquisition protocol under the same constraints.}
+
 \transclude{ftip-0003}
 \transclude{ftip-0004}
 \transclude{ftip-0005}

--- a/trees/ftip-00NW.tree
+++ b/trees/ftip-00NW.tree
@@ -3,8 +3,9 @@
 \title{How to read these notes}
 \tag{ftip}
 
-\p{The six chapters connect learning mechanisms, computational constraints,
-agent reliability, evaluation and capability growth. The diagram shows
+\p{The seven chapters connect learning mechanisms, computational constraints,
+agent reliability, evaluation, capability growth and economic conditions.
+The diagram shows
 their main logical relationships. Solid arrows indicate concepts used by
 another analysis. The dashed branch supplies architecture-specific detail
 for comparisons involving a particular model implementation or optimizer.}
@@ -27,6 +28,9 @@ for comparisons involving a particular model implementation or optimizer.}
   {5. Architecture\\optimization and capability};
 \node[wide,text width=44mm] (lineage) at (-1.2,-8.5)
   {6. Conceptual discovery\\capability across model generations};
+\node[wide,text width=44mm] (economy) at (-1.2,-10.8)
+  {7. Civilization and economy\\resources, renewal and contributions};
+\draw[flow] (lineage.south) -- (economy.north);
 \draw[flow] (foundation.south) -- (0,-1.1) -| (training.north);
 \draw[flow] (foundation.south) -- (0,-1.1) -| (harness.north);
 \draw[flow] (training.south) -- (-1.9,-3.5)
@@ -43,7 +47,10 @@ change: one changes learned parameters, while the other manages interaction,
 computation and retained artifacts. Evaluation studies the evidence for
 those changes and their limits. Architecture analysis connects the
 comparison to the model's computation and optimization. The lineage
-analysis extends it to discovery and learning across generations.}
+analysis extends it to discovery and learning across generations. Economic
+analysis then asks how productive capacity, knowledge renewal and financing
+make the required resources available, and how learning changes those
+conditions.}
 
 \ol{
   \li{[Foundations and interfaces](ftip-00J9) introduces capability claims,
@@ -71,6 +78,11 @@ analysis extends it to discovery and learning across generations.}
   the complete lineage, independently developed contributions,
   representation learning, curricula and mathematical research settings,
   alongside the conjecture and arguments that could establish or defeat it.}
+  \li{[Civilization, economic reproduction and capability](ftip-00NX)
+  conditions learning on feasible economic paths. It develops knowledge
+  renewal and financing bounds, reliable acquisition from contributors,
+  shared preparation costs, and alternative models with different implications
+  for continued learning.}
 }
 
 \p{The [research question and scope](ftip-0002) introduces the common
@@ -100,3 +112,17 @@ generations are developed in [conceptual discovery](ftip-00MH). Its
 [conjecture](ftip-00MN) specify the autonomous and contributed processes
 being compared. Contributor development, learned representations, curricula
 and mathematical research provide concrete settings for that open question.}
+
+\p{Questions about the origin of a learning budget begin with
+[economic state and admissible paths](ftip-00NY) and the
+[uniform resource envelope](ftip-00O1). The
+[knowledge-renewal model](ftip-00O4) and [financing account](ftip-00O7)
+give distinct constraints; the [automation game](ftip-00OA) studies an
+equilibrium effect under a narrower institutional assumption. The
+[contribution protocol](ftip-00OD) and [portfolio comparison](ftip-00OG)
+specify possible cost advantages. Read these with the
+[alternative mathematical models](ftip-00OJ): they show which
+maintenance, investment, substitution and simulation assumptions can
+prevent a proposed separation. Each proved implication is conditional;
+none alone establishes a universal training ceiling or the open
+conceptual-discovery lower bound.}

--- a/trees/ftip-00OB.tree
+++ b/trees/ftip-00OB.tree
@@ -4,7 +4,7 @@
 \tag{ftip}
 \taxon{Definition}
 
-\p{Fix an integer #{N>1}, #{L,k>0}, and #{0<\ell<s<k+\ell/N}.
+\p{Fix an integer #{N>1}, #{L,k>0}, and #{0<\ell<s<k+\ell / N}.
 Firm #{i} chooses #{\alpha_i\in[0,1]}, average automation is
 #{\bar\alpha=N^{-1}\sum_i\alpha_i}, and its profit is}
 ##{\pi_i=\Pi_0+L\left(s\alpha_i-\ell\bar\alpha
@@ -16,10 +16,10 @@ replacement-income fraction #{\eta}. These are static parameters; they do
 not specify training expenditure or a law of economic development.}
 \p{Strict concavity gives the unique Nash choice and the unique
 joint-profit maximizing choice, both interior:}
-##{\alpha^{\rm NE}=\frac{s-\ell/N}{k},\qquad
+##{\alpha^{\rm NE}=\frac{s-\ell / N}{k},\qquad
 \alpha^{\rm CO}=\frac{s-\ell}{k}.}
 \proof{\p{Differentiate individual profit in #{\alpha_i} to obtain
-#{L(s-\ell/N-k\alpha_i)}. Differentiate total profit in each choice
+#{L(s-\ell / N-k\alpha_i)}. Differentiate total profit in each choice
 to obtain #{L(s-\ell-k\alpha_i)}. The stated inequalities put both
 stationary choices strictly between zero and one; negative second
 derivatives establish the maxima.}}

--- a/trees/ftip-00OC.tree
+++ b/trees/ftip-00OC.tree
@@ -16,7 +16,7 @@
 unavailable, and its compute price is a fixed #{p>0}. The difference
 between the monetary training allocations is #{\rho\Delta\Pi},
 and the difference between their financially purchasable compute
-quantities is #{\rho\Delta\Pi/p}. This follows directly from the
+quantities is #{\rho\Delta\Pi / p}. This follows directly from the
 stipulated rule #{C(a)=\rho\Pi(a)/p}; other physical constraints can
 prevent those quantities from being realized.}
 \p{The result compares two allocations. It does not bound all autonomous


### PR DESCRIPTION
This integrates the completed economic chapter into the FTIP suite as chapter seven, preserving the existing chapter addresses and their coverage. The opening and scope explain how economic paths determine attainable learning resources, while the refreshed diagram and reader guide connect the renewal, finance, contribution and alternative-model results.

Four notation fixes also remove Forester identifier warnings without changing the automation formulas.

The guide distinguishes conditional model propositions from equilibrium comparisons and the open conceptual-discovery lower bound. The prior post-training, agent, evaluation and architecture directions retain balanced coverage.

Part 5 of five, dependent on #199. Series: #196 economic conditions; #197 renewal and finance; #198 reliable contributions and shared costs; #199 alternative models; this PR opening and reader navigation.

Validation passed at `d367a238d3454bb65fa786fc655925f5502ce811`: source prose, full site build, 2,360 XML/HTML pairs, and the complete 310-page PDF. Independent source, terminology, HTML, diagram and PDF review passed; all 21 frozen artifact hashes and five source objects were checked. The final PDF text and diagram match the reviewed versions, and the corrected formulas were visually rechecked. Browser checks passed on five pages; the standalone guide and diagram fit at 390px. Existing expanded-root mobile overflow remains. PR lint passed.

This PR completes the reviewed dependent series. Each substantive PR also has its own full local build, chapter PDF and independent review. The existing Pages build workflow runs only for PRs targeting main; #196 passed that build. The series is ready for review and has not been merged or deployed.
